### PR TITLE
feat(server): default to EOS/context generation with on-demand KV growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ export QWISP_MODEL=/path/to/Qwen3.6-35B-A3B-MTPLX-…    # the model directory
 # OpenAI-compatible server (QWISP_PORT, default 8080)
 "$BIN" serve
 
-# CLI (in-process, streams to stdout; --max-tokens caps generation, default 512)
+# CLI (in-process, streams to stdout). By default it generates until EOS / context;
+# --max-tokens N caps the length (like mlx-lm; -1 = unlimited, the default).
 "$BIN" chat "Explain MoE routing in two sentences."
 "$BIN" chat --max-tokens 256 "Explain MoE routing in two sentences."
 ```
@@ -54,7 +55,7 @@ curl -N http://127.0.0.1:8080/v1/chat/completions \
 | Endpoint | Notes |
 |---|---|
 | `GET /v1/models` | Lists the loaded model (id = model folder name). |
-| `POST /v1/chat/completions` | `stream:true` → SSE (`chat.completion.chunk`); otherwise a `chat.completion` JSON with `usage`. |
+| `POST /v1/chat/completions` | `stream:true` → SSE (`chat.completion.chunk`); otherwise a `chat.completion` JSON with `usage`. Omit `max_tokens` (or send a negative value) to generate until EOS / context; the KV arena grows on demand from an 8K baseline. |
 
 **Sampling is ignored — the engine is lossless greedy.** `temperature` / `top_p` / `n` are
 accepted but have no effect (output is deterministic). When any are supplied, the response carries

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -73,10 +73,22 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     let engine: SeedlessEngine
     let modelDir: String
     let tier: SeedlessTier
+    let contextLen: Int      // model context window (max_position_embeddings); caps unbounded generation.
+
+    /// Read `text_config.max_position_embeddings` from the checkpoint's config.json.
+    /// Falls back to 32768 if absent — a sane bound that still lets any real chat reach EOS.
+    static func readContextLen(_ modelDir: String) -> Int {
+        let url = URL(fileURLWithPath: modelDir).appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: url),
+              let top = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return 32768 }
+        let tc = (top["text_config"] as? [String: Any]) ?? top
+        return (tc["max_position_embeddings"] as? Int) ?? 32768
+    }
 
     public init(modelDir: String, tier: SeedlessTier = .auto) throws {
         self.modelDir = modelDir
         self.tier = tier
+        self.contextLen = SeedlessBackend.readContextLen(modelDir)
         let store = try WeightStore(modelDir: modelDir)
         // residency by tier (mirrors run(): streaming keeps only non-experts resident).
         if SeedlessBackend.config(tier: tier, promptLen: 0, maxTokens: 0).isStreaming {
@@ -89,31 +101,54 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     }
 
     public func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncStream<Int> {
-        let cfg = SeedlessBackend.config(tier: tier, promptLen: prompt.count, maxTokens: options.maxTokens)
-        let promptIds = prompt.map { Int32($0) }
+        // c / maxK / maxM / isStreaming are prompt-length independent; only maxSeqLen (per
+        // segment, below) tracks the growing sequence. Resolve those once.
+        let cfg = SeedlessBackend.config(tier: tier, promptLen: 0, maxTokens: 0)
+        let promptIds0 = prompt.map { Int32($0) }
+        // Hard ceiling on GENERATED tokens: <0 (unset / `--max-tokens -1`) → fill to the model
+        // context; else the caller's cap. Both clamped to the context headroom.
+        let headroom = Swift.max(0, contextLen - prompt.count)
+        let ceiling = options.maxTokens < 0 ? headroom : Swift.min(options.maxTokens, headroom)
+        // First KV arena budget; grows geometrically to `ceiling` only if generation needs it.
+        let baseline = Swift.max(1, Tell.envInt("QWISP_CTX_BASELINE", 8192))
         let cancel = CancelFlag()
         return AsyncStream { continuation in
-            // Consumer dropped the stream (early stop token / maxTokens / client disconnect)
-            // → cancel the detached decode so it stops at the next spec-step boundary instead
-            // of running to maxTokens on the GPU. Without this the orphaned thread keeps the
-            // (exclusive) GPU busy and the next request's decode overlaps it.
+            // Consumer dropped the stream (EOS at the consumer / client disconnect) → cancel the
+            // detached decode so it stops at the next spec-step boundary instead of running to the
+            // ceiling on the (exclusive) GPU and overlapping the next request's decode.
             continuation.onTermination = { _ in cancel.cancel() }
-            // The decode loop is synchronous + GPU-bound. Run it off the caller's task and
-            // yield each accepted token as it lands (true incremental streaming). The spec
-            // backend is built INSIDE the thread so no non-Sendable state is captured;
-            // generation is serialized upstream (server AsyncLock) so touching engine is safe.
-            // ponytail: the spec backend is rebuilt per request — fine for a single-user
-            // server; make it a persistent per-instance backend if throughput matters.
+            // Decode is synchronous + GPU-bound → run off the caller's task, yielding each token as
+            // it lands. The spec backend is built INSIDE the thread so no non-Sendable state is
+            // captured; generation is serialized upstream (server AsyncLock).
+            //
+            // Segmented growth: start with an 8K-token KV arena and only enlarge it (rebuild +
+            // re-prefill prompt+generated-so-far) if a segment fills without stopping. The common
+            // case (answer < 8K, ends at EOS) never grows and pays nothing. ponytail: re-prefill on
+            // grow costs ~2× prefill on the tail; growing the KV buffer in place would need engine
+            // changes (frozen forward path). The spec backend is also rebuilt per segment — fine for
+            // a single-user server; a persistent per-instance backend is the throughput lever.
             Thread.detachNewThread {
-                let specBackend: Tell.SpecBackend? = cfg.isStreaming
-                    ? Tell.streamingBackend(engine: self.engine, modelDir: self.modelDir,
-                                            maxM: cfg.maxM, maxSeqLen: cfg.maxSeqLen, C: cfg.c).map { $0.0 }
-                    : Tell.fusedBackend(engine: self.engine, maxM: cfg.maxM, maxSeqLen: cfg.maxSeqLen)
-                guard let sb = specBackend else { continuation.finish(); return }
-                _ = Tell.runSpecLoop(promptIds: promptIds, backend: sb, engine: self.engine,
-                                     N: options.maxTokens, maxK: cfg.maxK,
-                                     isCancelled: { cancel.isCancelled }) { tok in
-                    continuation.yield(tok)
+                var seq = promptIds0          // prompt + all accepted tokens so far
+                var produced = 0
+                var budget = Swift.min(baseline, Swift.max(1, ceiling))
+                while produced < ceiling && !cancel.isCancelled {
+                    let segN = Swift.min(budget, ceiling - produced)
+                    let maxSeqLen = seq.count + segN + cfg.maxK + 64
+                    let sb: Tell.SpecBackend? = cfg.isStreaming
+                        ? Tell.streamingBackend(engine: self.engine, modelDir: self.modelDir,
+                                                maxM: cfg.maxM, maxSeqLen: maxSeqLen, C: cfg.c).map { $0.0 }
+                        : Tell.fusedBackend(engine: self.engine, maxM: cfg.maxM, maxSeqLen: maxSeqLen)
+                    guard let backend = sb else { break }
+                    let seg = Tell.runSpecLoop(promptIds: seq, backend: backend, engine: self.engine,
+                                               N: segN, maxK: cfg.maxK,
+                                               isCancelled: { cancel.isCancelled }) { tok in
+                        continuation.yield(tok)
+                    }
+                    guard let seg, !seg.isEmpty else { break }
+                    seq += seg.map { Int32($0) }
+                    produced += seg.count
+                    if seg.count < segN { break }   // stopped early (consumer cancel / EOS) → done
+                    budget = Swift.min(budget * 2, 65536)
                 }
                 continuation.finish()
             }

--- a/swift/Sources/qwisp/ChatCompletion.swift
+++ b/swift/Sources/qwisp/ChatCompletion.swift
@@ -84,7 +84,7 @@ func runGeneration(promptIds: [Int], maxTokens: Int, stopIds: [Int],
         let delta = full.hasPrefix(emitted) ? String(full[emitted.endIndex...]) : full
         emitted = full
         if !delta.isEmpty { onDelta(delta) }
-        if outIds.count >= maxTokens { finish = "length"; break }
+        if maxTokens >= 0 && outIds.count >= maxTokens { finish = "length"; break }  // <0 = until EOS/context
     }
     return CompletionResult(text: emitted, completionTokens: outIds.count, finishReason: finish)
 }

--- a/swift/Sources/qwisp/Selftest.swift
+++ b/swift/Sources/qwisp/Selftest.swift
@@ -13,7 +13,7 @@ final class FakeBackend: LLMBackend {
             var n = 0
             for id in script {
                 if options.stopTokens.contains(id) { break }
-                if n >= options.maxTokens { break }
+                if options.maxTokens >= 0 && n >= options.maxTokens { break }  // <0 = until EOS/context
                 cont.yield(id); n += 1
             }
             cont.finish()

--- a/swift/Sources/qwisp/Server.swift
+++ b/swift/Sources/qwisp/Server.swift
@@ -57,7 +57,7 @@ final class QwispEngine: @unchecked Sendable {
     private func prompt(_ req: ChatCompletionRequest) throws -> (ids: [Int], maxTokens: Int, stop: [Int]) {
         let msgs = req.messages.map { ["role": $0.role, "content": $0.content] }
         let ids = try tokenizer.render(messages: msgs)
-        return (ids, req.max_tokens ?? 512, tokenizer.stopTokenIds)
+        return (ids, req.max_tokens ?? -1, tokenizer.stopTokenIds)   // omitted → until EOS/context
     }
 
     /// Non-streaming completion.
@@ -103,7 +103,7 @@ final class QwispEngine: @unchecked Sendable {
             let d = full.hasPrefix(emitted) ? String(full[emitted.endIndex...]) : full
             emitted = full
             if !d.isEmpty { try await send(Delta(role: nil, content: d), nil) }
-            if outIds.count >= p.maxTokens { finish = "length"; break }
+            if p.maxTokens >= 0 && outIds.count >= p.maxTokens { finish = "length"; break }  // <0 = until EOS/context
         }
         try await send(Delta(role: nil, content: nil), finish)
         try await writer.write(ByteBuffer(string: "data: [DONE]\n\n"))

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -29,8 +29,9 @@ case "serve":
     try await runServe(engine: engine, modelID: modelID, port: port)
 case "chat":
     // `--max-tokens N` | `--max-tokens=N` (matches mlx-lm); the rest of the args are the prompt.
+    // Default -1 = generate until EOS / context (mlx-lm / llama.cpp semantics); N caps it.
     var rest = Array(args.dropFirst())
-    var maxTokens = 512
+    var maxTokens = -1
     if let i = rest.firstIndex(where: { $0 == "--max-tokens" || $0.hasPrefix("--max-tokens=") }) {
         let flag = rest[i]
         if let eq = flag.firstIndex(of: "=") {


### PR DESCRIPTION
Stacked on #16 (the `--max-tokens` flag) — base will retarget to `main` once #16 merges. Review just the top commit here.

## What
Makes the **default** (no `--max-tokens`; negative value; or omitted `max_tokens` on the API) generate **until EOS or the model context**, instead of a fixed 512-token cap. Matches mlx-lm / llama.cpp `-1` and OpenAI's "omit `max_tokens`" semantics.

## How — segmented KV growth (no upfront giant allocation)
The engine preallocates its KV arena to a concrete `maxSeqLen` (persistent-buffer design), so "unbounded" can't just size to the full 262144 context — that's a 5-10 GB KV allocation **per request**. Instead `SeedlessBackend.generate` grows on demand:

- Start with an **8K-token** KV arena.
- If a segment fills without stopping (no EOS → no consumer-cancel), rebuild a larger arena and **re-prefill** `prompt + generated-so-far`, then continue. Budget doubles geometrically up to the context ceiling.
- Common case (answer < 8K, ends at EOS) **never grows** and pays nothing. `QWISP_CTX_BASELINE` overrides the 8K baseline.
- Frozen forward path untouched — reuses `runSpecLoop` + `makeFused`. (`ponytail`: re-prefill on grow costs ~2× prefill on the tail; in-place KV grow would need engine changes.)

## Files
- `LLMBackend.swift`: read `max_position_embeddings` from config.json; resolve ceiling (`<0` → context headroom); segmented-growth decode loop.
- `Server.swift` / `ChatCompletion.swift` / `Selftest.swift` (FakeBackend): treat `maxTokens < 0` as no consumer cap.
- `main.swift`: `qwisp chat` default `-1`; server `max_tokens ?? -1`.
- `README.md`: documents the new default.

## Verification
- **Growth is lossless**: `--max-tokens 40` with `QWISP_CTX_BASELINE=16` (3 segments, forced re-prefill) is **byte-identical** to a single-segment run. Re-prefill reproduces the exact greedy stream.
- **Default stops at EOS end-to-end**: default `chat` returns a complete answer in ~5 s (EOS), does not run to context, does not hang.
- **GPU-free sentinel**: default `-1` emits the full fake script; `--max-tokens 3` caps at 3.
- Gates: **COMPTEST 4/4**, **RAWTESTS 79/79**, **BENCHBATCHTEST PASS**. `xcodebuild` qwisp + qwisp-poc: BUILD SUCCEEDED.

## Note
Omitting `max_tokens` on the server now generates until EOS/context (was 512). More OpenAI-faithful; local single-user server. `--max-tokens N` / `max_tokens: N` still caps exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)