### PR TITLE
feat(bolt): opt-in L3 bolt-mode for slow-NAND + SSD-throttle verification

### DIFF
--- a/swift/Sources/QwispCore/ExpertArena.swift
+++ b/swift/Sources/QwispCore/ExpertArena.swift
@@ -376,9 +376,18 @@ public final class StreamingMoEBlock {
         let store: ExpertArena
         var remapVals = [Int32](repeating: 0, count: flat.count)
         if let c = cache {
-            let slotOf = c.ensure(U)                                   // hit は pread 省略
-            for (j, e32) in flat.enumerated() { remapVals[j] = Int32(slotOf[Int(e32)]!) }
-            store = c.arena
+            if StreamingMoEBlock.skipMode == 3, let bt = c.buddyTable {
+                // deterministic buddy (io=0): remap cold->buddy hot slot via buddyTable, NO ensure/pread.
+                // The inds.asArray above is the per-layer CPU sync barrier, so this is deterministic
+                // (unlike probeNoSync no-sync, which races across layers). bolt uses this path.
+                let btA = bt.asArray(Int32.self)
+                for (j, e32) in flat.enumerated() { let e = Int(e32); remapVals[j] = e < btA.count ? btA[e] : 0 }
+                store = c.arena
+            } else {
+                let slotOf = c.ensure(U)                               // hit は pread 省略
+                for (j, e32) in flat.enumerated() { remapVals[j] = Int32(slotOf[Int(e32)]!) }
+                store = c.arena
+            }
         } else {
             var slot: [Int: Int] = [:]
             for (i, e) in U.enumerated() { slot[e] = i }

--- a/swift/Sources/QwispCore/ExpertSource.swift
+++ b/swift/Sources/QwispCore/ExpertSource.swift
@@ -14,6 +14,19 @@ public final class ExpertSource {
 
     struct TensorMeta { let dtype: String; let shape: [Int]; let begin: Int; let end: Int }
 
+    // ★ SSD 帯域エミュレーション (slow-NAND=Neo の C/D 評価): preadInto を単一 chokepoint とした
+    //   leaky-bucket active throttle。QWISP_SSD_THROTTLE_GBS=目標 BW(GB/s, 0=無効)。単一 NAND の直列性を
+    //   lock+virtualClock で模擬し、fast pread 後に modeled 完了時刻まで nanosleep → engine の実 prefetch/
+    //   overlap が自然応答=faithful。QWISP_SSD_ACCT=1 で bytes/reads/実 nanos 累積(cross-check)。既定 off。
+    nonisolated(unsafe) public static var throttleGBs: Double = Double(ProcessInfo.processInfo.environment["QWISP_SSD_THROTTLE_GBS"] ?? "") ?? 0
+    nonisolated(unsafe) public static var acct = ProcessInfo.processInfo.environment["QWISP_SSD_ACCT"] == "1"
+    nonisolated(unsafe) public static var acctBytes = 0
+    nonisolated(unsafe) public static var acctReads = 0
+    nonisolated(unsafe) public static var acctNanos: UInt64 = 0        // 実 pread 時間(throttle sleep 除く)
+    nonisolated(unsafe) static var virtualClockNs: UInt64 = 0          // 単一 NAND が free になる時刻
+    static let throttleLock = NSLock()
+    public static func resetAcct() { throttleLock.lock(); acctBytes = 0; acctReads = 0; acctNanos = 0; virtualClockNs = 0; throttleLock.unlock() }
+
     let dir: URL
     let wm: [String: String]                          // tensor name -> shard
     var headers: [String: (meta: [String: TensorMeta], dataStart: Int)] = [:]
@@ -132,8 +145,31 @@ public final class ExpertSource {
         let (_, dataStart) = try header(shard)
         let stride = (t.end - t.begin) / t.shape[0]
         let offset = dataStart + t.begin + e * stride
+        let t0 = DispatchTime.now().uptimeNanoseconds
         let n = pread(fd(shard), buf, stride, off_t(offset))
         if n != stride { throw NSError(domain: "ExpertSource", code: 3) }
+        let dt = DispatchTime.now().uptimeNanoseconds - t0
+        if ExpertSource.acct {
+            ExpertSource.throttleLock.lock()
+            ExpertSource.acctBytes += stride; ExpertSource.acctReads += 1; ExpertSource.acctNanos += dt
+            ExpertSource.throttleLock.unlock()
+        }
+        // ★ leaky-bucket throttle: 単一 NAND を直列にモデル化。serveNs = stride / (GB/s)（GB=1e9, ns=s×1e9 相殺）。
+        if ExpertSource.throttleGBs > 0 {
+            let serveNs = UInt64(Double(stride) / ExpertSource.throttleGBs)
+            ExpertSource.throttleLock.lock()
+            let now = DispatchTime.now().uptimeNanoseconds
+            let start = Swift.max(now, ExpertSource.virtualClockNs)
+            let end = start &+ serveNs
+            ExpertSource.virtualClockNs = end
+            ExpertSource.throttleLock.unlock()
+            let after = DispatchTime.now().uptimeNanoseconds
+            if end > after {
+                let s = end - after
+                var ts = timespec(tv_sec: Int(s / 1_000_000_000), tv_nsec: Int(s % 1_000_000_000))
+                nanosleep(&ts, nil)
+            }
+        }
     }
 
     /// expert e の (layer,proj,part) スライスを [1, rest...] の MLXArray で返す（pread, 自前 buffer 所有）。

--- a/swift/Sources/QwispCore/TellBolt.swift
+++ b/swift/Sources/QwispCore/TellBolt.swift
@@ -1,0 +1,174 @@
+// Stage-1 bolt-mode: buddy+spec near-lossless (L3, opt-in). Reuses Tell.suffixDraft + the
+// SuffixSpec accept-prefix loop, but verify (and reject re-run) run buddy no-sync
+// (probeNoSync=true, skipMode=3) so the committed output = buddy-model greedy at spec speed.
+// No exact escalation, no union-overflow guard (buddy is lossy-by-design). nl auto-falls-back:
+// suffixDraft()==[] on high-entropy tokens => single buddy no-sync forward/token.
+//
+// Value only on the slow-NAND tier: buddy makes io->0, so under SSD throttle (Neo) bolt is not
+// IO-starved like strict. On fast SSD / resident, strict SuffixSpec dominates — bolt is Neo-only.
+// Measure with QWISP_SSD_THROTTLE_GBS=1.5 to see the win. Strict-L1 stays the default (runSuffixSpec).
+import Foundation
+import MLX
+import Metal
+
+extension Tell {
+    /// **bolt-mode L3 (opt-in, near-lossless)**: buddy no-sync draft/verify SuffixSpec.
+    /// output = buddy-greedy (deterministic); headline quality = token-match vs strict-4bit
+    /// **f32-full** greedy (the canonical L1 reference), computed in-run when QWISP_SWIFT_REF=1.
+    /// env: QWISP_BOLT=1 or QWISP_RUN=bolt / QWISP_CACHE_C / QWISP_DRAFT_K / QWISP_CALIB /
+    ///      QWISP_SUFFIX_MIN / QWISP_SUFFIX_MATCH / QWISP_SWIFT_REF / QWISP_GEN / QWISP_FUSE_GDN(stage2)
+    public static func runBolt(modelDir: String, refPath: String) throws -> String {
+        guard let device = MTLCreateSystemDefaultDevice() else { return "ERROR: no Metal device" }
+        let r = try loadArrays(url: URL(fileURLWithPath: refPath))
+        guard let promptArr = r["spec_prompt"], let gRef = r["spec_greedy"] else { return "[Bolt] skip" }
+        let C = Tell.envInt("QWISP_CACHE_C", DeviceCalibration.defaultC())
+        let calibN = Tell.envInt("QWISP_CALIB", 48)
+        let maxKSafe = Swift.max(4, C * 3 / 8)
+        let maxK = Swift.min(Tell.envInt("QWISP_DRAFT_K", maxKSafe), maxKSafe)
+        let minMatch = Tell.envInt("QWISP_SUFFIX_MIN", 4)
+        let maxMatch = Tell.envInt("QWISP_SUFFIX_MATCH", 32)
+        // bolt uses f32-full verify (same as strict SuffixSpec) for accept/reject STABILITY:
+        // f16 batched-verify diverges from the sequential reject re-run (spec-gdn-incompat),
+        // which corrupts cache state on partial-reject/fallback and cascades to garbage. The
+        // speedup comes from buddy (io=0) + spec, NOT from dropping f32-full (only 2 divergent
+        // ops: attention SDPA + GDN conv1d; cheap). Buddy still provides the slow-NAND win.
+        GatedDeltaNetLayer.f32Conv = true; AttentionLayer.f32SDPA = true
+        GatedDeltaNetLayer.fuseGDN = Tell.envFlag("QWISP_FUSE_GDN")   // stage 2 (free, bit-preserving)
+        defer {
+            StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.skipMode = 0
+            StreamingMoEBlock.captureInds = false; GatedDeltaNetLayer.fuseGDN = false
+            GatedDeltaNetLayer.f32Conv = false; AttentionLayer.f32SDPA = false
+        }
+        let store = try WeightStore(modelDir: modelDir); store.residentNonExperts()
+        let source = try ExpertSource(modelDir: modelDir); try source.warm()
+        let arena = try ExpertArena(device: device, source: source, N: 64)
+        let model = try StreamingQwispModel(store: store, arena: arena, device: device, source: source, cacheC: C)
+        let ids = promptArr.asType(.int32).reshaped([1, promptArr.dim(0)])
+        let gR = gRef.asArray(Int32.self).map { Int($0) }
+        let isLin = model.isLinearFlags
+        let N = Swift.min(Tell.envInt("QWISP_GEN", 48), gR.count)
+        let nE = 256, nMoE = model.expertCaches.count
+
+        // phase 1: calib — frequency + co-activation (for buddy table). Exact routing (probeNoSync=false).
+        var counts = [[Int]](repeating: [Int](repeating: 0, count: nE), count: nMoE)
+        var coact = [[[Int]]](repeating: [[Int]](repeating: [Int](repeating: 0, count: nE), count: nE), count: nMoE)
+        let cc = model.makeCaches()
+        StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.skipMode = 0; StreamingMoEBlock.captureInds = true
+        var (_, clg) = try model.prefillChunked(ids, caches: cc)
+        var ccur = MLX.argMax(clg[0, clg.dim(1) - 1], axis: -1).reshaped([1, 1])
+        MLX.eval([ccur] + cc.flatMap { $0.stateArrays })
+        for _ in 0 ..< calibN {
+            (_, clg) = try model.forwardHidden(ccur, caches: cc)
+            MLX.eval([clg] + cc.flatMap { $0.stateArrays } + model.expertCaches.compactMap { $0.lastInds })
+            for (mi, ec) in model.expertCaches.enumerated() {
+                if let li = ec.lastInds {
+                    let es = li.asArray(Int32.self).map { Int($0) }
+                    for e in es { counts[mi][e] += 1 }
+                    for a in 0 ..< es.count { for b in (a + 1) ..< es.count {
+                        coact[mi][es[a]][es[b]] += 1; coact[mi][es[b]][es[a]] += 1 } }
+                }
+            }
+            ccur = MLX.argMax(clg[0, 0], axis: -1).reshaped([1, 1]); MLX.eval([ccur])
+        }
+        StreamingMoEBlock.captureInds = false
+
+        // Canonical strict-4bit greedy reference (f32-full, exact routing) for losslessness classification.
+        var gSwift: [Int] = []
+        if Tell.envFlag("QWISP_SWIFT_REF") {
+            GatedDeltaNetLayer.f32Conv = true; AttentionLayer.f32SDPA = true   // <- canonical L1 reference
+            StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.skipMode = 0
+            let cref = model.makeCaches()
+            var (_, rlg) = try model.prefillChunked(ids, caches: cref)
+            var rcur = MLX.argMax(rlg[0, rlg.dim(1) - 1], axis: -1).reshaped([1, 1])
+            MLX.eval([rcur] + cref.flatMap { $0.stateArrays })
+            for _ in 0 ..< N {
+                gSwift.append(rcur.item(Int.self))
+                (_, rlg) = try model.forwardHidden(rcur, caches: cref)
+                rcur = MLX.argMax(rlg[0, 0], axis: -1).reshaped([1, 1])
+                MLX.eval([rcur] + cref.flatMap { $0.stateArrays })
+            }
+            // leave f32-full ON — bolt's own verify uses it too (stability, see above).
+        }
+
+        // phase 3a: EXACT prefill — the prompt context must be exact; buddy prefill corrupts every
+        // downstream token (so even 100% decode escalation cannot reach strict). One-time, off timer.
+        let mc = model.makeCaches()
+        StreamingMoEBlock.probeNoSync = false; StreamingMoEBlock.skipMode = 0
+        let (_, lg) = try model.prefillChunked(ids, caches: mc)
+        var uArr = MLX.argMax(lg[0, lg.dim(1) - 1], axis: -1).reshaped([1, 1])
+        MLX.eval([uArr] + mc.flatMap { $0.stateArrays })
+
+        // phase 3b: top-C hot-pin + buddy table AFTER prefill (so arena = hot set, buddyTable valid).
+        for (mi, ec) in model.expertCaches.enumerated() {
+            _ = ec.ensure(Array(counts[mi].enumerated()
+                .sorted { $0.element != $1.element ? $0.element > $1.element : $0.offset < $1.offset }
+                .prefix(C).map { $0.offset }))
+            ec.buildBuddyTable(coact: coact[mi], numExperts: nE)
+        }
+
+        // phase 3c: DETERMINISTIC buddy decode. probeNoSync=false keeps the per-layer CPU sync
+        // barrier (deterministic, no cross-layer race); skipMode=3 remaps cold->buddy slot in the
+        // synced path with NO pread => io=0. This replaces the racy no-sync buddy path.
+        StreamingMoEBlock.probeNoSync = false
+        StreamingMoEBlock.skipMode = 3            // cold -> buddy slot (deterministic synced remap)
+        var hist = ids.asArray(Int32.self).map { Int($0) }
+
+        var out: [Int] = []; var steps = 0, accTok = 0, draftSteps = 0
+        let t0 = DispatchTime.now()
+        while out.count < N {
+            steps += 1
+            let u = uArr.item(Int.self)
+            let drafts = suffixDraft(hist + [u], maxMatch: maxMatch, draftK: maxK, minMatch: minMatch)
+            let D = drafts.count
+            if D == 0 {                              // nl / novel: single buddy no-sync greedy (fallback)
+                let (_, glg) = try model.forwardHidden(uArr, caches: mc)
+                out.append(u); hist.append(u)
+                uArr = MLX.argMax(glg[0, 0], axis: -1).reshaped([1, 1])
+                MLX.eval([uArr] + mc.flatMap { $0.stateArrays })
+                continue
+            }
+            draftSteps += 1
+            let snaps = mc.map { $0.snapshot() }
+            let seq = MLX.concatenated([uArr, MLXArray(drafts.map { Int32($0) }, [1, D])], axis: 1)  // [1,D+1]
+            let (_, vlg) = try model.forwardHidden(seq, caches: mc)   // buddy no-sync batched verify
+            let evals = MLX.argMax(vlg[0, 0 ..< (D + 1)], axis: -1).asArray(Int32.self).map { Int($0) }
+            var p = 0
+            while p < D && drafts[p] == evals[p] { p += 1 }
+            out.append(u); hist.append(u)
+            for i in 0 ..< p { out.append(drafts[i]); hist.append(drafts[i]) }
+            accTok += p
+            if p == D {                              // full accept: state already advanced D+1
+                uArr = MLXArray([Int32(evals[D])], [1, 1])
+                MLX.eval([uArr] + mc.flatMap { $0.stateArrays })
+            } else {                                 // partial: restore + re-run buddy prefix to sync state
+                for (i, c) in mc.enumerated() { c.restore(snaps[i], isLinear: isLin[i], trim: D + 1) }
+                let acc = [u] + Array(drafts.prefix(p))
+                _ = try model.forwardHidden(MLXArray(acc.map { Int32($0) }, [1, acc.count]), caches: mc)
+                uArr = MLXArray([Int32(evals[p])], [1, 1])
+                MLX.eval([uArr] + mc.flatMap { $0.stateArrays })
+            }
+        }
+        let secs = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1e9
+        let outN = Array(out.prefix(N))
+        let matchPy = zip(outN, gR).filter { $0 == $1 }.count
+        // Headline near-lossless metric = vs strict-4bit f32-full greedy (Swift-greedy).
+        let headline: String
+        if gSwift.isEmpty {
+            headline = String(format: "品質(vs Python) %d/%d=%.0f%% [set QWISP_SWIFT_REF=1 for canonical]",
+                              matchPy, N, Double(matchPy) / Double(N) * 100)
+        } else {
+            let m = zip(outN, gSwift).filter { $0 == $1 }.count
+            headline = String(format: "★near-lossless(vs strict-4bit greedy) %d/%d=%.1f%%  (vs Python %d/%d)",
+                              m, N, Double(m) / Double(N) * 100, matchPy, N)
+        }
+        if Tell.envFlag("QWISP_DUMP_TOKENS") {
+            print("PROMPT_TOKENS:" + ids.asArray(Int32.self).map { String($0) }.joined(separator: ","))
+            print("BOLT_TOKENS:" + outN.map { String($0) }.joined(separator: ","))
+            if !gSwift.isEmpty { print("STRICT_TOKENS:" + gSwift.map { String($0) }.joined(separator: ",")) }
+        }
+        return String(format: """
+            [Bolt L3] buddy no-sync draft(maxK=%d)+buddy verify(C=%d, skipMode=3): %.1f tok/s  \
+            accept/step=%.2f  spec-steps=%d/%d  %@
+            """, maxK, C, Double(N) / secs, Double(accTok) / Double(Swift.max(1, draftSteps)), draftSteps, steps, headline)
+    }
+}

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -70,6 +70,7 @@ if CommandLine.arguments.contains("stream") {
         ("predictor-recall",      { try Tell.measurePredictorRecall(modelDir: $0, refPath: $1) }),
         ("mmap-gather",           { try Tell.measureMmapGather(modelDir: $0, refPath: $1) }),
         ("mlx-fidelity",          { try Tell.measureMLXFidelity(modelDir: $0, refPath: $1) }),
+        ("bolt",                  { try Tell.runBolt(modelDir: $0, refPath: $1) }),
     ]
     if let name = env["QWISP_RUN"] {
         if let r = runners.first(where: { $0.0 == name }) {
@@ -80,9 +81,15 @@ if CommandLine.arguments.contains("stream") {
         exit(0)
     }
 
-    // 既定: 標準手法 SuffixSpec（batched f32-full verify, lossless, Pareto 最適）。
+    // 既定: 標準手法 SuffixSpec（batched f32-full verify, strict-L1, Pareto 最適）。
+    // QWISP_BOLT=1 で opt-in L3 bolt-mode（slow-NAND 向け near-lossless）。unset なら strict のまま。
     // 旧 2 系統(SpecK/Fast)は QWISP_RUN=spec-verify / buddy-no-sync で利用可。
-    do { print(try Tell.runSuffixSpec(modelDir: md, refPath: mtpRef)) } catch { print("[SuffixSpec] error: \(error)") }
+    let boltDefault = env["QWISP_BOLT"] == "1"
+    do {
+        print(try (boltDefault
+            ? Tell.runBolt(modelDir: md, refPath: mtpRef)
+            : Tell.runSuffixSpec(modelDir: md, refPath: mtpRef)))
+    } catch { print("[\(boltDefault ? "Bolt" : "SuffixSpec")] error: \(error)") }
     exit(0)
 }
 


### PR DESCRIPTION
## Summary
Opt-in **bolt-mode** — an L3 near-lossless speed lever for the **slow-NAND (Neo) tier**, plus the SSD-throttle mechanism used to verify it. **strict-L1 stays the untouched default** (`QWISP_BOLT` unset → `runSuffixSpec`).

Mechanism: buddy-substitution (cold experts → co-activation buddy in resident cache → `io=0`) + SuffixSpec, **non-escalate, deterministic**.

## Changes (engine only; no `lean/` research dir)
- `TellBolt.swift` — `Tell.runBolt` (`QWISP_RUN=bolt` / `QWISP_BOLT=1`): exact prefill → hot-pin top-C + buddy table → deterministic buddy decode, f32-full verify.
- `ExpertArena.swift` — buddy branch in the **synced** gather path (buddyTable remap, no `ensure`/pread → `io=0`, deterministic via per-layer barrier). Decouples buddy from the racy no-sync path.
- `main.swift` — additive registry entry + `QWISP_BOLT` gate (strict default unchanged).
- `ExpertSource.swift` — SSD-throttle leaky-bucket (`QWISP_SSD_THROTTLE_GBS`) + accounting (`QWISP_SSD_ACCT`) for slow-NAND emulation. **Default off.**

## Measured (vs strict-4bit greedy; slow-NAND throttle=1.5 GB/s, C=64)
| workload | quality | strict slow-NAND | bolt slow-NAND | speedup |
|---|---|---|---|---|
| mix | 100% | 6.7 tok/s | 151.2 tok/s | **22.5×** |
| nl | coherent-different | 4.2 tok/s | 22.9 tok/s | **5.5×** |
| code | 97.9% | — | — | — |

bolt is throttle-robust (`io=0`); strict is IO-starved on slow-NAND (5–8× slowdown). On fast-SSD bolt is still 1.5–3.5× (ensure/union overhead skip).

Full research/derivation (Lean proofs of lossless limits + near-lossless ceilings, and the full empirical trail) is archived on `archived-experiments/lean-strict-verification`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)