### PR TITLE
feat(cli): --max-tokens flag for `qwisp chat` (replaces QWISP_GEN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ export QWISP_MODEL=/path/to/Qwen3.6-35B-A3B-MTPLX-…    # the model directory
 # OpenAI-compatible server (QWISP_PORT, default 8080)
 "$BIN" serve
 
-# CLI (in-process, streams to stdout)
+# CLI (in-process, streams to stdout; --max-tokens caps generation, default 512)
 "$BIN" chat "Explain MoE routing in two sentences."
+"$BIN" chat --max-tokens 256 "Explain MoE routing in two sentences."
 ```
 
 Talk to the server with any OpenAI client:

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -28,10 +28,25 @@ case "serve":
     let engine = QwispEngine(tokenizer: tok, backend: backend, modelID: modelID)
     try await runServe(engine: engine, modelID: modelID, port: port)
 case "chat":
-    let promptText = args.dropFirst().joined(separator: " ")
+    // `--max-tokens N` | `--max-tokens=N` (matches mlx-lm); the rest of the args are the prompt.
+    var rest = Array(args.dropFirst())
+    var maxTokens = 512
+    if let i = rest.firstIndex(where: { $0 == "--max-tokens" || $0.hasPrefix("--max-tokens=") }) {
+        let flag = rest[i]
+        if let eq = flag.firstIndex(of: "=") {
+            maxTokens = Int(flag[flag.index(after: eq)...]) ?? maxTokens
+            rest.remove(at: i)
+        } else if i + 1 < rest.count, let v = Int(rest[i + 1]) {
+            maxTokens = v
+            rest.removeSubrange(i...(i + 1))
+        } else {
+            rest.remove(at: i)   // dangling flag → ignore, fall back to default
+        }
+    }
+    let promptText = rest.joined(separator: " ")
     let prompt = promptText.isEmpty ? (readLine(strippingNewline: true) ?? "") : promptText
     if prompt.isEmpty {
-        print("usage: qwisp chat <prompt>   (or pipe text via stdin)")
+        print("usage: qwisp chat [--max-tokens N] <prompt>   (or pipe text via stdin)")
     } else {
         let tok = try await QwispTokenizer(modelDir: model)
         let backend: any LLMBackend
@@ -40,7 +55,6 @@ case "chat":
         } else {
             backend = try SeedlessBackend(modelDir: model)
         }
-        let maxTokens = Int(ProcessInfo.processInfo.environment["QWISP_GEN"] ?? "512") ?? 512
         await runChat(prompt: prompt, tokenizer: tok, backend: backend, maxTokens: maxTokens)
     }
 case "selftest":


### PR DESCRIPTION
Makes max generation length a CLI flag — the conventional mechanism (mlx-lm `--max-tokens`, llama.cpp `-n`) — instead of the non-standard `QWISP_GEN` env var. (Env vars in mainstream runtimes configure infra, not per-generation length.)

## Change
- `qwisp chat` parses `--max-tokens N` and `--max-tokens=N` (position-independent; stripped from the prompt args). Default stays **512**.
- Drops `QWISP_GEN` (only referenced in `main.swift`; not documented in README).
- README chat example gains a `--max-tokens 256` line.
- Server path untouched — it already uses the OpenAI `max_tokens` request field.

## Verification (GPU-free, fake backend)
| invocation | output (fake script) |
|---|---|
| `chat "hi"` | full script |
| `chat --max-tokens 3 "hi"` | capped at 3 |
| `chat --max-tokens=5 "hi"` | capped at 5 |
| `chat "hi there" --max-tokens 2` | flag parsed out, capped at 2 |
| `chat` (no prompt) | usage: `qwisp chat [--max-tokens N] <prompt>` |

Engine untouched → RAWTESTS unaffected. `xcodebuild` qwisp: **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)