### PR TITLE
fix(server): cancel orphaned decode thread on aborted request

### DIFF
--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -91,7 +91,13 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     public func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncStream<Int> {
         let cfg = SeedlessBackend.config(tier: tier, promptLen: prompt.count, maxTokens: options.maxTokens)
         let promptIds = prompt.map { Int32($0) }
+        let cancel = CancelFlag()
         return AsyncStream { continuation in
+            // Consumer dropped the stream (early stop token / maxTokens / client disconnect)
+            // → cancel the detached decode so it stops at the next spec-step boundary instead
+            // of running to maxTokens on the GPU. Without this the orphaned thread keeps the
+            // (exclusive) GPU busy and the next request's decode overlaps it.
+            continuation.onTermination = { _ in cancel.cancel() }
             // The decode loop is synchronous + GPU-bound. Run it off the caller's task and
             // yield each accepted token as it lands (true incremental streaming). The spec
             // backend is built INSIDE the thread so no non-Sendable state is captured;
@@ -105,11 +111,21 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                     : Tell.fusedBackend(engine: self.engine, maxM: cfg.maxM, maxSeqLen: cfg.maxSeqLen)
                 guard let sb = specBackend else { continuation.finish(); return }
                 _ = Tell.runSpecLoop(promptIds: promptIds, backend: sb, engine: self.engine,
-                                     N: options.maxTokens, maxK: cfg.maxK) { tok in
+                                     N: options.maxTokens, maxK: cfg.maxK,
+                                     isCancelled: { cancel.isCancelled }) { tok in
                     continuation.yield(tok)
                 }
                 continuation.finish()
             }
         }
     }
+}
+
+/// Thread-safe one-shot cancellation flag: set from the AsyncStream consumer side
+/// (onTermination), polled from the detached decode thread. NSLock keeps it boring.
+final class CancelFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var flag = false
+    var isCancelled: Bool { lock.lock(); defer { lock.unlock() }; return flag }
+    func cancel() { lock.lock(); flag = true; lock.unlock() }
 }

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -290,6 +290,7 @@ extension Tell {
     /// Returns out[0..<N] token ids.
     static func runSpecLoop(promptIds: [Int32], backend: SpecBackend, engine: SeedlessEngine,
                              N: Int, maxK: Int, useA3: Bool = false,
+                             isCancelled: (() -> Bool)? = nil,
                              onToken: ((Int) -> Void)? = nil) -> [Int]? {
         guard let lastNormed = prefill(promptIds: promptIds, backend: backend) else { return nil }
         guard let lg0 = engine.logits(lastNormed, M: 1) else { return nil }
@@ -304,7 +305,11 @@ extension Tell {
         var streamed = 0
         func flush() { if let onToken { while streamed < out.count { onToken(out[streamed]); streamed += 1 } } }
 
-        while out.count < N {
+        // isCancelled nil → `?? false` → loop condition byte-identical (RAWTESTS 79/79).
+        // Set by the streaming backend when the consumer drops the stream, so an
+        // aborted request stops at the next spec-step boundary instead of running
+        // to N and orphaning the GPU (see SeedlessBackend.generate).
+        while out.count < N && !(isCancelled?() ?? false) {
             flush()
             let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: 4)
             let D      = drafts.count


### PR DESCRIPTION
Closes #14

## Problem
`qwisp serve` gets progressively "too heavy" under an agentic client (opencode). `SeedlessBackend.generate` runs decode on a detached thread with no cancellation; the `AsyncStream`'s default *unbounded* buffer means `yield` never blocks, so an early consumer break (stop token / maxTokens / client disconnect in `Server.swift streamSSE`) leaves the thread running `runSpecLoop` to full `maxTokens` on the **exclusive GPU**. The server `lock` releases when `streamSSE` returns — not when the thread ends — so the next request starts a *second* overlapping decode. Orphans accumulate → GPU thrash.

## Fix
- `TellRuntime.swift`: add `isCancelled: (() -> Bool)? = nil` to `runSpecLoop`; loop condition becomes `while out.count < N && !(isCancelled?() ?? false)`. Nil → `?? false` → **byte-identical** to before (same seam contract as the existing `onToken` hook; frozen decode logic untouched).
- `LLMBackend.swift`: set a thread-safe `CancelFlag` from `AsyncStream.onTermination` and poll it via `isCancelled`. Aborted requests now stop at the next spec-step boundary and free the GPU.

## Verification
- ✅ RAWTESTS **79/79** (nil path unchanged — lossless safety net intact)
- ✅ `xcodebuild` `qwisp` + `qwisp-poc` Release: **BUILD SUCCEEDED**
- Not covered: live GPU behavioral test (early-disconnect halts decode / no cross-request overlap) — needs the ~20GB resident model started. Logic is standard AsyncStream `onTermination` (`.cancelled` fires when the consumer drops the iterator).

## Out of scope
The by-design resident tier (64GB → full ~20GB model resident + GPU-exclusive decode) is expected, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)