### PR TITLE
issue#3 lever-1: forward床=dispatch/sync律速を実測確定 + no-sync round-trip除去で resident decode を bit-exact 高速化

### DIFF
--- a/notes/01-speedup-investigation.md
+++ b/notes/01-speedup-investigation.md
@@ -116,8 +116,21 @@ materialize を消す＝[[pre-attention-predictor]]/[[selective-margin-prefetch]
   escalate が要る([[hotcold-hybrid-gate]]/[[nosync-approx-improve]] の near-lossless 路線)。
 - **含意: 「nl は forward 壁で resident でも頭打ち」(2-3)は sync forward 前提**。no-sync で forward 半減
   ＝resident/covered tier の greedy/nl は **~57 tok/s lossless**(従来 ~20-32 の ~1.7-2.9x)。
-- **未配線**: 本番 decode(`runSuffixSpec`)は C=256 でも sync のまま。resident/covered で no-sync に
-  切替えるのが lever-1 の製品化(次)。memory [[footprint-vs-budget]] の C=128 ~59 tok/s 予測と一致。
+- **本番配線済**: `runSuffixSpec` を **C>=nE(256) で auto pure no-sync**(QWISP_NOSYNC=1/0)。実測 C=256:
+  greedy 56.9 / spec 224(vs sync 196, +14%) 何れも 48/48 lossless。C<256 は従来 sync で無回帰。
+
+### 2-6. escalation(miss 検出→sync 再計算)は cold-start で net 効かず: 実用 no-sync は C=256 のみ
+C<256 で no-sync を安全(exact)化する `countHotMiss` escalation(`nosync-escalate` runner / `runSuffixSpec`
+の QWISP_NOSYNC_MIN opt-in)を検証。**出力は常に bit-exact**(hotMiss>0 token を sync 再計算)だが速度は:
+- **token 粒度 escalation は per-token all-hit≈0 の壁**: 1 token=40 層×top8=最大 320 routes、どれか 1 つ
+  cold で token 全体 sync 化。C=128 で escalation **98%→0.67x**(sync 以下)。[[footprint-vs-budget]] 再確認。
+- `nosync-escalate` runner で C=192 が 0% escalation・1.80x と出たのは **直前の sync-greedy が working set を
+  warm したアーティファクト**。実 decode の cold-start single-pass(`runSuffixSpec` 純 greedy)では C=192 でも
+  **escalation 100%**(frequency hot-pin が trajectory working set を覆えず、warming も収束せず)→ 移動窓+grace
+  の adaptive fallback で sync へ。多トークン verify は working set 過大ゆえ escalation 対象外(必ず損)。
+- ∴ **escalation の greedy 高速化は working set 事前常駐時のみ＝実質 C=256(全常駐)**。C=256 は ~21GB ゆえ
+  24GB+ 機で pure no-sync 可。**16GB(C=128)は exact lossless 高速化は壁**(approximate buddy/margin ~51-58
+  tok/s @ ~98% が別路線 [[nosync-approx-improve]])。production は band off 既定で C=256 pure / 以下 sync。
 
 ---
 

--- a/notes/01-speedup-investigation.md
+++ b/notes/01-speedup-investigation.md
@@ -72,8 +72,31 @@ nl で accept が伸びない（suffix 0.23）。その先を speculation 以外
 **50ms = 40 層 × mx.fast-optimal な matmul/gather/recurrent kernel の batch=1 latency-bound 実行**。
 各 matmul は weight 全体を読むのに 1 行しか計算せず GPU を underutilize するが、kernel 自体は既に最適。
 これは融合・compile・量子化で動かない。**唯一 latency-bound matmul を効率化する道 = batching(=speculation)**で、
-それは accept を要し反復 content でしか効かない。∴ **nl(novel)は batch=1 床で原理的に ~20 tok/s 頭打ち**
-（MLX/Apple Silicon の物理であり実装不足でない）。
+それは accept を要し反復 content でしか効かない。∴ **nl(novel)は batch=1 床で ~20 tok/s 頭打ち**。
+
+### 2-4. 床の機構 = dispatch/sync 律速（GPU ~35% busy・実測, issue#3 §5・commit このブランチ）
+2-3 の「batch=1 latency-bound」を **GPU 占有率の実測で確定**した（issue#3 への裏取り）。
+`QWISP_RUN=forward-gpu-busy`（forward-cost と同じ hot-pin 経路）で:
+- **CPU-busy ≈ 0.51 cores**（`getrusage` の process CPU 時間 / wall）＝ wall の約半分は CPU が
+  encode/per-layer routing 同期でビジー、残り半分は GPU 待ちで block。
+- **build-only(eval せず forwardHidden のみ) ≈ 37ms ≈ K=1 eval 35ms** ＝ forward は lazy でなく
+  **内部で per-layer routing 同期を強制**（router logits を materialize して expert gather する round-trip）。
+- 独立 forward を K 本まとめて 1 eval する pipeline 法は **flat(0.94x)** ＝ 同期が forward 内で逐次化し、
+  末尾 eval をまとめても GPU idle を埋められない（層を interleave しない限り回収不可）。
+- **Metal System Trace（`metal-gpu-intervals`）実測（M1 Max）: GPU-busy ≈ 34.6%**
+  （steady median 33.8% / p90 51%）＝ **GPU は wall の ~65% アイドル**。`tools/gpu_busy_from_trace.py`。
+
+→ **床は GPU-exec(帯域/compute)でなく dispatch/sync-latency 律速**。理論帯域床 ~260 tok/s に対し 20 が出る
+真因は per-layer の CPU↔GPU routing round-trip（GPU 65% idle）。issue#3 の指摘どおり「fundamental
+physics」は **言い過ぎ**で、実体は **tooling/sync 床**。
+**ただし idle の正体が MoE 動的 routing の round-trip** ゆえ、標準治療の command-graph capture は
+per-token の expert 選択を capture できず native には効かない（issue#3 §3 と整合）。効く lever は
+intra-kernel fusion でなく **sync/round-trip 除去**（routing 予測で expert 選択を先回りし層跨ぎの
+materialize を消す＝[[pre-attention-predictor]]/[[selective-margin-prefetch]] 系の延長）。これは別途
+高難度（予測精度 ~82-84% 頭打ち実績）で、弱機（M1/Neo 帯域床 ~40-45 tok/s）では旨味 ~2x に縮む。
+∴ **「nl は今追わない」判断は妥当だが framing は「MLX/Metal の sync-tooling 限界」に修正**。
+再現: `forward-gpu-busy` probe + `xcrun xctrace record --template 'Metal System Trace'` →
+`tools/gpu_busy_from_trace.py`（手順は同スクリプト docstring）。
 
 ---
 

--- a/notes/01-speedup-investigation.md
+++ b/notes/01-speedup-investigation.md
@@ -98,6 +98,27 @@ materialize を消す＝[[pre-attention-predictor]]/[[selective-margin-prefetch]
 再現: `forward-gpu-busy` probe + `xcrun xctrace record --template 'Metal System Trace'` →
 `tools/gpu_busy_from_trace.py`（手順は同スクリプト docstring）。
 
+### 2-5. lever-1 実証: round-trip 除去(no-sync)で resident greedy ~2x lossless
+2-4 の sync 床に対し、no-sync 経路(GPU slot-table remap, 毎層 CPU materialize/ensure 無し)を
+**全 expert resident で使うと exact 経路と bit 一致のまま 2x**。forward 単位(`forward-gpu-busy` (B)):
+**sync 31.9ms → no-sync 16.1ms = 1.99x, max|Δhidden|=0.0**。エンドツーエンドの実 greedy decode
+(`QWISP_RUN=nosync-resident`, sync/no-sync を各 1 回回し生成 token 比較):
+
+| C (tier) | sync tok/s | no-sync tok/s | speedup | lossless |
+|---|---|---|---|---|
+| 256 (32GB) | 32.7 | 56.7 | **1.73x** | ✅ **無条件**(全 expert 常駐＝alias 不可能) |
+| 128 (16GB) | 29.1 | 57.4 | **1.97x** | ✅ coverage 100% 前提 |
+| 64 (8GB)   | 20.6 | 59.1 | **2.87x** | ✅(本プロンプト, routed⊂hot-pin) |
+
+- no-sync tok/s は **~57-59 で C 非依存**(ensure/IO 消滅で純 compute)。sync は C 減で overhead 増。
+- **C=256 のみ無条件 bit-exact**(slot-table が全 expert を持ち alias 皆無)。C<256 の lossless は
+  coverage 依存(cold routed で slot-0 alias=garbage)→ 保証には miss 検出(`countHotMiss`)で sync
+  escalate が要る([[hotcold-hybrid-gate]]/[[nosync-approx-improve]] の near-lossless 路線)。
+- **含意: 「nl は forward 壁で resident でも頭打ち」(2-3)は sync forward 前提**。no-sync で forward 半減
+  ＝resident/covered tier の greedy/nl は **~57 tok/s lossless**(従来 ~20-32 の ~1.7-2.9x)。
+- **未配線**: 本番 decode(`runSuffixSpec`)は C=256 でも sync のまま。resident/covered で no-sync に
+  切替えるのが lever-1 の製品化(次)。memory [[footprint-vs-budget]] の C=128 ~59 tok/s 予測と一致。
+
 ---
 
 ## 3. 手法比較: SuffixSpec は Pareto 最適（task 別 dispatch 不要）

--- a/swift/Sources/QwispCore/ExpertArena.swift
+++ b/swift/Sources/QwispCore/ExpertArena.swift
@@ -263,6 +263,14 @@ public final class StreamingMoEBlock {
         return order[0..., (numExperts - topK)...].asType(.int32)
     }
 
+    /// predictInds の幅可変版: 任意 hidden から top-k(k>=topK)を返す（exact-pipeline の prefetch 幅振り用）。
+    public func predictIndsK(_ h: MLXArray, _ k: Int) -> MLXArray {
+        let kk = Swift.min(Swift.max(k, topK), numExperts)
+        let gates = MLX.softmax(gate.apply(h), axis: -1, precise: true)
+        let order = MLX.argPartition(gates, kth: numExperts - kk, axis: -1)
+        return order[0..., (numExperts - kk)...].asType(.int32)
+    }
+
     private func gatherQmm(_ x: MLXArray, _ store: ExpertArena, _ proj: String, _ remap: MLXArray) -> MLXArray {
         gatherQuantizedMatmul(x, store.arr(proj, "weight"), scales: store.arr(proj, "scales"),
                               biases: store.arr(proj, "biases"), rhsIndices: remap,

--- a/swift/Sources/QwispCore/StreamingModel.swift
+++ b/swift/Sources/QwispCore/StreamingModel.swift
@@ -122,6 +122,8 @@ public final class StreamingQwispModel {
     public var layerCount: Int { numLayers }
     /// Tell M1: 層 i の expert を任意 hidden h から予測（cross-layer）。
     public func predictLayerInds(_ i: Int, _ h: MLXArray) -> MLXArray { layers[i].mlp.predictInds(h) }
+    /// 幅可変版: 層 i の top-k 予測（exact-pipeline prefetch 幅振り用）。
+    public func predictLayerIndsK(_ i: Int, _ h: MLXArray, _ k: Int) -> MLXArray { layers[i].mlp.predictIndsK(h, k) }
 
     func headProj() -> Proj {
         .quantized(store.req("language_model.lm_head.weight"),

--- a/swift/Sources/QwispCore/StreamingModel.swift
+++ b/swift/Sources/QwispCore/StreamingModel.swift
@@ -135,6 +135,47 @@ public final class StreamingQwispModel {
         try forwardHidden(ids, caches: caches).logits
     }
 
+    /// **[8GB exact-pipeline] per-layer 予測 prefetch + miss escalation の exact forward（L=1 専用）**
+    /// 各層 i: intra1(前層 gate入力)で top-w 予測→ensure(resident 化)→no-sync gather→1int miss drain。
+    /// true top-8 ⊂ predicted-resident(miss=0)なら no-sync exact、miss>0 ならその層だけ snapshot 巻戻し
+    /// sync 再計算(exact)。出力は exact 経路と bit 一致。escLayers=sync 再計算した層数。
+    /// ※直列版(予測+ensure は同期)。overlap 無しゆえ予測コストを含む＝速度は async 化前提の go/no-go 計測用。
+    public func forwardHiddenPipeline(_ ids: MLXArray, caches: [LayerCache], predictW: Int, isLin: [Bool])
+        throws -> (hidden: MLXArray, logits: MLXArray, escLayers: Int) {
+        var h = embed(ids)
+        var esc = 0
+        let trim = ids.dim(1)
+        StreamingMoEBlock.captureGateInput = true
+        for i in 0 ..< numLayers {
+            if i > 0, let src = expertCaches[i - 1].lastGateInput {        // intra1 予測 → prefetch
+                let pred = layers[i].mlp.predictIndsK(src, predictW)
+                var seen = Set<Int>(); var u: [Int] = []
+                for e in pred.asArray(Int32.self) { let v = Int(e); if seen.insert(v).inserted { u.append(v) } }
+                _ = expertCaches[i].ensure(u)
+            }
+            let snap = caches[i].snapshot()
+            StreamingMoEBlock.hotMissAccum = nil
+            StreamingMoEBlock.probeNoSync = (i > 0)                        // 層0は予測元無し→sync
+            StreamingMoEBlock.countHotMiss = (i > 0)
+            var hn = try layers[i](h, cache: caches[i])
+            if i > 0 {
+                let missArr = StreamingMoEBlock.hotMissAccum ?? MLXArray(Int32(0))
+                MLX.eval([hn, missArr] + caches[i].stateArrays)            // per-layer 1int drain（+ 出力確定）
+                if missArr.item(Int32.self) != 0 {                        // cold routed → その層だけ sync 再計算
+                    esc += 1
+                    caches[i].restore(snap, isLinear: isLin[i], trim: trim)
+                    StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.countHotMiss = false
+                    hn = try layers[i](h, cache: caches[i])
+                }
+            }
+            h = hn
+        }
+        StreamingMoEBlock.captureGateInput = false
+        StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.countHotMiss = false
+        let hidden = MLXFast.rmsNorm(h, weight: store.req("language_model.model.norm.weight"), eps: eps)
+        return (hidden, headProj().apply(hidden), esc)
+    }
+
     /// cached forward で (post-norm hidden, logits)（MTP 投機用）。
     public func forwardHidden(_ ids: MLXArray, caches: [LayerCache]) throws -> (hidden: MLXArray, logits: MLXArray) {
         var h = embed(ids)

--- a/swift/Sources/QwispCore/Tell.swift
+++ b/swift/Sources/QwispCore/Tell.swift
@@ -56,7 +56,10 @@ public enum Tell {
         // 既定 f32-full(QWISP_F32_ATTN/CONV=0 で各々無効化可)。f16 batched を試すなら両方 0。
         GatedDeltaNetLayer.f32Conv = Tell.envStr("QWISP_F32_CONV", "1") != "0"
         AttentionLayer.f32SDPA = Tell.envStr("QWISP_F32_ATTN", "1") != "0"
-        defer { GatedDeltaNetLayer.f32Conv = false; AttentionLayer.f32SDPA = false; AttentionLayer.perQueryNone = false; StreamingMoEBlock.probeNoSync = false }
+        defer {
+            GatedDeltaNetLayer.f32Conv = false; AttentionLayer.f32SDPA = false; AttentionLayer.perQueryNone = false
+            StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.countHotMiss = false; StreamingMoEBlock.hotMissAccum = nil
+        }
         let store = try WeightStore(modelDir: modelDir)
         store.residentNonExperts()
         let source = try ExpertSource(modelDir: modelDir); try source.warm()
@@ -108,18 +111,21 @@ public enum Tell {
         }
 
         // phase 3: suffix-lookup draft + clean exact verify
-        // ★ lever-1(issue#3): 全 expert resident(C>=nE)なら no-sync 経路(GPU slot-table remap)が
-        //   exact 経路と bit 一致(alias 不可能)＝per-layer routing round-trip 除去で ~1.7x lossless。
-        //   QWISP_NOSYNC=1 強制 / =0 無効 / 既定 auto(C>=256 で自動)。C<nE は cold routed が slot-0
-        //   alias で garbage ゆえ無効(escalation 路線は別 runner)。
+        // ★ lever-1(issue#3): per-layer routing round-trip 除去で ~1.7-1.8x lossless（dispatch/sync 律速）。
+        //   C>=nE(256): 全 expert resident=no-sync gather(GPU slot-table remap)が無条件 bit-exact → pure no-sync。
+        //   C < nE: 既定 sync(cold-start の greedy working set は frequency-pin に収まらず escalation が
+        //     net 損＝warming 浪費。escalation の greedy 高速化は working set 事前常駐時のみ＝実質 C=256)。
+        //   研究用に QWISP_NOSYNC_MIN=<C> を明示すると [その値, nE) で no-sync+escalation(率監視 fallback)を有効化。
+        //   QWISP_NOSYNC=1 強制 pure / =0 無効。出力は常に exact(pure は residency 保証, escalation は sync 再計算)。
         let nosyncEnv = Tell.envStr("QWISP_NOSYNC", "auto")
-        let residentNoSync = nosyncEnv == "1" || (nosyncEnv != "0" && C >= nE)
-        if residentNoSync {
-            print("[SuffixSpec] no-sync exact 経路 ON (C=\(C)>=\(nE) 全 expert resident, round-trip 除去 ~1.7x lossless)")
-        }
+        let escalMin = Tell.envInt("QWISP_NOSYNC_MIN", nE)   // 既定 nE=band 空=production は pure/sync のみ
+        let pureNoSync = nosyncEnv == "1" || (nosyncEnv != "0" && C >= nE)
+        var escalateActive = nosyncEnv != "0" && !pureNoSync && C >= escalMin
+        if pureNoSync { print("[SuffixSpec] no-sync pure ON (C=\(C)>=\(nE) 全 resident, 無条件 lossless ~1.7x)") }
+        else if escalateActive { print("[SuffixSpec] no-sync+escalation ON (C=\(C) in [\(escalMin),\(nE)), exact, 率監視 fallback)") }
         var hist = ids.asArray(Int32.self).map { Int($0) }     // 履歴（prompt + commit token）
         let mc = model.makeCaches()
-        StreamingMoEBlock.probeNoSync = residentNoSync
+        StreamingMoEBlock.probeNoSync = pureNoSync
         var (_, lg) = try model.prefillChunked(ids, caches: mc)
         var uArr = MLX.argMax(lg[0, lg.dim(1) - 1], axis: -1).reshaped([1, 1])
         MLX.eval([uArr] + mc.flatMap { $0.stateArrays })
@@ -134,6 +140,50 @@ public enum Tell {
         let prof = Tell.envFlag("QWISP_SPECK_PROF")
         var tDraft: UInt64 = 0, tVerify: UInt64 = 0
         func now() -> UInt64 { DispatchTime.now().uptimeNanoseconds }
+        // adaptive escalation: escalateActive 時、input を no-sync で forward→cold routed があれば cache を
+        //   巻戻して sync 再計算(exact)。escalation 率が高ければ escalateActive を落とし以降 sync(footprint 壁で無回帰)。
+        //   非 escalation 時は global probeNoSync(pure か false)のまま素通し。返す logits は常に exact。
+        //   escalate=false(verify 多トークン)では escalation 無効: working set が大きく必ず miss→2x 損。
+        //   pure no-sync(C>=256)は global probeNoSync で verify も安全に no-sync 化される。
+        //   fallback 判定は移動窓 + grace: escalate は cache を warm する(sync 再計算が cold expert を ensure)ので
+        //   cold start は高 escalation でも収束しうる。grace 後の recent rate が break-even(no-sync 0.5x +
+        //   escalate 2x ゆえ rate>~0.5 で sync より損)を超えたら footprint 壁と判断し sync へ自動 fallback。
+        var escSeen = 0
+        var escRecent: [Bool] = []
+        let escWindow = Tell.envInt("QWISP_ESC_WINDOW", 16)
+        let escGrace = Tell.envInt("QWISP_ESC_GRACE", 24)
+        let escMaxRate = 0.45
+        func decodeForward(_ input: MLXArray, rows: Int, escalate: Bool) throws -> MLXArray {
+            if !escalateActive || !escalate {
+                let (_, l) = try model.forwardHidden(input, caches: mc)
+                return l
+            }
+            let snaps = mc.map { $0.snapshot() }
+            StreamingMoEBlock.hotMissAccum = nil
+            StreamingMoEBlock.probeNoSync = true; StreamingMoEBlock.countHotMiss = true
+            let (_, l) = try model.forwardHidden(input, caches: mc)
+            let missArr = StreamingMoEBlock.hotMissAccum ?? MLXArray(Int32(0))
+            MLX.eval([l, missArr] + mc.flatMap { $0.stateArrays })
+            StreamingMoEBlock.countHotMiss = false; StreamingMoEBlock.probeNoSync = false
+            escSeen += 1
+            var result = l
+            let escalated = missArr.item(Int32.self) != 0
+            if escalated {                                           // cold routed あり → sync 再計算(exact, cold ensure)
+                for (i, c) in mc.enumerated() { c.restore(snaps[i], isLinear: isLin[i], trim: rows) }
+                let (_, l2) = try model.forwardHidden(input, caches: mc)
+                result = l2
+            }
+            escRecent.append(escalated); if escRecent.count > escWindow { escRecent.removeFirst() }
+            if escSeen >= escGrace && escRecent.count == escWindow {  // warming 後に移動窓で判定
+                let rate = Double(escRecent.filter { $0 }.count) / Double(escWindow)
+                if rate > escMaxRate {
+                    escalateActive = false
+                    print(String(format: "[SuffixSpec] recent escalation率 %.0f%% > %.0f%% → sync へ fallback(footprint 壁, 無回帰)",
+                                 rate * 100, escMaxRate * 100))
+                }
+            }
+            return result
+        }
         var out: [Int] = []; var steps = 0, accTok = 0, draftTot = 0
         let t0 = DispatchTime.now()
         while out.count < N {
@@ -145,7 +195,7 @@ public enum Tell {
             draftTot += D
             if prof { tDraft += now() - ts; ts = now() }
             if D == 0 {                                          // 一致なし → 通常 greedy 1 step
-                let (_, glg) = try model.forwardHidden(uArr, caches: mc)
+                let glg = try decodeForward(uArr, rows: 1, escalate: true)
                 out.append(u); hist.append(u)
                 uArr = MLX.argMax(glg[0, 0], axis: -1).reshaped([1, 1])
                 MLX.eval([uArr] + mc.flatMap { $0.stateArrays })
@@ -155,7 +205,7 @@ public enum Tell {
             setVerifyMode(true)
             let snaps = mc.map { $0.snapshot() }
             let seq = MLX.concatenated([uArr, MLXArray(drafts.map { Int32($0) }, [1, D])], axis: 1)  // [1, D+1]
-            let (_, vlg) = try model.forwardHidden(seq, caches: mc)
+            let vlg = try decodeForward(seq, rows: D + 1, escalate: false)
             let evals = MLX.argMax(vlg[0, 0 ..< (D + 1)], axis: -1).asArray(Int32.self).map { Int($0) }
             var p = 0
             while p < D && drafts[p] == evals[p] { p += 1 }

--- a/swift/Sources/QwispCore/Tell.swift
+++ b/swift/Sources/QwispCore/Tell.swift
@@ -56,7 +56,7 @@ public enum Tell {
         // 既定 f32-full(QWISP_F32_ATTN/CONV=0 で各々無効化可)。f16 batched を試すなら両方 0。
         GatedDeltaNetLayer.f32Conv = Tell.envStr("QWISP_F32_CONV", "1") != "0"
         AttentionLayer.f32SDPA = Tell.envStr("QWISP_F32_ATTN", "1") != "0"
-        defer { GatedDeltaNetLayer.f32Conv = false; AttentionLayer.f32SDPA = false; AttentionLayer.perQueryNone = false }
+        defer { GatedDeltaNetLayer.f32Conv = false; AttentionLayer.f32SDPA = false; AttentionLayer.perQueryNone = false; StreamingMoEBlock.probeNoSync = false }
         let store = try WeightStore(modelDir: modelDir)
         store.residentNonExperts()
         let source = try ExpertSource(modelDir: modelDir); try source.warm()
@@ -108,9 +108,18 @@ public enum Tell {
         }
 
         // phase 3: suffix-lookup draft + clean exact verify
+        // ★ lever-1(issue#3): 全 expert resident(C>=nE)なら no-sync 経路(GPU slot-table remap)が
+        //   exact 経路と bit 一致(alias 不可能)＝per-layer routing round-trip 除去で ~1.7x lossless。
+        //   QWISP_NOSYNC=1 強制 / =0 無効 / 既定 auto(C>=256 で自動)。C<nE は cold routed が slot-0
+        //   alias で garbage ゆえ無効(escalation 路線は別 runner)。
+        let nosyncEnv = Tell.envStr("QWISP_NOSYNC", "auto")
+        let residentNoSync = nosyncEnv == "1" || (nosyncEnv != "0" && C >= nE)
+        if residentNoSync {
+            print("[SuffixSpec] no-sync exact 経路 ON (C=\(C)>=\(nE) 全 expert resident, round-trip 除去 ~1.7x lossless)")
+        }
         var hist = ids.asArray(Int32.self).map { Int($0) }     // 履歴（prompt + commit token）
         let mc = model.makeCaches()
-        StreamingMoEBlock.probeNoSync = false
+        StreamingMoEBlock.probeNoSync = residentNoSync
         var (_, lg) = try model.prefillChunked(ids, caches: mc)
         var uArr = MLX.argMax(lg[0, lg.dim(1) - 1], axis: -1).reshaped([1, 1])
         MLX.eval([uArr] + mc.flatMap { $0.stateArrays })

--- a/swift/Sources/QwispCore/TellExperiments.swift
+++ b/swift/Sources/QwispCore/TellExperiments.swift
@@ -1842,6 +1842,152 @@ extension Tell {
             + "\n  (B) 有効層数依存(L=1, 末尾skip):\n  " + lines2.joined(separator: "\n  ")
     }
 
+    /// **[計測] issue#3 §5: forward 50ms 床は dispatch-latency 律速か GPU-exec 床か（二値判定）**
+    /// 機構 = 独立 forward パイプライン法。K 個の **データ依存の無い** L=1 forward を 1 回の eval に
+    /// まとめて投入し、per-forward wall が K で下がるかを測る。単 forward が dispatch 律速（40 層の
+    /// 逐次カーネル投入の間 GPU がアイドル）なら、独立 forward を束ねるとその idle 隙間が埋まり
+    /// per-forward wall が **下がる**＝CPU submit が GPU を待たせている証拠。GPU が既に飽和（exec 床）
+    /// なら K を増やしても **flat**＝50ms は本物の GPU-exec 床で graph-capture も無駄。GPU counter 不要・
+    /// mlx 再ビルド不要でクリーンな二値数値が出る（RNN-T「GPU 80% idle」測定の型）。
+    /// build-only(lazy 構築) vs eval(submit+exec) も分離して CPU-record 寄与も見る。
+    /// hot-pin top-C で IO 排除。QWISP_GPUTRACE=path を渡すと K=1 区間を .gputrace capture（要 mlx
+    /// MLX_METAL_DEBUG ビルド + MTL_CAPTURE_ENABLED=1。無ければ Instruments の Metal System Trace で代替可）。
+    /// - env: QWISP_RUN=forward-gpu-busy / QWISP_CACHE_C / QWISP_FC_REPS(既定20) /
+    ///        QWISP_GPUBUSY_K(既定"1,2,4,8") / QWISP_GPUTRACE(任意, capture 出力パス)
+    public static func runForwardGpuBusy(modelDir: String, refPath: String) throws -> String {
+        guard let device = MTLCreateSystemDefaultDevice() else { return "ERROR: no Metal device" }
+        let r = try loadArrays(url: URL(fileURLWithPath: refPath))
+        guard let promptArr = r["spec_prompt"] else { return "[GpuBusy] skip" }
+        let C = Tell.envInt("QWISP_CACHE_C", 64)
+        let reps = Tell.envInt("QWISP_FC_REPS", 20)
+        let Ks = (ProcessInfo.processInfo.environment["QWISP_GPUBUSY_K"] ?? "1,2,4,8")
+            .split(separator: ",").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+        let tracePath = ProcessInfo.processInfo.environment["QWISP_GPUTRACE"]
+        GatedDeltaNetLayer.f32Conv = true; AttentionLayer.f32SDPA = true
+        defer { GatedDeltaNetLayer.f32Conv = false; AttentionLayer.f32SDPA = false }
+        let store = try WeightStore(modelDir: modelDir); store.residentNonExperts()
+        let source = try ExpertSource(modelDir: modelDir); try source.warm()
+        let arena = try ExpertArena(device: device, source: source, N: 64)
+        let model = try StreamingQwispModel(store: store, arena: arena, device: device, source: source, cacheC: C)
+        let ids = promptArr.asType(.int32).reshaped([1, promptArr.dim(0)])
+        let isLin = model.isLinearFlags
+        let nE = 256, nMoE = model.expertCaches.count
+        // calib + hot-pin top-C で IO 排除（pure compute を測る）— runForwardCost と同型
+        var counts = [[Int]](repeating: [Int](repeating: 0, count: nE), count: nMoE)
+        let cc = model.makeCaches()
+        StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.captureInds = true
+        var (_, clg) = try model.prefillChunked(ids, caches: cc)
+        var ccur = MLX.argMax(clg[0, clg.dim(1) - 1], axis: -1).reshaped([1, 1])
+        MLX.eval([ccur] + cc.flatMap { $0.stateArrays })
+        for _ in 0 ..< 48 {
+            (_, clg) = try model.forwardHidden(ccur, caches: cc)
+            MLX.eval([clg] + cc.flatMap { $0.stateArrays } + model.expertCaches.compactMap { $0.lastInds })
+            for (mi, ec) in model.expertCaches.enumerated() {
+                if let li = ec.lastInds { for e in li.asArray(Int32.self) { counts[mi][Int(e)] += 1 } }
+            }
+            ccur = MLX.argMax(clg[0, 0], axis: -1).reshaped([1, 1]); MLX.eval([ccur])
+        }
+        StreamingMoEBlock.captureInds = false
+        for (mi, ec) in model.expertCaches.enumerated() {
+            _ = ec.ensure(Array(counts[mi].enumerated()
+                .sorted { $0.element != $1.element ? $0.element > $1.element : $0.offset < $1.offset }
+                .prefix(C).map { $0.offset }))
+        }
+        func now() -> UInt64 { DispatchTime.now().uptimeNanoseconds }
+        // プロセス全体の累積 CPU 時間(user+sys, 全スレッド合算)。wall と比べて cores-busy 比を出す。
+        // cores-busy ≈ 1+ なら CPU が wall を占有(=encode/sync 律速=dispatch 系)、≈0 なら CPU は GPU 待ちで block(=GPU-exec 床)。
+        func cpuNs() -> UInt64 {
+            var ru = rusage()
+            getrusage(RUSAGE_SELF, &ru)
+            let u = UInt64(ru.ru_utime.tv_sec) * 1_000_000_000 + UInt64(ru.ru_utime.tv_usec) * 1000
+            let s = UInt64(ru.ru_stime.tv_sec) * 1_000_000_000 + UInt64(ru.ru_stime.tv_usec) * 1000
+            return u + s
+        }
+        let seq = MLXArray([Int32(100)], [1, 1])                                  // L=1 ダミー decode
+        // 各 K 用に独立した cache 群（データ依存なし）を prefill しておく
+        let maxK = Ks.max() ?? 1
+        var bcs: [[LayerCache]] = []
+        var snapss: [[LayerCache.Snapshot]] = []
+        for _ in 0 ..< maxK {
+            let bc = model.makeCaches()
+            _ = try model.prefillChunked(ids, caches: bc)
+            MLX.eval(bc.flatMap { $0.stateArrays })
+            bcs.append(bc); snapss.append(bc.map { $0.snapshot() })
+        }
+        // build-only(lazy 構築のみ, eval せず) の CPU-record 寄与を 1 forward で測る
+        var buildAcc: UInt64 = 0
+        for _ in 0 ..< reps {
+            let t = now()
+            let (h, _) = try model.forwardHidden(seq, caches: bcs[0])     // lazy: ops 記録のみ
+            _ = h
+            buildAcc += now() - t
+            for (i, c) in bcs[0].enumerated() { c.restore(snapss[0][i], isLinear: isLin[i], trim: 1) }
+        }
+        let buildMs = Double(buildAcc) / Double(reps) / 1e6
+        // (A) パイプライン法: K 独立 forward を 1 eval、per-forward wall を測る
+        var lines: [String] = []
+        var perK: [(K: Int, ms: Double, cores: Double)] = []
+        for K in Ks {
+            // warmup
+            do {
+                var hs: [MLXArray] = []
+                for k in 0 ..< K { let (h, _) = try model.forwardHidden(seq, caches: bcs[k]); hs.append(h) }
+                MLX.eval(hs + (0 ..< K).flatMap { bcs[$0].flatMap { $0.stateArrays } })
+                for k in 0 ..< K { for (i, c) in bcs[k].enumerated() { c.restore(snapss[k][i], isLinear: isLin[i], trim: 1) } }
+            }
+            LayerExpertCache.missTotal = 0
+            var tAcc: UInt64 = 0
+            let doTrace = tracePath != nil && K == 1
+            if doTrace, let tp = tracePath { MLX.GPU.startCapture(url: URL(fileURLWithPath: tp)) }
+            let cpu0 = cpuNs()
+            for _ in 0 ..< reps {
+                let t = now()
+                var hs: [MLXArray] = []
+                for k in 0 ..< K { let (h, _) = try model.forwardHidden(seq, caches: bcs[k]); hs.append(h) }
+                MLX.eval(hs + (0 ..< K).flatMap { bcs[$0].flatMap { $0.stateArrays } })   // K 本まとめて submit
+                tAcc += now() - t
+                for k in 0 ..< K { for (i, c) in bcs[k].enumerated() { c.restore(snapss[k][i], isLinear: isLin[i], trim: 1) } }   // 非計時(CPU はここも含むが小)
+            }
+            let cpuDelta = cpuNs() - cpu0
+            if doTrace, let tp = tracePath { MLX.GPU.stopCapture(url: URL(fileURLWithPath: tp)) }
+            let perFwd = Double(tAcc) / Double(reps) / Double(K) / 1e6
+            let cores = Double(cpuDelta) / Double(tAcc)                       // CPU時間 / 計時 wall = 平均ビジー core 数
+            perK.append((K, perFwd, cores))
+            lines.append(String(format: "K=%d: %6.2f ms/forward  (batch wall %6.2f ms, CPU-busy=%.2f cores, misses/fwd=%.1f)%@",
+                                K, perFwd, perFwd * Double(K), cores,
+                                Double(LayerExpertCache.missTotal) / Double(reps) / Double(K),
+                                doTrace ? "  [gputrace→\(tracePath!)]" : ""))
+        }
+        // 二値判定(主=CPU-busy, 副=pipeline ratio):
+        //   CPU-busy ≳1.0 → wall を CPU が占有=encode/routing-sync 律速(dispatch 系) → graph-capture/sync削減に価値
+        //   CPU-busy ≲0.3 → CPU は GPU 待ちで block=GPU-exec 床 → 50ms は本物の compute 床、graph capture も無駄
+        let base = perK.first?.ms ?? 0
+        let best = perK.map { $0.ms }.min() ?? base
+        let ratio = base > 0 ? best / base : 1.0
+        let cores = perK.first?.cores ?? 0
+        let verdict: String
+        if cores >= 0.8 {
+            verdict = String(format: "DISPATCH/SYNC 律速 (CPU-busy=%.2f cores≒wall占有, pipeline %.2fx). "
+                + "wall は GPU exec でなく CPU の encode/per-layer routing 同期律速。"
+                + "→ MoE routing を含むため native graph-capture は困難だが、sync 削減(routing 予測でround-trip除去)に価値。"
+                + "「fundamental physics」でなく tooling/sync 床=issue#3 §4 の framing 修正が正しい", cores, ratio)
+        } else if cores <= 0.3 {
+            verdict = String(format: "GPU-EXEC 床 (CPU-busy=%.2f cores=GPU待ちで block, pipeline %.2fx flat). "
+                + "→ 50ms は本物の GPU compute 床、graph capture も無駄。penta の「床」が正しい", cores, ratio)
+        } else {
+            verdict = String(format: "混在 (CPU-busy=%.2f cores, pipeline %.2fx). CPU sync と GPU exec が拮抗。"
+                + "gputrace で GPU 占有率を裏取りして確定", cores, ratio)
+        }
+        return "[GpuBusy C=\(C), f32-full, hot-pin top-C, reps=\(reps)] issue#3 §5 dispatch vs exec\n"
+            + String(format: "  build-only(eval せず forwardHidden のみ; lazy なら~0 のはず): %.2f ms/forward\n", buildMs)
+            + "  (A) 独立 forward パイプライン (per-forward wall + CPU-busy cores):\n  " + lines.joined(separator: "\n  ")
+            + "\n  判定: " + verdict
+            + (tracePath == nil
+                ? "\n  ※ gputrace 裏取り: QWISP_GPUTRACE=/path/x.gputrace を渡す(要 mlx MLX_METAL_DEBUG ビルド)、"
+                  + "または Instruments の Metal System Trace で本バイナリの GPU 占有率を直接読む"
+                : "")
+    }
+
     /// cost-model 検証: 同一プロセスで (A)forward-cost→a,b fit (B)maxK-sweep の SuffixSpec 実測 を行い、
     /// 予測 tok/s=(1+p)/(a+b(D+1)) が実測と一致するか確認。dev 機は IO≈0 ゆえ forward+accept 項を検証。
     /// 一致なら cost-model で C/maxK/mode を予測選択して良い。ズレれば feedback/起動時実 sweep が要ると判る。

--- a/swift/Sources/QwispCore/TellExperiments.swift
+++ b/swift/Sources/QwispCore/TellExperiments.swift
@@ -2109,6 +2109,124 @@ extension Tell {
             + String(format: "  → speedup=%.2fx, token一致=%d/%d  %@", speedup, match, N, losslessTag)
     }
 
+    /// **[高速化] issue#3 lever-1 製品化: 16GB(C=128) を no-sync + miss-escalation で真 lossless 化**
+    /// C<256 では no-sync gather が cold routed を slot-0 alias=garbage 化するが、`countHotMiss` で
+    /// その token の cold route 数を層横断 GPU 累積し、**hotMiss=0 の token は no-sync 結果が bit-exact
+    /// ゆえ採用、hotMiss>0 の token だけ cache を巻戻して sync 再計算(exact, cold expert を ensure)**。
+    /// 検出は cold route の厳密 superset ゆえ出力は pure-sync と完全一致(真 lossless)。miss-check は token
+    /// 毎 1 scalar drain のみ(40 層 materialize より遥かに安い)。期待: 16GB を ~45-57 tok/s exact。
+    /// - env: QWISP_RUN=nosync-escalate / QWISP_CACHE_C(既定128) / QWISP_GEN(既定64) / QWISP_CALIB(既定48)
+    public static func runNoSyncEscalate(modelDir: String, refPath: String) throws -> String {
+        guard let device = MTLCreateSystemDefaultDevice() else { return "ERROR: no Metal device" }
+        let r = try loadArrays(url: URL(fileURLWithPath: refPath))
+        guard let promptArr = r["spec_prompt"] else { return "[NoSyncEscalate] skip" }
+        let C = Tell.envInt("QWISP_CACHE_C", 128)
+        let N = Tell.envInt("QWISP_GEN", 64)
+        let calibN = Tell.envInt("QWISP_CALIB", 48)
+        GatedDeltaNetLayer.f32Conv = true; AttentionLayer.f32SDPA = true
+        defer {
+            GatedDeltaNetLayer.f32Conv = false; AttentionLayer.f32SDPA = false
+            StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.countHotMiss = false
+            StreamingMoEBlock.hotMissAccum = nil
+        }
+        let store = try WeightStore(modelDir: modelDir); store.residentNonExperts()
+        let source = try ExpertSource(modelDir: modelDir); try source.warm()
+        let arena = try ExpertArena(device: device, source: source, N: 64)
+        let model = try StreamingQwispModel(store: store, arena: arena, device: device, source: source, cacheC: C)
+        let ids = promptArr.asType(.int32).reshaped([1, promptArr.dim(0)])
+        let isLin = model.isLinearFlags
+        let nE = 256, nMoE = model.expertCaches.count
+        // calib + hot-pin top-C
+        var counts = [[Int]](repeating: [Int](repeating: 0, count: nE), count: nMoE)
+        let cc = model.makeCaches()
+        StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.captureInds = true
+        var (_, clg) = try model.prefillChunked(ids, caches: cc)
+        var ccur = MLX.argMax(clg[0, clg.dim(1) - 1], axis: -1).reshaped([1, 1])
+        MLX.eval([ccur] + cc.flatMap { $0.stateArrays })
+        for _ in 0 ..< calibN {
+            (_, clg) = try model.forwardHidden(ccur, caches: cc)
+            MLX.eval([clg] + cc.flatMap { $0.stateArrays } + model.expertCaches.compactMap { $0.lastInds })
+            for (mi, ec) in model.expertCaches.enumerated() {
+                if let li = ec.lastInds { for e in li.asArray(Int32.self) { counts[mi][Int(e)] += 1 } }
+            }
+            ccur = MLX.argMax(clg[0, 0], axis: -1).reshaped([1, 1]); MLX.eval([ccur])
+        }
+        StreamingMoEBlock.captureInds = false
+        for (mi, ec) in model.expertCaches.enumerated() {
+            _ = ec.ensure(Array(counts[mi].enumerated()
+                .sorted { $0.element != $1.element ? $0.element > $1.element : $0.offset < $1.offset }
+                .prefix(C).map { $0.offset }))
+        }
+        // 参照: pure-sync greedy
+        func greedySync() throws -> (toks: [Int], tps: Double) {
+            StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.countHotMiss = false
+            let mc = model.makeCaches()
+            var (_, lg) = try model.prefillChunked(ids, caches: mc)
+            var u = MLX.argMax(lg[0, lg.dim(1) - 1], axis: -1).reshaped([1, 1])
+            MLX.eval([u] + mc.flatMap { $0.stateArrays })
+            let s0 = mc.map { $0.snapshot() }
+            (_, lg) = try model.forwardHidden(u, caches: mc); MLX.eval([lg])     // warmup
+            for (i, c) in mc.enumerated() { c.restore(s0[i], isLinear: isLin[i], trim: 1) }
+            var toks: [Int] = []; let t0 = DispatchTime.now().uptimeNanoseconds
+            for _ in 0 ..< N {
+                (_, lg) = try model.forwardHidden(u, caches: mc)
+                u = MLX.argMax(lg[0, 0], axis: -1).reshaped([1, 1])
+                MLX.eval([u] + mc.flatMap { $0.stateArrays }); toks.append(u.item(Int.self))
+            }
+            return (toks, Double(N) / (Double(DispatchTime.now().uptimeNanoseconds - t0) / 1e9))
+        }
+        // no-sync + escalation greedy
+        func greedyEscalate() throws -> (toks: [Int], tps: Double, escal: Int) {
+            let mc = model.makeCaches()
+            var (_, lg) = try model.prefillChunked(ids, caches: mc)
+            var u = MLX.argMax(lg[0, lg.dim(1) - 1], axis: -1).reshaped([1, 1])
+            MLX.eval([u] + mc.flatMap { $0.stateArrays })
+            // warmup（両 mode のグラフを確定、cache 巻戻し）
+            let s0 = mc.map { $0.snapshot() }
+            StreamingMoEBlock.probeNoSync = true; StreamingMoEBlock.countHotMiss = true; StreamingMoEBlock.hotMissAccum = nil
+            let (_, w1) = try model.forwardHidden(u, caches: mc); MLX.eval([w1])
+            for (i, c) in mc.enumerated() { c.restore(s0[i], isLinear: isLin[i], trim: 1) }
+            StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.countHotMiss = false
+            let (_, w2) = try model.forwardHidden(u, caches: mc); MLX.eval([w2])
+            for (i, c) in mc.enumerated() { c.restore(s0[i], isLinear: isLin[i], trim: 1) }
+            var toks: [Int] = []; var escal = 0
+            let t0 = DispatchTime.now().uptimeNanoseconds
+            for _ in 0 ..< N {
+                let snaps = mc.map { $0.snapshot() }
+                StreamingMoEBlock.hotMissAccum = nil
+                StreamingMoEBlock.probeNoSync = true; StreamingMoEBlock.countHotMiss = true
+                let (_, lns) = try model.forwardHidden(u, caches: mc)
+                let missArr = StreamingMoEBlock.hotMissAccum ?? MLXArray(Int32(0))
+                MLX.eval([lns, missArr] + mc.flatMap { $0.stateArrays })           // token 毎 1 sync(scalar+logits)
+                if missArr.item(Int32.self) == 0 {
+                    u = MLX.argMax(lns[0, 0], axis: -1).reshaped([1, 1]); MLX.eval([u])   // 採用(cache exact)
+                } else {
+                    escal += 1
+                    for (i, c) in mc.enumerated() { c.restore(snaps[i], isLinear: isLin[i], trim: 1) }
+                    StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.countHotMiss = false
+                    let (_, lex) = try model.forwardHidden(u, caches: mc)            // sync 再計算(exact, cold ensure)
+                    u = MLX.argMax(lex[0, 0], axis: -1).reshaped([1, 1])
+                    MLX.eval([u] + mc.flatMap { $0.stateArrays })
+                }
+                toks.append(u.item(Int.self))
+            }
+            StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.countHotMiss = false
+            return (toks, Double(N) / (Double(DispatchTime.now().uptimeNanoseconds - t0) / 1e9), escal)
+        }
+        let ref = try greedySync()
+        let esc = try greedyEscalate()
+        let match = zip(ref.toks, esc.toks).filter { $0 == $1 }.count
+        let speedup = ref.tps > 0 ? esc.tps / ref.tps : 0
+        let escRate = Double(esc.escal) / Double(N) * 100
+        let tag = match == N ? "✅ 真 lossless(sync と完全一致)"
+            : "❌ \(N - match)/\(N) 不一致=escalation 検出漏れ(バグ)"
+        return "[NoSyncEscalate C=\(C), N=\(N), f32-full] issue#3 lever-1 16GB 安全化\n"
+            + String(format: "  pure-sync(exact)         : %.1f tok/s\n", ref.tps)
+            + String(format: "  no-sync+escalate         : %.1f tok/s  (escalation %d/%d=%.0f%%)\n",
+                     esc.tps, esc.escal, N, escRate)
+            + String(format: "  → speedup=%.2fx, token一致=%d/%d  %@", speedup, match, N, tag)
+    }
+
     /// cost-model 検証: 同一プロセスで (A)forward-cost→a,b fit (B)maxK-sweep の SuffixSpec 実測 を行い、
     /// 予測 tok/s=(1+p)/(a+b(D+1)) が実測と一致するか確認。dev 機は IO≈0 ゆえ forward+accept 項を検証。
     /// 一致なら cost-model で C/maxK/mode を予測選択して良い。ズレれば feedback/起動時実 sweep が要ると判る。

--- a/swift/Sources/QwispCore/TellExperiments.swift
+++ b/swift/Sources/QwispCore/TellExperiments.swift
@@ -1958,6 +1958,40 @@ extension Tell {
                                 Double(LayerExpertCache.missTotal) / Double(reps) / Double(K),
                                 doTrace ? "  [gputrace→\(tracePath!)]" : ""))
         }
+        // (B) round-trip 除去の天井: sync(probeNoSync=false, 毎層 inds.asArray+ensure) vs
+        //     no-sync(GPU slot-table remap, 毎層 CPU materialize 無し)を同一 resident 状態で A/B。
+        //     hot-pin top-C に routed ⊂ なので no-sync gather は exact 経路と bit 一致のはず（lossless 確認込み）。
+        StreamingMoEBlock.captureInds = false; StreamingMoEBlock.captureK = 0
+        StreamingMoEBlock.marginK = 0; StreamingMoEBlock.skipMode = 0
+        StreamingMoEBlock.countHotMiss = false; StreamingMoEBlock.syncLayers = nil
+        func measureMode(_ noSync: Bool) throws -> (ms: Double, cores: Double, h: MLXArray) {
+            StreamingMoEBlock.probeNoSync = noSync
+            // warmup + 代表 hidden を1本確保（bit 比較用）
+            let (hw, _) = try model.forwardHidden(seq, caches: bcs[0]); MLX.eval([hw])
+            for (i, c) in bcs[0].enumerated() { c.restore(snapss[0][i], isLinear: isLin[i], trim: 1) }
+            var tAcc: UInt64 = 0
+            let cpu0 = cpuNs()
+            for _ in 0 ..< reps {
+                let t = now()
+                let (h, _) = try model.forwardHidden(seq, caches: bcs[0])
+                MLX.eval([h] + bcs[0].flatMap { $0.stateArrays })
+                tAcc += now() - t
+                for (i, c) in bcs[0].enumerated() { c.restore(snapss[0][i], isLinear: isLin[i], trim: 1) }
+            }
+            let cores = Double(cpuNs() - cpu0) / Double(tAcc)
+            return (Double(tAcc) / Double(reps) / 1e6, cores, hw)
+        }
+        let mSync = try measureMode(false)
+        let mNo = try measureMode(true)
+        StreamingMoEBlock.probeNoSync = false
+        let maxAbs = MLX.abs(mSync.h - mNo.h).max().item(Float.self)         // lossless 確認(0=bit一致)
+        let speedup = mNo.ms > 0 ? mSync.ms / mNo.ms : 1.0
+        let abLines = String(format:
+            "  sync   (毎層 materialize+ensure): %6.2f ms/forward  CPU-busy=%.2f cores\n  "
+            + "no-sync(GPU slot-table remap)  : %6.2f ms/forward  CPU-busy=%.2f cores\n  "
+            + "→ round-trip 除去 speedup=%.2fx, max|Δhidden|=%.2e (%@)",
+            mSync.ms, mSync.cores, mNo.ms, mNo.cores, speedup, maxAbs,
+            maxAbs < 1e-3 ? "resident で bit一致=lossless" : "差あり(routed が hot-pin 外=要 resident 化)")
         // 二値判定(主=CPU-busy, 副=pipeline ratio):
         //   CPU-busy ≳1.0 → wall を CPU が占有=encode/routing-sync 律速(dispatch 系) → graph-capture/sync削減に価値
         //   CPU-busy ≲0.3 → CPU は GPU 待ちで block=GPU-exec 床 → 50ms は本物の compute 床、graph capture も無駄
@@ -1981,11 +2015,98 @@ extension Tell {
         return "[GpuBusy C=\(C), f32-full, hot-pin top-C, reps=\(reps)] issue#3 §5 dispatch vs exec\n"
             + String(format: "  build-only(eval せず forwardHidden のみ; lazy なら~0 のはず): %.2f ms/forward\n", buildMs)
             + "  (A) 独立 forward パイプライン (per-forward wall + CPU-busy cores):\n  " + lines.joined(separator: "\n  ")
+            + "\n  (B) sync vs no-sync round-trip 除去 A/B (同一 resident):\n" + abLines
             + "\n  判定: " + verdict
             + (tracePath == nil
                 ? "\n  ※ gputrace 裏取り: QWISP_GPUTRACE=/path/x.gputrace を渡す(要 mlx MLX_METAL_DEBUG ビルド)、"
                   + "または Instruments の Metal System Trace で本バイナリの GPU 占有率を直接読む"
                 : "")
+    }
+
+    /// **[高速化] issue#3 lever-1: round-trip 除去で resident greedy を ~2x lossless 化**
+    /// forward-gpu-busy の (B) A/B が「全 expert resident なら no-sync gather は exact 経路と bit 一致で 2x」
+    /// と forward 単位で示した。本 runner はそれを **エンドツーエンドの実 greedy decode** で確認する:
+    /// 同一プロンプトから N トークン greedy を sync / no-sync で各 1 回回し、(1)生成トークン完全一致(lossless)、
+    /// (2)tok/s を比較。C=256(全 expert 常駐)なら gpuSlotTable が全 expert を持ち alias 皆無＝無条件 exact。
+    /// C<256 では routed が cold に当たると slot-0 alias で発散(その divergent token 数も報告)。
+    /// - env: QWISP_RUN=nosync-resident / QWISP_CACHE_C(既定256) / QWISP_GEN(既定64) / QWISP_CALIB(既定48)
+    public static func runNoSyncResident(modelDir: String, refPath: String) throws -> String {
+        guard let device = MTLCreateSystemDefaultDevice() else { return "ERROR: no Metal device" }
+        let r = try loadArrays(url: URL(fileURLWithPath: refPath))
+        guard let promptArr = r["spec_prompt"] else { return "[NoSyncResident] skip" }
+        let C = Tell.envInt("QWISP_CACHE_C", 256)
+        let N = Tell.envInt("QWISP_GEN", 64)
+        let calibN = Tell.envInt("QWISP_CALIB", 48)
+        GatedDeltaNetLayer.f32Conv = true; AttentionLayer.f32SDPA = true
+        defer { GatedDeltaNetLayer.f32Conv = false; AttentionLayer.f32SDPA = false; StreamingMoEBlock.probeNoSync = false }
+        let store = try WeightStore(modelDir: modelDir); store.residentNonExperts()
+        let source = try ExpertSource(modelDir: modelDir); try source.warm()
+        let arena = try ExpertArena(device: device, source: source, N: 64)
+        let model = try StreamingQwispModel(store: store, arena: arena, device: device, source: source, cacheC: C)
+        let ids = promptArr.asType(.int32).reshaped([1, promptArr.dim(0)])
+        let isLin = model.isLinearFlags
+        let nE = 256, nMoE = model.expertCaches.count
+        // calib + hot-pin top-C（C=256 なら全 expert を resident 化）
+        var counts = [[Int]](repeating: [Int](repeating: 0, count: nE), count: nMoE)
+        let cc = model.makeCaches()
+        StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.captureInds = true
+        var (_, clg) = try model.prefillChunked(ids, caches: cc)
+        var ccur = MLX.argMax(clg[0, clg.dim(1) - 1], axis: -1).reshaped([1, 1])
+        MLX.eval([ccur] + cc.flatMap { $0.stateArrays })
+        for _ in 0 ..< calibN {
+            (_, clg) = try model.forwardHidden(ccur, caches: cc)
+            MLX.eval([clg] + cc.flatMap { $0.stateArrays } + model.expertCaches.compactMap { $0.lastInds })
+            for (mi, ec) in model.expertCaches.enumerated() {
+                if let li = ec.lastInds { for e in li.asArray(Int32.self) { counts[mi][Int(e)] += 1 } }
+            }
+            ccur = MLX.argMax(clg[0, 0], axis: -1).reshaped([1, 1]); MLX.eval([ccur])
+        }
+        StreamingMoEBlock.captureInds = false
+        var residentExperts = 0
+        for (mi, ec) in model.expertCaches.enumerated() {
+            let pin = Array(counts[mi].enumerated()
+                .sorted { $0.element != $1.element ? $0.element > $1.element : $0.offset < $1.offset }
+                .prefix(C).map { $0.offset })
+            _ = ec.ensure(pin); residentExperts += pin.count
+        }
+        let avgResident = residentExperts / Swift.max(1, nMoE)
+        // greedy 1 run（probeNoSync 指定）。tokens と tok/s を返す。fresh cache（expert 常駐は model 側で持続）。
+        func greedy(_ noSync: Bool) throws -> (toks: [Int], tps: Double) {
+            let mc = model.makeCaches()
+            var (_, lg) = try model.prefillChunked(ids, caches: mc)
+            var u = MLX.argMax(lg[0, lg.dim(1) - 1], axis: -1).reshaped([1, 1])
+            MLX.eval([u] + mc.flatMap { $0.stateArrays })
+            // warmup 1（kernel/グラフ確定を計時外に）。snapshot を warmup 前に取り、cache を post-prefill へ巻戻す。
+            StreamingMoEBlock.probeNoSync = noSync
+            let snaps0 = mc.map { $0.snapshot() }
+            let (_, wlg) = try model.forwardHidden(u, caches: mc); MLX.eval([wlg])
+            for (i, c) in mc.enumerated() { c.restore(snaps0[i], isLinear: isLin[i], trim: 1) }
+            var toks: [Int] = []
+            let t0 = DispatchTime.now().uptimeNanoseconds
+            for _ in 0 ..< N {
+                (_, lg) = try model.forwardHidden(u, caches: mc)
+                u = MLX.argMax(lg[0, 0], axis: -1).reshaped([1, 1])
+                MLX.eval([u] + mc.flatMap { $0.stateArrays })
+                toks.append(u.item(Int.self))
+            }
+            StreamingMoEBlock.probeNoSync = false
+            let secs = Double(DispatchTime.now().uptimeNanoseconds - t0) / 1e9
+            return (toks, Double(N) / secs)
+        }
+        let sync = try greedy(false)      // 参照=exact
+        let nosync = try greedy(true)
+        let match = zip(sync.toks, nosync.toks).filter { $0 == $1 }.count
+        // 先頭発散位置（lossless なら N、途中で alias 混入なら < N）
+        var firstDiv = N
+        for i in 0 ..< N where sync.toks[i] != nosync.toks[i] { firstDiv = i; break }
+        let speedup = sync.tps > 0 ? nosync.tps / sync.tps : 0
+        let losslessTag = match == N ? "✅ lossless(完全一致)"
+            : "⚠️ \(N - match)/\(N) 発散(先頭 token#\(firstDiv))=C<256 で routed が cold alias。要 full-resident or 予測"
+        return "[NoSyncResident C=\(C), avg resident=\(avgResident)/256 experts/層, N=\(N), f32-full]"
+            + " issue#3 lever-1 round-trip 除去\n"
+            + String(format: "  sync   (exact, 毎層 materialize+ensure): %.1f tok/s\n", sync.tps)
+            + String(format: "  no-sync(GPU slot-table remap)          : %.1f tok/s\n", nosync.tps)
+            + String(format: "  → speedup=%.2fx, token一致=%d/%d  %@", speedup, match, N, losslessTag)
     }
 
     /// cost-model 検証: 同一プロセスで (A)forward-cost→a,b fit (B)maxK-sweep の SuffixSpec 実測 を行い、

--- a/swift/Sources/QwispCore/TellExperiments.swift
+++ b/swift/Sources/QwispCore/TellExperiments.swift
@@ -2227,6 +2227,102 @@ extension Tell {
             + String(format: "  → speedup=%.2fx, token一致=%d/%d  %@", speedup, match, N, tag)
     }
 
+    /// **[計測] 8GB exact-pipeline go/no-go: cross-layer 予測の per-layer/per-token hit 率**
+    /// 「層跨ぎ予測 prefetch で routing round-trip を除去（bit-exact）」が成立するかの決め手を測る。
+    /// 機構: 各 token を exact greedy で回し、各層の **真の top-8** を、前 token 同層 gate 入力(temporal, M2 signal)
+    /// から予測した **top-w 集合**が覆うか判定。報告:
+    ///   - per-expert recall(w=8): 真 top-8 のうち予測 top-8 に入る割合（memory の 82-84% と比較）。
+    ///   - **per-layer all-8-hit 率**: その層の真 top-8 が全部 予測 top-w に入る確率（= その層が no-sync で exact に
+    ///     回せる＝round-trip 不要な割合）。
+    ///   - **per-token all-layers-hit 率**: 全層が hit する token の割合（= その token は全層 no-sync＝round-trip 完全ゼロ）。
+    /// 高い w で per-token all-hit が高く、w<=C(=64) に収まれば exact-pipeline が成立（残り層だけ sync fallback）。
+    /// - env: QWISP_RUN=cross-layer-hitrate / QWISP_CACHE_C(既定64) / QWISP_GEN(既定64)
+    public static func runCrossLayerHitrate(modelDir: String, refPath: String) throws -> String {
+        guard let device = MTLCreateSystemDefaultDevice() else { return "ERROR: no Metal device" }
+        let r = try loadArrays(url: URL(fileURLWithPath: refPath))
+        guard let promptArr = r["spec_prompt"] else { return "[CrossLayerHitrate] skip" }
+        let C = Tell.envInt("QWISP_CACHE_C", 64)
+        let N = Tell.envInt("QWISP_GEN", 64)
+        let widths = [8, 16, 32, 48]
+        GatedDeltaNetLayer.f32Conv = true; AttentionLayer.f32SDPA = true
+        defer {
+            GatedDeltaNetLayer.f32Conv = false; AttentionLayer.f32SDPA = false
+            StreamingMoEBlock.captureGateInput = false; StreamingMoEBlock.captureInds = false
+        }
+        let store = try WeightStore(modelDir: modelDir); store.residentNonExperts()
+        let source = try ExpertSource(modelDir: modelDir); try source.warm()
+        let arena = try ExpertArena(device: device, source: source, N: 64)
+        let model = try StreamingQwispModel(store: store, arena: arena, device: device, source: source, cacheC: C)
+        let ids = promptArr.asType(.int32).reshaped([1, promptArr.dim(0)])
+        let L = model.layerCount
+        let caches = model.makeCaches()
+        StreamingMoEBlock.probeNoSync = false
+        StreamingMoEBlock.captureGateInput = true; StreamingMoEBlock.captureInds = true
+        var (_, lg) = try model.prefillChunked(ids, caches: caches)
+        var cur = MLX.argMax(lg[0, lg.dim(1) - 1], axis: -1).reshaped([1, 1])
+        MLX.eval([cur] + caches.flatMap { $0.stateArrays }
+            + model.expertCaches.compactMap { $0.lastGateInput })
+        func capGate() -> [MLXArray] { (0 ..< L).map { model.expertCaches[$0].lastGateInput! } }
+        var prevGate = capGate()
+        // 集計
+        var layerHit = [Int: Int](); var tokAllHit = [Int: Int]()
+        for w in widths { layerHit[w] = 0; tokAllHit[w] = 0 }
+        // 信号選択: temporal(前 token 同層 gate入力, full-token lead) / intra1(同 token 前層 gate入力, ~1層 lead)
+        let sig = Tell.envStr("QWISP_SIGNAL", "temporal")
+        var recallSum = 0.0; var lt = 0; var toks = 0
+        for _ in 1 ..< N {
+            // exact forward（真の routing + 各層 gate 入力を捕捉）
+            let (_, lgt) = try model.forwardHidden(cur, caches: caches)
+            MLX.eval([lgt] + caches.flatMap { $0.stateArrays }
+                + model.expertCaches.compactMap { $0.lastInds }
+                + model.expertCaches.compactMap { $0.lastGateInput })
+            let true8 = (0 ..< L).map { Set(model.expertCaches[$0].lastInds!.asArray(Int32.self).map { Int($0) }) }
+            let thisGate = capGate()
+            // 予測元 signal（層毎）: forward 後に確定した入力で各幅予測（accuracy 計測）
+            let srcGate: [MLXArray] = (0 ..< L).map { i in
+                switch sig {
+                case "intra1": return i > 0 ? thisGate[i - 1] : prevGate[i]   // 同 token 前層
+                default:       return prevGate[i]                              // temporal
+                }
+            }
+            var predByW = [Int: [Set<Int>]]()
+            for w in widths {
+                let preds = (0 ..< L).map { model.predictLayerIndsK($0, srcGate[$0], w) }
+                MLX.eval(preds)
+                predByW[w] = preds.map { Set($0.asArray(Int32.self).map { Int($0) }) }
+            }
+            // per-expert recall（w=8）
+            for i in 0 ..< L {
+                let inter = true8[i].intersection(predByW[8]![i]).count
+                recallSum += Double(inter) / Double(Swift.max(1, true8[i].count))
+            }
+            // per-layer all-8-hit & per-token all-layers-hit（各幅）
+            for w in widths {
+                var allHit = true
+                for i in 0 ..< L {
+                    if true8[i].isSubset(of: predByW[w]![i]) { layerHit[w]! += 1 } else { allHit = false }
+                }
+                if allHit { tokAllHit[w]! += 1 }
+            }
+            lt += L; toks += 1
+            prevGate = thisGate
+            cur = MLX.argMax(lgt[0, 0], axis: -1).reshaped([1, 1]); MLX.eval([cur])
+        }
+        let recall = recallSum / Double(Swift.max(1, lt)) * 100
+        var lines: [String] = []
+        for w in widths {
+            lines.append(String(format: "  w=%2d: per-layer all-8-hit=%5.1f%%  per-token all-layers-hit=%5.1f%%  (prefetch %d≤C=%d %@)",
+                                w, Double(layerHit[w]!) / Double(Swift.max(1, lt)) * 100,
+                                Double(tokAllHit[w]!) / Double(Swift.max(1, toks)) * 100,
+                                w, C, w <= C ? "✓fit" : "✗"))
+        }
+        return "[CrossLayerHitrate C=\(C), N=\(N), signal=\(sig)] 8GB exact-pipeline go/no-go\n"
+            + String(format: "  per-expert recall(w=8)=%.1f%% (memory 82-84% と比較), L=%d 層\n", recall, L)
+            + lines.joined(separator: "\n")
+            + "\n  判定: per-token all-layers-hit が高い w で exact-pipeline 有望(全層 no-sync=round-trip 0)。"
+            + "低ければ per-layer fallback 頻発で sync 並みに縮退。"
+    }
+
     /// cost-model 検証: 同一プロセスで (A)forward-cost→a,b fit (B)maxK-sweep の SuffixSpec 実測 を行い、
     /// 予測 tok/s=(1+p)/(a+b(D+1)) が実測と一致するか確認。dev 機は IO≈0 ゆえ forward+accept 項を検証。
     /// 一致なら cost-model で C/maxK/mode を予測選択して良い。ズレれば feedback/起動時実 sweep が要ると判る。

--- a/swift/Sources/QwispCore/TellExperiments.swift
+++ b/swift/Sources/QwispCore/TellExperiments.swift
@@ -2323,6 +2323,106 @@ extension Tell {
             + "低ければ per-layer fallback 頻発で sync 並みに縮退。"
     }
 
+    /// **[高速化試作] 8GB exact-pipeline: per-layer 予測 prefetch + miss escalation の bit-exact 検証**
+    /// `forwardHiddenPipeline` を実 greedy decode で回し、sync greedy と (1)token 完全一致(bit-exact)、
+    /// (2)tok/s、(3)実 per-layer escalation 率 を比較。直列版ゆえ速度は async 化前の go/no-go 指標
+    /// (escalation 率が低く bit-exact なら async overlap で round-trip 除去の勝算)。
+    /// - env: QWISP_RUN=pipeline-exact / QWISP_CACHE_C(既定64) / QWISP_GEN(既定64) / QWISP_PREDICT_W(既定48) / QWISP_CALIB(48)
+    public static func runPipelineExact(modelDir: String, refPath: String) throws -> String {
+        guard let device = MTLCreateSystemDefaultDevice() else { return "ERROR: no Metal device" }
+        let r = try loadArrays(url: URL(fileURLWithPath: refPath))
+        guard let promptArr = r["spec_prompt"] else { return "[PipelineExact] skip" }
+        let C = Tell.envInt("QWISP_CACHE_C", 64)
+        let N = Tell.envInt("QWISP_GEN", 64)
+        let predictW = Tell.envInt("QWISP_PREDICT_W", 48)
+        let calibN = Tell.envInt("QWISP_CALIB", 48)
+        GatedDeltaNetLayer.f32Conv = true; AttentionLayer.f32SDPA = true
+        defer {
+            GatedDeltaNetLayer.f32Conv = false; AttentionLayer.f32SDPA = false
+            StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.countHotMiss = false
+            StreamingMoEBlock.captureGateInput = false; StreamingMoEBlock.captureInds = false
+        }
+        let store = try WeightStore(modelDir: modelDir); store.residentNonExperts()
+        let source = try ExpertSource(modelDir: modelDir); try source.warm()
+        let arena = try ExpertArena(device: device, source: source, N: 64)
+        let model = try StreamingQwispModel(store: store, arena: arena, device: device, source: source, cacheC: C)
+        let ids = promptArr.asType(.int32).reshaped([1, promptArr.dim(0)])
+        let isLin = model.isLinearFlags
+        let nE = 256, nMoE = model.expertCaches.count
+        // calib + hot-pin top-C（warm start）
+        var counts = [[Int]](repeating: [Int](repeating: 0, count: nE), count: nMoE)
+        let cc = model.makeCaches()
+        StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.captureInds = true
+        var (_, clg) = try model.prefillChunked(ids, caches: cc)
+        var ccur = MLX.argMax(clg[0, clg.dim(1) - 1], axis: -1).reshaped([1, 1])
+        MLX.eval([ccur] + cc.flatMap { $0.stateArrays })
+        for _ in 0 ..< calibN {
+            (_, clg) = try model.forwardHidden(ccur, caches: cc)
+            MLX.eval([clg] + cc.flatMap { $0.stateArrays } + model.expertCaches.compactMap { $0.lastInds })
+            for (mi, ec) in model.expertCaches.enumerated() {
+                if let li = ec.lastInds { for e in li.asArray(Int32.self) { counts[mi][Int(e)] += 1 } }
+            }
+            ccur = MLX.argMax(clg[0, 0], axis: -1).reshaped([1, 1]); MLX.eval([ccur])
+        }
+        StreamingMoEBlock.captureInds = false
+        for (mi, ec) in model.expertCaches.enumerated() {
+            _ = ec.ensure(Array(counts[mi].enumerated()
+                .sorted { $0.element != $1.element ? $0.element > $1.element : $0.offset < $1.offset }
+                .prefix(C).map { $0.offset }))
+        }
+        // 参照: sync greedy（exact, 先に実行して true token 列を確定）
+        func greedySync() throws -> (toks: [Int], tps: Double) {
+            StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.countHotMiss = false
+            let mc = model.makeCaches()
+            var (_, lg) = try model.prefillChunked(ids, caches: mc)
+            var u = MLX.argMax(lg[0, lg.dim(1) - 1], axis: -1).reshaped([1, 1])
+            MLX.eval([u] + mc.flatMap { $0.stateArrays })
+            let s0 = mc.map { $0.snapshot() }
+            (_, lg) = try model.forwardHidden(u, caches: mc); MLX.eval([lg])
+            for (i, c) in mc.enumerated() { c.restore(s0[i], isLinear: isLin[i], trim: 1) }
+            var toks: [Int] = []; let t0 = DispatchTime.now().uptimeNanoseconds
+            for _ in 0 ..< N {
+                (_, lg) = try model.forwardHidden(u, caches: mc)
+                u = MLX.argMax(lg[0, 0], axis: -1).reshaped([1, 1])
+                MLX.eval([u] + mc.flatMap { $0.stateArrays }); toks.append(u.item(Int.self))
+            }
+            return (toks, Double(N) / (Double(DispatchTime.now().uptimeNanoseconds - t0) / 1e9))
+        }
+        // pipeline greedy（per-layer 予測 prefetch + miss escalation）
+        func greedyPipeline() throws -> (toks: [Int], tps: Double, escPerTok: Double) {
+            let mc = model.makeCaches()
+            var (_, lg) = try model.prefillChunked(ids, caches: mc)
+            var u = MLX.argMax(lg[0, lg.dim(1) - 1], axis: -1).reshaped([1, 1])
+            MLX.eval([u] + mc.flatMap { $0.stateArrays })
+            let s0 = mc.map { $0.snapshot() }
+            let (_, wlg, _) = try model.forwardHiddenPipeline(u, caches: mc, predictW: predictW, isLin: isLin)
+            MLX.eval([wlg])
+            for (i, c) in mc.enumerated() { c.restore(s0[i], isLinear: isLin[i], trim: 1) }
+            var toks: [Int] = []; var escTot = 0
+            let t0 = DispatchTime.now().uptimeNanoseconds
+            for _ in 0 ..< N {
+                let (_, plg, esc) = try model.forwardHiddenPipeline(u, caches: mc, predictW: predictW, isLin: isLin)
+                u = MLX.argMax(plg[0, 0], axis: -1).reshaped([1, 1])
+                MLX.eval([u] + mc.flatMap { $0.stateArrays }); toks.append(u.item(Int.self)); escTot += esc
+            }
+            return (toks, Double(N) / (Double(DispatchTime.now().uptimeNanoseconds - t0) / 1e9), Double(escTot) / Double(N))
+        }
+        let sync = try greedySync()
+        let pipe = try greedyPipeline()
+        let match = zip(sync.toks, pipe.toks).filter { $0 == $1 }.count
+        var firstDiv = N; for i in 0 ..< N where sync.toks[i] != pipe.toks[i] { firstDiv = i; break }
+        let speedup = sync.tps > 0 ? pipe.tps / sync.tps : 0
+        let L = model.layerCount
+        let tag = match == N ? "✅ bit-exact(sync と完全一致)"
+            : "❌ \(N - match)/\(N) 不一致(先頭#\(firstDiv))=pipeline バグ(escalation 検出漏れ)"
+        return "[PipelineExact C=\(C), N=\(N), predictW=\(predictW), intra1 signal, 直列(overlap無)] 8GB exact-pipeline\n"
+            + String(format: "  sync     (exact)        : %.1f tok/s\n", sync.tps)
+            + String(format: "  pipeline (予測prefetch) : %.1f tok/s  (escalation %.1f/%d 層=%.0f%%/token)\n",
+                     pipe.tps, pipe.escPerTok, L, pipe.escPerTok / Double(L) * 100)
+            + String(format: "  → speedup=%.2fx, token一致=%d/%d  %@\n", speedup, match, N, tag)
+            + "  ※直列版ゆえ予測+ensure コスト込み。escalation 率が低く bit-exact なら async overlap で勝算"
+    }
+
     /// cost-model 検証: 同一プロセスで (A)forward-cost→a,b fit (B)maxK-sweep の SuffixSpec 実測 を行い、
     /// 予測 tok/s=(1+p)/(a+b(D+1)) が実測と一致するか確認。dev 機は IO≈0 ゆえ forward+accept 項を検証。
     /// 一致なら cost-model で C/maxK/mode を予測選択して良い。ズレれば feedback/起動時実 sweep が要ると判る。

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -47,6 +47,7 @@ if CommandLine.arguments.contains("stream") {
         ("mtp-spec-verify",       { try Tell.runMTPSpecVerify(modelDir: $0, refPath: $1) }),
         ("suffix-spec",           { try Tell.runSuffixSpec(modelDir: $0, refPath: $1) }),
         ("forward-cost",          { try Tell.runForwardCost(modelDir: $0, refPath: $1) }),
+        ("forward-gpu-busy",      { try Tell.runForwardGpuBusy(modelDir: $0, refPath: $1) }),
         ("mtp-draft-calib",       { try Tell.runMTPDraftCalib(modelDir: $0, refPath: $1) }),
         ("device-probe",          { md, _ in try DeviceProbe.run(modelDir: md) }),
         ("cost-model-validate",   { try Tell.runCostModelValidate(modelDir: $0, refPath: $1) }),

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -49,6 +49,7 @@ if CommandLine.arguments.contains("stream") {
         ("forward-cost",          { try Tell.runForwardCost(modelDir: $0, refPath: $1) }),
         ("forward-gpu-busy",      { try Tell.runForwardGpuBusy(modelDir: $0, refPath: $1) }),
         ("nosync-resident",       { try Tell.runNoSyncResident(modelDir: $0, refPath: $1) }),
+        ("nosync-escalate",       { try Tell.runNoSyncEscalate(modelDir: $0, refPath: $1) }),
         ("mtp-draft-calib",       { try Tell.runMTPDraftCalib(modelDir: $0, refPath: $1) }),
         ("device-probe",          { md, _ in try DeviceProbe.run(modelDir: md) }),
         ("cost-model-validate",   { try Tell.runCostModelValidate(modelDir: $0, refPath: $1) }),

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -48,6 +48,7 @@ if CommandLine.arguments.contains("stream") {
         ("suffix-spec",           { try Tell.runSuffixSpec(modelDir: $0, refPath: $1) }),
         ("forward-cost",          { try Tell.runForwardCost(modelDir: $0, refPath: $1) }),
         ("forward-gpu-busy",      { try Tell.runForwardGpuBusy(modelDir: $0, refPath: $1) }),
+        ("nosync-resident",       { try Tell.runNoSyncResident(modelDir: $0, refPath: $1) }),
         ("mtp-draft-calib",       { try Tell.runMTPDraftCalib(modelDir: $0, refPath: $1) }),
         ("device-probe",          { md, _ in try DeviceProbe.run(modelDir: md) }),
         ("cost-model-validate",   { try Tell.runCostModelValidate(modelDir: $0, refPath: $1) }),

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -50,6 +50,7 @@ if CommandLine.arguments.contains("stream") {
         ("forward-gpu-busy",      { try Tell.runForwardGpuBusy(modelDir: $0, refPath: $1) }),
         ("nosync-resident",       { try Tell.runNoSyncResident(modelDir: $0, refPath: $1) }),
         ("nosync-escalate",       { try Tell.runNoSyncEscalate(modelDir: $0, refPath: $1) }),
+        ("cross-layer-hitrate",   { try Tell.runCrossLayerHitrate(modelDir: $0, refPath: $1) }),
         ("mtp-draft-calib",       { try Tell.runMTPDraftCalib(modelDir: $0, refPath: $1) }),
         ("device-probe",          { md, _ in try DeviceProbe.run(modelDir: md) }),
         ("cost-model-validate",   { try Tell.runCostModelValidate(modelDir: $0, refPath: $1) }),

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -51,6 +51,7 @@ if CommandLine.arguments.contains("stream") {
         ("nosync-resident",       { try Tell.runNoSyncResident(modelDir: $0, refPath: $1) }),
         ("nosync-escalate",       { try Tell.runNoSyncEscalate(modelDir: $0, refPath: $1) }),
         ("cross-layer-hitrate",   { try Tell.runCrossLayerHitrate(modelDir: $0, refPath: $1) }),
+        ("pipeline-exact",        { try Tell.runPipelineExact(modelDir: $0, refPath: $1) }),
         ("mtp-draft-calib",       { try Tell.runMTPDraftCalib(modelDir: $0, refPath: $1) }),
         ("device-probe",          { md, _ in try DeviceProbe.run(modelDir: md) }),
         ("cost-model-validate",   { try Tell.runCostModelValidate(modelDir: $0, refPath: $1) }),

--- a/tools/gpu_busy_from_trace.py
+++ b/tools/gpu_busy_from_trace.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""issue#3 §5: Metal System Trace から forward の GPU-busy 占有率を算出。
+
+dispatch/sync 律速か GPU-exec 床かを二値判定する。`metal-gpu-intervals`(GPU 実行区間)を
+process=qwisp・depth=0 で抽出し、区間 union / span = GPU 占有率を出す。GPU が大きく idle
+(≲50%)なら 50ms 床は GPU-exec でなく dispatch/sync(per-layer routing round-trip)律速。
+
+使い方:
+  # 1) forward ループを長く回しつつ Metal System Trace を記録
+  xcrun xctrace record --template 'Metal System Trace' --output /tmp/qwisp_gpu.trace \
+    --env QWISP_RUN=forward-gpu-busy --env QWISP_GPUBUSY_K=1 --env QWISP_FC_REPS=200 \
+    --env QWISP_MODEL=... --env QWISP_MTP_REF=/tmp/qwisp_mtp_ref.safetensors \
+    --launch -- <qwisp-poc> stream
+  # 2) GPU 区間を export
+  xcrun xctrace export --input /tmp/qwisp_gpu.trace \
+    --xpath '/trace-toc/run[@number="1"]/data/table[@schema="metal-gpu-intervals"]' \
+    --output /tmp/qwisp_gpuint.xml
+  # 3) 占有率を算出
+  python3 tools/gpu_busy_from_trace.py /tmp/qwisp_gpuint.xml [qwisp]
+
+実測(2026-06-28, M1 Max): GPU-busy ≈ 34.6%(steady median 33.8%) ＝ GPU は ~65% idle
+→ dispatch/sync 律速確定。CPU-busy ≈0.51 cores(probe forward-gpu-busy)と整合。
+"""
+import re, sys, statistics as st
+from collections import defaultdict
+
+path = sys.argv[1] if len(sys.argv) > 1 else "/tmp/qwisp_gpuint.xml"
+needle = sys.argv[2] if len(sys.argv) > 2 else "qwisp"
+data = open(path, "r", errors="replace").read()
+
+# xctrace export は値を id で intern し、以降は ref で参照する。先に id->値の表を作る。
+def build(tag):
+    return {int(i): int(v) for i, v in re.findall(r'<%s id="(\d+)"[^>]*>(\d+)</%s>' % (tag, tag), data)}
+
+startmap = build("start-time")
+depthmap = build("metal-nesting-level")
+durmap = build("duration")               # col2(exec duration); row 内の最初の <duration>
+procmap = {int(i): f for i, f in re.findall(r'<process id="(\d+)" fmt="([^"]*)"', data)}
+
+ivals = []
+total = 0
+for r in re.finditer(r"<row>(.*?)</row>", data, re.S):
+    body = r.group(1); total += 1
+    pm = re.search(r'<process (?:id|ref)="(\d+)"', body)
+    proc = procmap.get(int(pm.group(1))) if pm else None
+    if not proc or needle not in proc:
+        continue
+    dm = re.search(r'<metal-nesting-level (?:id|ref)="(\d+)"', body)
+    if not dm or depthmap.get(int(dm.group(1))) != 0:
+        continue
+    sm = re.search(r'<start-time (?:id|ref)="(\d+)"', body)
+    um = re.search(r'<duration (?:id|ref)="(\d+)"', body)
+    s = startmap.get(int(sm.group(1))) if sm else None
+    d = durmap.get(int(um.group(1))) if um else None
+    if s is None or d is None:
+        continue
+    ivals.append((s, s + d))
+
+print(f"rows={total}  {needle} depth0 GPU intervals={len(ivals)}")
+if not ivals:
+    sys.exit("no intervals — wrong process name? try arg2")
+
+ivals.sort()
+def union(iv):
+    tot = 0; cs, ce = iv[0]
+    for s, e in iv[1:]:
+        if s > ce: tot += ce - cs; cs, ce = s, e
+        else: ce = max(ce, e)
+    return tot + (ce - cs)
+
+span0 = ivals[0][0]; span1 = max(e for _, e in ivals); span = span1 - span0
+busy = union(ivals)
+print(f"GPU-active span={span/1e6:.0f}ms  union GPU-busy={busy/1e6:.0f}ms  overall occupancy={busy/span*100:.1f}%")
+
+binw = 10_000_000
+bins = defaultdict(list)
+for s, e in ivals:
+    bins[(s - span0) // binw].append((s, e))
+occ = sorted(min(union(sorted(v)), binw) / binw for v in bins.values())
+busy_bins = [o for o in occ if o > 0.05]
+if busy_bins:
+    print(f"steady GPU occupancy /10ms: median={st.median(busy_bins)*100:.1f}%  "
+          f"p90={busy_bins[int(len(busy_bins)*0.9)]*100:.1f}%  max={max(busy_bins)*100:.1f}%")
+print(f"mean interval dur={st.mean(e-s for s,e in ivals)/1e3:.1f}us")
+verdict = ("DISPATCH/SYNC 律速 (GPU 大きく idle)" if busy/span < 0.5
+           else "GPU-EXEC 床 (GPU ほぼ飽和)" if busy/span >= 0.8 else "混在")
+print("判定:", verdict)


### PR DESCRIPTION
## 概要
issue#3「nl床は physics でなく dispatch-latency 律速の可能性」を検証し、その lever を製品化。さらに 8GB streaming への拡張（routing 予測）を試行し NO-GO を確定（知見として収録）。

## 1. 床の正体を実測確定（dispatch/sync 律速）
- 想定の「probe に `GPUStartTime–GPUEndTime` を足すだけ」は **mlx-swift が command buffer 非公開ゆえ不可**。代替2法で測定。
- **Metal System Trace 実測（M1 Max）: forward の GPU-busy ≈ 34.6%（GPU ~65% idle）**。`forward-gpu-busy` probe で CPU-busy≈0.51 cores、build-only≈eval＝forward は lazy でなく per-layer routing 同期を強制。
- → 床は GPU-exec でなく **dispatch/sync-latency 律速**（per-layer MoE routing round-trip）。issue#3 の「fundamental physics は言い過ぎ／tooling-sync 床」を実測で支持。

## 2. lever-1: round-trip 除去（no-sync）で bit-exact 高速化
全 expert resident なら no-sync gather（GPU slot-table remap）は exact 経路と **bit 一致**（`max|Δhidden|=0`）。
- forward 単位: sync 31.9ms → no-sync 16.1ms = **1.99x**
- 実 greedy decode（token 完全一致検証）: **C=256 32.7→56.7 tok/s 1.73x, 64/64 lossless**
- **本番配線**: `runSuffixSpec` を **C≥256 で auto pure no-sync**（`QWISP_NOSYNC=1/0`）。C=256 mix: spec **224 vs 196**, greedy 56.9、48/48 lossless。**C<256 は従来 sync で無回帰**。

## 3. escalation 検証（cold-start で net 無効）
C<256 で no-sync を exact 化する miss-escalation を実装・検証。出力は常に bit-exact だが token 粒度は per-token all-hit≈0 の footprint 壁（C=128 で escalation 98%→0.67x）。`nosync-escalate` runner の C=192 1.8x は warm アーティファクトで、cold-start single-pass は escalate 100%→fallback。∴ 実用 no-sync は **C=256（全常駐, ~21GB, 24GB+機）のみ**。escalation band は既定オフ（opt-in `QWISP_NOSYNC_MIN`）。

## 4. 8GB streaming への拡張（routing 予測）= NO-GO（知見収録）
8GB(C=64) で bit-exact に round-trip 除去を狙い、cross-layer 予測→prefetch→per-layer escalation を試作。
- signal: temporal 17% / intra1 59.5%。per-token all-hit≈0%（0.9^40）→ per-layer 方式必須。
- prototype `forwardHiddenPipeline`: **64/64 bit-exact ✅ だが直列 0.26-0.46x（2-4x 遅）**。
- **決定的理由**: 予測は round-trip を除去でなく**追加**する（予測 drain+ensure+per-layer miss drain+escalation 再計算 = 80+ sync/token > sync の 40）。GPU compute ~16ms に対し drain 群が critical path に残り async でも sync 超え不可。
- ∴ exact no-sync が効くのは予測/ensure/verify 不要な **C=256 全常駐のみ**。8GB/16GB の単流 bit-exact 高速化は容量壁で道無し。

## 変更
- `forward-gpu-busy` / `nosync-resident` / `nosync-escalate` / `cross-layer-hitrate` / `pipeline-exact` probe
- `runSuffixSpec` に no-sync gate（C≥256 pure / opt-in escalation / 以下 sync）
- `predictIndsK` / `forwardHiddenPipeline`（予測 pipeline）
- `tools/gpu_busy_from_trace.py`（Metal trace → GPU 占有率）
- notes/01 §2-4/2-5/2-6

## 検証
lever-1 全 tier（C=256/192/128/64）で **48/48=100% lossless（vs Swift-greedy）**、production 既定は無回帰。予測 pipeline は 64/64 bit-exact（速度 NO-GO）。

関連: #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)