### PR TITLE
feat(sampling): speculative sampling (temperature/top_p/penalties/logit_bias) on GPU

### DIFF
--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -133,10 +133,24 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                 // QWISP_FORCE_SAMPLE=1 forces the sampling loop even at temperature 0, so the
                 // T=0-equivalence gate can exercise runSpecSampleLoop against greedy.
                 let forceSample = Tell.envFlag("QWISP_FORCE_SAMPLE")
-                if options.sampling || forceSample {
-                    // Option B: speculative sampling. maxK capped (per-position logits readback is
-                    // the prototype cost; a GPU sampler kernel would lift the cap). Greedy path
-                    // (below) is untouched.
+                let wantSample = options.sampling || forceSample
+                // GPU sampler is eligible only for the temperature-only shape (no top_p / penalties /
+                // logit_bias, which still use the optimized CPU loop). QWISP_SAMPLE_CPU forces CPU.
+                let gpuEligible = wantSample && options.topP >= 1.0
+                    && options.frequencyPenalty == 0 && options.presencePenalty == 0 && options.logitBias.isEmpty
+                    && sb.stepSampleRows != nil && !Tell.envFlag("QWISP_SAMPLE_CPU")
+                if gpuEligible {
+                    // Option B "本速度化": softmax + categorical + accept on the GPU, tiny readback,
+                    // maxK uncapped. T=0 degenerates to argmax → byte-identical to greedy.
+                    _ = Tell.runSpecSampleLoopGPU(promptIds: promptIds, backend: sb, engine: self.engine,
+                                                  N: options.maxTokens, maxK: cfg.maxK,
+                                                  temperature: options.temperature, seed: options.seed,
+                                                  isCancelled: { cancel.isCancelled }) { tok in
+                        continuation.yield(tok)
+                    }
+                } else if wantSample {
+                    // CPU speculative sampling: handles top_p / penalties / logit_bias (per-position
+                    // logits readback → maxK capped at 8). Greedy path (below) is untouched.
                     _ = Tell.runSpecSampleLoop(promptIds: promptIds, backend: sb, engine: self.engine,
                                                N: options.maxTokens, maxK: Swift.min(cfg.maxK, 8),
                                                temperature: options.temperature, topP: options.topP,

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -134,23 +134,25 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                 // T=0-equivalence gate can exercise runSpecSampleLoop against greedy.
                 let forceSample = Tell.envFlag("QWISP_FORCE_SAMPLE")
                 let wantSample = options.sampling || forceSample
-                // GPU sampler is eligible only for the temperature-only shape (no top_p / penalties /
-                // logit_bias, which still use the optimized CPU loop). QWISP_SAMPLE_CPU forces CPU.
-                let gpuEligible = wantSample && options.topP >= 1.0
-                    && options.frequencyPenalty == 0 && options.presencePenalty == 0 && options.logitBias.isEmpty
-                    && sb.stepSampleRows != nil && !Tell.envFlag("QWISP_SAMPLE_CPU")
+                // GPU sampler now handles the full shape (temperature + top_p + penalties + logit_bias),
+                // all on-GPU with tiny readback + uncapped maxK. QWISP_SAMPLE_CPU forces the CPU loop.
+                let gpuEligible = wantSample && sb.stepSampleRows != nil && !Tell.envFlag("QWISP_SAMPLE_CPU")
                 if gpuEligible {
-                    // Option B "本速度化": softmax + categorical + accept on the GPU, tiny readback,
-                    // maxK uncapped. T=0 degenerates to argmax → byte-identical to greedy.
+                    // Option B "本速度化": softmax + top_p nucleus + penalties/bias + categorical +
+                    // accept on the GPU. T=0 degenerates to argmax → byte-identical to greedy.
                     _ = Tell.runSpecSampleLoopGPU(promptIds: promptIds, backend: sb, engine: self.engine,
                                                   N: options.maxTokens, maxK: cfg.maxK,
-                                                  temperature: options.temperature, seed: options.seed,
+                                                  temperature: options.temperature, topP: options.topP,
+                                                  seed: options.seed,
+                                                  frequencyPenalty: options.frequencyPenalty,
+                                                  presencePenalty: options.presencePenalty,
+                                                  logitBias: options.logitBias,
                                                   isCancelled: { cancel.isCancelled }) { tok in
                         continuation.yield(tok)
                     }
                 } else if wantSample {
-                    // CPU speculative sampling: handles top_p / penalties / logit_bias (per-position
-                    // logits readback → maxK capped at 8). Greedy path (below) is untouched.
+                    // CPU speculative sampling fallback (QWISP_SAMPLE_CPU / no head): per-position
+                    // logits readback → maxK capped at 8. Greedy path (below) is untouched.
                     _ = Tell.runSpecSampleLoop(promptIds: promptIds, backend: sb, engine: self.engine,
                                                N: options.maxTokens, maxK: Swift.min(cfg.maxK, 8),
                                                temperature: options.temperature, topP: options.topP,

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -140,8 +140,11 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                 if gpuEligible {
                     // Option B "本速度化": softmax + top_p nucleus + penalties/bias + categorical +
                     // accept on the GPU. T=0 degenerates to argmax → byte-identical to greedy.
+                    // top_p lowers acceptance → a narrower draft cuts both the forward (M rows) and
+                    // the per-row bisection with little accept-rate loss; temperature-only keeps 96.
+                    let sampMaxK = options.topP < 1.0 ? Swift.min(cfg.maxK, 24) : cfg.maxK
                     _ = Tell.runSpecSampleLoopGPU(promptIds: promptIds, backend: sb, engine: self.engine,
-                                                  N: options.maxTokens, maxK: cfg.maxK,
+                                                  N: options.maxTokens, maxK: sampMaxK,
                                                   temperature: options.temperature, topP: options.topP,
                                                   seed: options.seed,
                                                   frequencyPenalty: options.frequencyPenalty,

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -23,9 +23,19 @@ public struct GenerateOptions {
     /// Token ids that halt decoding (EOS / chat turn-end). Empty = run to maxTokens.
     /// A stop token is NOT emitted; the runtime stops before yielding it.
     public var stopTokens: [Int]
-    public init(maxTokens: Int = 128, stopTokens: [Int] = []) {
+    /// Sampling (Option B prototype). temperature 0 → greedy/lossless (default); >0 → sample.
+    /// topP < 1 → nucleus truncation. `sampling` is true when any of these shape the distribution.
+    public var temperature: Double
+    public var topP: Double
+    public var seed: UInt64
+    public var sampling: Bool { temperature > 0 || topP < 1.0 }
+    public init(maxTokens: Int = 128, stopTokens: [Int] = [],
+                temperature: Double = 0, topP: Double = 1.0, seed: UInt64 = 0) {
         self.maxTokens = maxTokens
         self.stopTokens = stopTokens
+        self.temperature = temperature
+        self.topP = topP
+        self.seed = seed
     }
 }
 
@@ -110,10 +120,26 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                                             maxM: cfg.maxM, maxSeqLen: cfg.maxSeqLen, C: cfg.c).map { $0.0 }
                     : Tell.fusedBackend(engine: self.engine, maxM: cfg.maxM, maxSeqLen: cfg.maxSeqLen)
                 guard let sb = specBackend else { continuation.finish(); return }
-                _ = Tell.runSpecLoop(promptIds: promptIds, backend: sb, engine: self.engine,
-                                     N: options.maxTokens, maxK: cfg.maxK,
-                                     isCancelled: { cancel.isCancelled }) { tok in
-                    continuation.yield(tok)
+                // QWISP_FORCE_SAMPLE=1 forces the sampling loop even at temperature 0, so the
+                // T=0-equivalence gate can exercise runSpecSampleLoop against greedy.
+                let forceSample = Tell.envFlag("QWISP_FORCE_SAMPLE")
+                if options.sampling || forceSample {
+                    // Option B: speculative sampling. maxK capped (per-position logits readback is
+                    // the prototype cost; a GPU sampler kernel would lift the cap). Greedy path
+                    // (below) is untouched.
+                    _ = Tell.runSpecSampleLoop(promptIds: promptIds, backend: sb, engine: self.engine,
+                                               N: options.maxTokens, maxK: Swift.min(cfg.maxK, 8),
+                                               temperature: options.temperature, topP: options.topP,
+                                               seed: options.seed,
+                                               isCancelled: { cancel.isCancelled }) { tok in
+                        continuation.yield(tok)
+                    }
+                } else {
+                    _ = Tell.runSpecLoop(promptIds: promptIds, backend: sb, engine: self.engine,
+                                         N: options.maxTokens, maxK: cfg.maxK,
+                                         isCancelled: { cancel.isCancelled }) { tok in
+                        continuation.yield(tok)
+                    }
                 }
                 continuation.finish()
             }

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -24,18 +24,28 @@ public struct GenerateOptions {
     /// A stop token is NOT emitted; the runtime stops before yielding it.
     public var stopTokens: [Int]
     /// Sampling (Option B prototype). temperature 0 → greedy/lossless (default); >0 → sample.
-    /// topP < 1 → nucleus truncation. `sampling` is true when any of these shape the distribution.
+    /// topP < 1 → nucleus truncation. Penalties + logitBias reshape the logits before sampling.
+    /// `sampling` is true when any of these shape the distribution (so it leaves the greedy path).
     public var temperature: Double
     public var topP: Double
     public var seed: UInt64
-    public var sampling: Bool { temperature > 0 || topP < 1.0 }
+    public var frequencyPenalty: Double
+    public var presencePenalty: Double
+    public var logitBias: [Int: Double]
+    public var sampling: Bool {
+        temperature > 0 || topP < 1.0 || frequencyPenalty != 0 || presencePenalty != 0 || !logitBias.isEmpty
+    }
     public init(maxTokens: Int = 128, stopTokens: [Int] = [],
-                temperature: Double = 0, topP: Double = 1.0, seed: UInt64 = 0) {
+                temperature: Double = 0, topP: Double = 1.0, seed: UInt64 = 0,
+                frequencyPenalty: Double = 0, presencePenalty: Double = 0, logitBias: [Int: Double] = [:]) {
         self.maxTokens = maxTokens
         self.stopTokens = stopTokens
         self.temperature = temperature
         self.topP = topP
         self.seed = seed
+        self.frequencyPenalty = frequencyPenalty
+        self.presencePenalty = presencePenalty
+        self.logitBias = logitBias
     }
 }
 
@@ -131,6 +141,9 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                                                N: options.maxTokens, maxK: Swift.min(cfg.maxK, 8),
                                                temperature: options.temperature, topP: options.topP,
                                                seed: options.seed,
+                                               frequencyPenalty: options.frequencyPenalty,
+                                               presencePenalty: options.presencePenalty,
+                                               logitBias: options.logitBias,
                                                isCancelled: { cancel.isCancelled }) { tok in
                         continuation.yield(tok)
                     }

--- a/swift/Sources/QwispCore/Sampler.swift
+++ b/swift/Sources/QwispCore/Sampler.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+// Speculative-sampling support (Option B prototype).
+//
+// The greedy path verifies drafts by argmax-equality (lossless at T=0). To sample at T>0
+// while keeping the target distribution EXACT, we use speculative sampling (Leviathan/Chen
+// 2023) with a *deterministic* suffix draft (draft dist q = δ_d, so q(d)=1):
+//   • accept the drafted token d with probability p(d)               [min(1, p(d)/q(d)) = p(d)]
+//   • on reject, resample from the residual  norm(max(0, p − q))  =  p with d zeroed, renormalized
+//   • if the whole draft is accepted, sample a bonus token from p at the next position
+// This reduces EXACTLY to greedy at T=0 (p is one-hot at argmax → accept iff d==argmax), so the
+// T=0 stream is byte-identical to the current engine regardless of seed — the small correctness gate.
+//
+// `p` here is the tempered + top_p-truncated distribution: "sample with temperature/top_p" means
+// the target distribution IS that shaped one, and speculative sampling reproduces it exactly.
+
+/// Deterministic, seedable PRNG (SplitMix64) — reproducible sampling for a given `seed`.
+public struct SplitMix64: RandomNumberGenerator {
+    private var state: UInt64
+    public init(seed: UInt64) { self.state = seed }
+    public mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+    /// Uniform Double in [0, 1).
+    public mutating func unit() -> Double { Double(next() >> 11) * (1.0 / 9_007_199_254_740_992.0) }
+}
+
+public enum Sampler {
+    /// Turn raw logits into the tempered + top_p-truncated probability vector.
+    /// temperature == 0 → one-hot at argmax (greedy limit); tokens outside the top_p nucleus → 0.
+    public static func probs(logits: [Float], temperature: Double, topP: Double) -> [Float] {
+        let n = logits.count
+        var p = [Float](repeating: 0, count: n)
+        if temperature <= 0 {                       // greedy limit: one-hot at argmax
+            var best = 0; var bv = logits[0]
+            for i in 1..<n where logits[i] > bv { bv = logits[i]; best = i }
+            p[best] = 1
+            return p
+        }
+        // softmax(logits / T) in a numerically stable way.
+        let invT = Float(1.0 / temperature)
+        var mx = logits[0]
+        for v in logits where v > mx { mx = v }
+        var sum: Float = 0
+        for i in 0..<n { let e = expf((logits[i] - mx) * invT); p[i] = e; sum += e }
+        let inv = 1 / sum
+        for i in 0..<n { p[i] *= inv }
+        if topP < 1.0 { nucleusTruncate(&p, topP: topP) }
+        return p
+    }
+
+    /// Zero everything outside the smallest set whose cumulative prob ≥ topP, then renormalize.
+    static func nucleusTruncate(_ p: inout [Float], topP: Double) {
+        let order = (0..<p.count).sorted { p[$0] > p[$1] }
+        var cum: Double = 0
+        var keep = Set<Int>()
+        for i in order {
+            keep.insert(i)
+            cum += Double(p[i])
+            if cum >= topP { break }               // include the token that crosses the threshold
+        }
+        var sum: Float = 0
+        for i in 0..<p.count { if !keep.contains(i) { p[i] = 0 } else { sum += p[i] } }
+        if sum > 0 { let inv = 1 / sum; for i in 0..<p.count { p[i] *= inv } }
+    }
+
+    /// Categorical draw from a (already normalized) probability vector.
+    public static func categorical(_ p: [Float], rng: inout SplitMix64) -> Int {
+        let r = Float(rng.unit())
+        var acc: Float = 0
+        for i in 0..<p.count { acc += p[i]; if r < acc { return i } }
+        // Fallback for FP drift: last nonzero.
+        for i in stride(from: p.count - 1, through: 0, by: -1) where p[i] > 0 { return i }
+        return 0
+    }
+
+    /// Speculative-sampling accept for one draft token `d` against target `p`.
+    /// Returns (accepted, resampled): if accepted, `resampled` is nil; else it is the residual draw.
+    public static func acceptOrResample(p: [Float], draft d: Int, rng: inout SplitMix64) -> (Bool, Int?) {
+        let coin = Float(rng.unit())
+        if coin < p[d] { return (true, nil) }       // accept with prob p(d)
+        var resid = p
+        resid[d] = 0                                 // residual = max(0, p − δ_d), renormalized
+        var sum: Float = 0
+        for v in resid { sum += v }
+        if sum > 0 { let inv = 1 / sum; for i in 0..<resid.count { resid[i] *= inv } }
+        return (false, categorical(resid, rng: &rng))
+    }
+
+    /// GPU-free self-check of the sampling math (run via `qwisp sampletest`).
+    public static func selfCheck() -> (passed: Int, total: Int, log: [String]) {
+        var passed = 0, total = 0; var log: [String] = []
+        func ok(_ name: String, _ cond: Bool) {
+            total += 1; if cond { passed += 1 }; log.append("[sample-test] \(name): \(cond ? "PASS" : "FAIL")")
+        }
+        // 1. T=0 → one-hot at argmax.
+        let lg: [Float] = [1.0, 3.0, 2.0, 0.5]
+        let p0 = probs(logits: lg, temperature: 0, topP: 1)
+        ok("temp0_onehot_argmax", p0 == [0, 1, 0, 0])
+
+        // 2. T=0 accept: draft==argmax always accepts; draft≠argmax always rejects → resample=argmax.
+        var r = SplitMix64(seed: 42)
+        let (a1, _) = acceptOrResample(p: p0, draft: 1, rng: &r)
+        let (a2, res2) = acceptOrResample(p: p0, draft: 0, rng: &r)
+        ok("temp0_accept_argmax", a1 == true)
+        ok("temp0_reject_nonargmax_resample_argmax", a2 == false && res2 == 1)
+
+        // 3. softmax normalizes; higher logit → higher prob.
+        let p1 = probs(logits: lg, temperature: 1.0, topP: 1)
+        let s = p1.reduce(0, +)
+        ok("softmax_normalized", abs(s - 1) < 1e-4 && p1[1] > p1[2] && p1[2] > p1[0])
+
+        // 4. top_p truncation keeps only the nucleus (here the top-1 crosses 0.5 for this dist? check top-2).
+        let pT = probs(logits: [10, 9, 0, -5], temperature: 1.0, topP: 0.5)
+        ok("topp_truncates_tail", pT[2] == 0 && pT[3] == 0 && abs(pT.reduce(0,+) - 1) < 1e-4)
+
+        // 5. determinism: same seed → same categorical draws.
+        var ra = SplitMix64(seed: 7), rb = SplitMix64(seed: 7)
+        let da = (0..<20).map { _ in categorical(p1, rng: &ra) }
+        let db = (0..<20).map { _ in categorical(p1, rng: &rb) }
+        ok("seed_reproducible", da == db)
+
+        // 6. mean of many draws approximates p (statistical sanity).
+        var rc = SplitMix64(seed: 123)
+        var counts = [Int](repeating: 0, count: p1.count)
+        let N = 20000
+        for _ in 0..<N { counts[categorical(p1, rng: &rc)] += 1 }
+        let empiricalMode = counts.firstIndex(of: counts.max()!)!
+        let trueMode = p1.firstIndex(of: p1.max()!)!
+        ok("empirical_mode_matches", empiricalMode == trueMode)
+
+        return (passed, total, log)
+    }
+}

--- a/swift/Sources/QwispCore/Sampler.swift
+++ b/swift/Sources/QwispCore/Sampler.swift
@@ -91,6 +91,23 @@ public enum Sampler {
         return (false, categorical(resid, rng: &rng))
     }
 
+    /// Apply OpenAI penalties + logit_bias to raw logits before softmax.
+    /// `counts` maps token id → occurrences so far (only present tokens). frequency_penalty scales
+    /// with count; presence_penalty is applied once per present token; logit_bias is additive.
+    public static func adjustLogits(_ logits: inout [Float], counts: [Int: Int],
+                                    frequencyPenalty: Double = 0, presencePenalty: Double = 0,
+                                    logitBias: [Int: Double] = [:]) {
+        if frequencyPenalty != 0 || presencePenalty != 0 {
+            let fp = Float(frequencyPenalty), pp = Float(presencePenalty)
+            for (tok, c) in counts where tok >= 0 && tok < logits.count {
+                logits[tok] -= fp * Float(c) + pp
+            }
+        }
+        for (tok, b) in logitBias where tok >= 0 && tok < logits.count {
+            logits[tok] += Float(b)
+        }
+    }
+
     /// GPU-free self-check of the sampling math (run via `qwisp sampletest`).
     public static func selfCheck() -> (passed: Int, total: Int, log: [String]) {
         var passed = 0, total = 0; var log: [String] = []
@@ -132,6 +149,18 @@ public enum Sampler {
         let empiricalMode = counts.firstIndex(of: counts.max()!)!
         let trueMode = p1.firstIndex(of: p1.max()!)!
         ok("empirical_mode_matches", empiricalMode == trueMode)
+
+        // 7. logit_bias: -inf-ish bias bans a token; large positive forces it.
+        var lb = [Float]([1, 2, 3, 0])
+        adjustLogits(&lb, counts: [:], frequencyPenalty: 0, presencePenalty: 0, logitBias: [2: -100, 0: 100])
+        ok("logit_bias_applied", lb[2] == -97 && lb[0] == 101)
+        let pBias = probs(logits: lb, temperature: 1.0, topP: 1)
+        ok("logit_bias_shifts_argmax", pBias.firstIndex(of: pBias.max()!) == 0)   // token 0 now dominates
+
+        // 8. frequency/presence penalty lowers a repeated token's logit by count*fp + pp.
+        var lp = [Float]([5, 5, 5, 5])
+        adjustLogits(&lp, counts: [1: 3], frequencyPenalty: 0.5, presencePenalty: 1.0)
+        ok("freq_presence_penalty", abs(lp[1] - (5 - 0.5*3 - 1.0)) < 1e-5 && lp[0] == 5)
 
         return (passed, total, log)
     }

--- a/swift/Sources/QwispCore/Sampler.swift
+++ b/swift/Sources/QwispCore/Sampler.swift
@@ -54,18 +54,27 @@ public enum Sampler {
     }
 
     /// Zero everything outside the smallest set whose cumulative prob ≥ topP, then renormalize.
+    /// Sorting all V indices with a closure comparator is the dominant sampling cost, so sort only
+    /// the non-negligible candidates (a peaked softmax → a few hundred); fall back to the full sort
+    /// only when those don't cover topP (near-uniform dist) so the result stays exact.
     static func nucleusTruncate(_ p: inout [Float], topP: Double) {
-        let order = (0..<p.count).sorted { p[$0] > p[$1] }
+        let pm = p.max() ?? 0
+        let thr = pm * 1e-4                          // tokens below this cannot matter for a peaked dist
+        var cand: [Int] = []; var candMass: Double = 0
+        for i in 0..<p.count where p[i] >= thr { cand.append(i); candMass += Double(p[i]) }
+        let order = candMass >= topP ? cand.sorted { p[$0] > p[$1] }
+                                     : (0..<p.count).sorted { p[$0] > p[$1] }
         var cum: Double = 0
-        var keep = Set<Int>()
+        var kept: [(Int, Float)] = []
         for i in order {
-            keep.insert(i)
+            kept.append((i, p[i]))
             cum += Double(p[i])
-            if cum >= topP { break }               // include the token that crosses the threshold
+            if cum >= topP { break }                 // include the token that crosses the threshold
         }
+        for i in 0..<p.count { p[i] = 0 }            // zero-out then restore the nucleus (no per-elem Set lookup)
         var sum: Float = 0
-        for i in 0..<p.count { if !keep.contains(i) { p[i] = 0 } else { sum += p[i] } }
-        if sum > 0 { let inv = 1 / sum; for i in 0..<p.count { p[i] *= inv } }
+        for (i, v) in kept { p[i] = v; sum += v }
+        if sum > 0 { let inv = 1 / sum; for (i, _) in kept { p[i] *= inv } }
     }
 
     /// Categorical draw from a (already normalized) probability vector.

--- a/swift/Sources/QwispCore/SamplerGPU.swift
+++ b/swift/Sources/QwispCore/SamplerGPU.swift
@@ -1,0 +1,222 @@
+import Foundation
+import Metal
+import MLX
+
+// GPU speculative-sampling kernel (Option B "本速度化"). The greedy path reads back only the
+// argmax index; sampling instead needs a categorical draw + the accept test per verify row.
+// Doing that on the GPU (Gumbel-max — argmax of logit/T + Gumbel noise, no softmax normalization,
+// no sort) keeps the readback tiny (a few ints per row) and lifts the CPU-readback maxK cap.
+//
+// Per row m the kernel returns: full categorical sample, residual sample (excluding the draft
+// token), and the speculative-sampling accept flag (coin < p(draft)). The CPU loop then walks the
+// accept flags to pick the accepted prefix + next token — exactly like the CPU sample loop, but
+// with the per-vocab work on the GPU. At temperature 0 (invT ≤ 0) it degenerates to argmax with
+// the same first-max tie-break as `argmax_rows`, so the T=0 stream stays byte-identical to greedy.
+//
+// v1 scope: temperature only (no penalties/logit_bias/top_p in the kernel — those stay on the
+// optimized CPU path). `useAdj`/`logitAdj` are wired for a future penalties-on-GPU follow-up.
+public enum SamplerGPU {
+    nonisolated(unsafe) static var _pipeline: MTLComputePipelineState?
+
+    static let kernelSrc = """
+    #include <metal_stdlib>
+    using namespace metal;
+
+    inline uint qhash(uint a, uint b, uint c) {
+        uint h = a * 0x9E3779B1u + 0x165667B1u;
+        h ^= b + 0x9E3779B9u + (h << 6) + (h >> 2);
+        h ^= c + 0x9E3779B9u + (h << 6) + (h >> 2);
+        h ^= h >> 15; h *= 0x2C1B3C6Du; h ^= h >> 12; h *= 0x297A2D39u; h ^= h >> 15;
+        return h;
+    }
+    inline float u01(uint h) { return fmax((float)(h >> 8) * (1.0f / 16777216.0f), 1e-7f); }
+
+    // One threadgroup per verify row m; threads stride over the vocab V.
+    kernel void spec_sample_rows(
+        device const half*  logits    [[buffer(0)]],   // [M, V]
+        device const float* logitAdj  [[buffer(1)]],   // [V] penalties+bias (read iff useAdj)
+        device const int*   draftToks [[buffer(2)]],   // [M] draft per row, -1 = none/bonus
+        device int*         sampFull  [[buffer(3)]],   // [M] categorical sample
+        device int*         sampResid [[buffer(4)]],   // [M] categorical excluding draft
+        device int*         acceptOut [[buffer(5)]],   // [M] 1 if draft accepted
+        constant float&     invT      [[buffer(6)]],   // 1/T; <=0 → greedy (argmax)
+        constant uint&      V         [[buffer(7)]],
+        constant uint&      seedLo    [[buffer(8)]],
+        constant uint&      seedHi    [[buffer(9)]],
+        constant uint&      basePos   [[buffer(10)]],
+        constant uint&      useAdj    [[buffer(11)]],
+        uint m   [[threadgroup_position_in_grid]],
+        uint tid [[thread_position_in_threadgroup]],
+        uint tgs [[threads_per_threadgroup]])
+    {
+        threadgroup float rMax[256];
+        threadgroup float rFS[256]; threadgroup int rFI[256];
+        threadgroup float rRS[256]; threadgroup int rRI[256];
+        threadgroup float rZ[256];
+
+        device const half* row = logits + (size_t)m * V;
+        int d = draftToks[m];
+        bool greedy = invT <= 0.0f;
+        uint posSalt = seedHi ^ (basePos + m);
+
+        float locMax = -INFINITY;
+        float locFS = -INFINITY; int locFI = 0x7fffffff;   // Gumbel argmax (full)
+        float locRS = -INFINITY; int locRI = 0x7fffffff;   // Gumbel argmax (excl draft)
+        for (uint v = tid; v < V; v += tgs) {
+            float L = (float)row[v] + (useAdj ? logitAdj[v] : 0.0f);
+            if (L > locMax) locMax = L;
+            float score;
+            if (greedy) { score = L; }
+            else { score = L * invT + (-log(-log(u01(qhash(seedLo, posSalt, v))))); }
+            if (score > locFS || (score == locFS && (int)v < locFI)) { locFS = score; locFI = (int)v; }
+            if ((int)v != d && (score > locRS || (score == locRS && (int)v < locRI))) { locRS = score; locRI = (int)v; }
+        }
+        rMax[tid] = locMax; rFS[tid] = locFS; rFI[tid] = locFI; rRS[tid] = locRS; rRI[tid] = locRI;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint s = tgs / 2; s > 0; s >>= 1) {
+            if (tid < s) {
+                if (rMax[tid+s] > rMax[tid]) rMax[tid] = rMax[tid+s];
+                if (rFS[tid+s] > rFS[tid] || (rFS[tid+s]==rFS[tid] && rFI[tid+s]<rFI[tid])) { rFS[tid]=rFS[tid+s]; rFI[tid]=rFI[tid+s]; }
+                if (rRS[tid+s] > rRS[tid] || (rRS[tid+s]==rRS[tid] && rRI[tid+s]<rRI[tid])) { rRS[tid]=rRS[tid+s]; rRI[tid]=rRI[tid+s]; }
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+        float gmax = rMax[0];
+        int fullIdx = rFI[0], residIdx = rRI[0];
+
+        // pass 2: softmax normalizer Z (only needed for the accept probability at T>0).
+        float locZ = 0.0f;
+        if (!greedy) {
+            for (uint v = tid; v < V; v += tgs) {
+                float L = (float)row[v] + (useAdj ? logitAdj[v] : 0.0f);
+                locZ += exp((L - gmax) * invT);
+            }
+        }
+        rZ[tid] = locZ;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint s = tgs / 2; s > 0; s >>= 1) { if (tid < s) rZ[tid] += rZ[tid+s]; threadgroup_barrier(mem_flags::mem_threadgroup); }
+
+        if (tid == 0) {
+            sampFull[m]  = fullIdx;
+            sampResid[m] = (d < 0) ? fullIdx : residIdx;
+            float pDraft;
+            if (d < 0) pDraft = 0.0f;
+            else if (greedy) pDraft = (d == fullIdx) ? 1.0f : 0.0f;
+            else { float Ld = (float)row[d] + (useAdj ? logitAdj[d] : 0.0f); pDraft = exp((Ld - gmax) * invT) / rZ[0]; }
+            float coin = u01(qhash(seedLo, posSalt, 0x9999AAAAu));
+            acceptOut[m] = (coin < pDraft) ? 1 : 0;
+        }
+    }
+    """
+
+    @discardableResult
+    public static func ensurePipeline(_ device: MTLDevice) -> Bool {
+        if _pipeline != nil { return true }
+        do {
+            let lib = try device.makeLibrary(source: kernelSrc, options: nil)
+            _pipeline = try device.makeComputePipelineState(function: lib.makeFunction(name: "spec_sample_rows")!)
+            return true
+        } catch { return false }
+    }
+
+    /// Standalone dispatch on caller-supplied logits (for the distribution test; not the decode path).
+    /// Returns (full, resid, accept) per row.
+    public static func sampleRows(device: MTLDevice, queue: MTLCommandQueue,
+                                  logits: [[Float]], drafts: [Int], invT: Float,
+                                  seed: UInt64, basePos: Int) -> (full: [Int], resid: [Int], accept: [Bool])? {
+        guard ensurePipeline(device), let pipe = _pipeline, let first = logits.first else { return nil }
+        let M = logits.count, V = first.count
+        var flat = [UInt16](repeating: 0, count: M * V)   // f16
+        for m in 0..<M { for v in 0..<V { flat[m*V + v] = f32to16(logits[m][v]) } }
+        guard let lgBuf = device.makeBuffer(length: M*V*2, options: .storageModeShared),
+              let adjBuf = device.makeBuffer(length: max(1,V)*4, options: .storageModeShared),
+              let dBuf = device.makeBuffer(length: M*4, options: .storageModeShared),
+              let fBuf = device.makeBuffer(length: M*4, options: .storageModeShared),
+              let rBuf = device.makeBuffer(length: M*4, options: .storageModeShared),
+              let aBuf = device.makeBuffer(length: M*4, options: .storageModeShared) else { return nil }
+        flat.withUnsafeBytes { lgBuf.contents().copyMemory(from: $0.baseAddress!, byteCount: M*V*2) }
+        let dp = dBuf.contents().bindMemory(to: Int32.self, capacity: M)
+        for m in 0..<M { dp[m] = Int32(m < drafts.count ? drafts[m] : -1) }
+
+        let cb = queue.makeCommandBuffer()!, enc = cb.makeComputeCommandEncoder()!
+        enc.setComputePipelineState(pipe)
+        enc.setBuffer(lgBuf, offset: 0, index: 0); enc.setBuffer(adjBuf, offset: 0, index: 1)
+        enc.setBuffer(dBuf, offset: 0, index: 2); enc.setBuffer(fBuf, offset: 0, index: 3)
+        enc.setBuffer(rBuf, offset: 0, index: 4); enc.setBuffer(aBuf, offset: 0, index: 5)
+        var it = invT, vv = UInt32(V), sl = UInt32(truncatingIfNeeded: seed), sh = UInt32(truncatingIfNeeded: seed >> 32)
+        var bp = UInt32(basePos), ua = UInt32(0)
+        enc.setBytes(&it, length: 4, index: 6); enc.setBytes(&vv, length: 4, index: 7)
+        enc.setBytes(&sl, length: 4, index: 8); enc.setBytes(&sh, length: 4, index: 9)
+        enc.setBytes(&bp, length: 4, index: 10); enc.setBytes(&ua, length: 4, index: 11)
+        enc.dispatchThreadgroups(MTLSize(width: M, height: 1, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+
+        let fp = fBuf.contents().bindMemory(to: Int32.self, capacity: M)
+        let rp = rBuf.contents().bindMemory(to: Int32.self, capacity: M)
+        let ap = aBuf.contents().bindMemory(to: Int32.self, capacity: M)
+        return ((0..<M).map { Int(fp[$0]) }, (0..<M).map { Int(rp[$0]) }, (0..<M).map { ap[$0] != 0 })
+    }
+
+    // minimal f32→f16 bit conversion (round-to-nearest-even not required for test logits).
+    static func f32to16(_ f: Float) -> UInt16 {
+        let bits = f.bitPattern
+        let sign = UInt16((bits >> 16) & 0x8000)
+        let exp = Int((bits >> 23) & 0xFF) - 127 + 15
+        let mant = bits & 0x7FFFFF
+        if exp <= 0 { return sign }
+        if exp >= 0x1F { return sign | 0x7C00 }
+        return sign | UInt16(exp << 10) | UInt16(mant >> 13)
+    }
+
+    /// Distribution test: sample a fixed synthetic distribution many times on the GPU and compare
+    /// the empirical histogram to the analytic softmax (and to the CPU sampler). PASS on small TV.
+    public static func distributionSelfCheck() -> (passed: Int, total: Int, log: [String]) {
+        var passed = 0, total = 0; var log: [String] = []
+        func ok(_ n: String, _ c: Bool, _ extra: String = "") {
+            total += 1; if c { passed += 1 }; log.append("[gpusample-test] \(n): \(c ? "PASS" : "FAIL")\(extra.isEmpty ? "" : " (\(extra))")")
+        }
+        guard let device = MTLCreateSystemDefaultDevice(), let queue = device.makeCommandQueue() else {
+            return (0, 1, ["[gpusample-test] no_metal_device: FAIL"])
+        }
+        let logits: [Float] = [3.0, 2.0, 1.0, 0.5, 0.0, -1.0, -2.0, -4.0]
+        let T: Float = 1.0
+        let analytic = Sampler.probs(logits: logits, temperature: Double(T), topP: 1.0)
+        let N = 40000
+        var histGPU = [Int](repeating: 0, count: logits.count)
+        for i in 0..<N {
+            if let r = sampleRows(device: device, queue: queue, logits: [logits], drafts: [-1],
+                                  invT: 1.0 / T, seed: UInt64(i) &* 0x9E3779B97F4A7C15, basePos: i) {
+                histGPU[r.full[0]] += 1
+            }
+        }
+        var tvGPU = 0.0
+        for i in 0..<logits.count { tvGPU += abs(Double(histGPU[i]) / Double(N) - Double(analytic[i])) }
+        tvGPU *= 0.5
+        ok("gpu_matches_softmax", tvGPU < 0.02, String(format: "TV=%.4f", tvGPU))
+
+        // T=0 (greedy): GPU full-sample must be the argmax regardless of seed.
+        let amax = analytic.firstIndex(of: analytic.max()!)!
+        var greedyOK = true
+        for i in 0..<50 {
+            if let r = sampleRows(device: device, queue: queue, logits: [logits], drafts: [-1],
+                                  invT: -1.0, seed: UInt64(i), basePos: i) { if r.full[0] != amax { greedyOK = false } }
+        }
+        ok("gpu_temp0_is_argmax", greedyOK)
+
+        // accept flag calibration: for draft == a mid token, accept rate ≈ p(draft) over seeds.
+        let draft = 2
+        var acc = 0
+        for i in 0..<N {
+            if let r = sampleRows(device: device, queue: queue, logits: [logits], drafts: [draft],
+                                  invT: 1.0 / T, seed: UInt64(i) &* 0xD1B54A32D192ED03, basePos: i) {
+                if r.accept[0] { acc += 1 }
+            }
+        }
+        let accRate = Double(acc) / Double(N)
+        ok("accept_rate_matches_p", abs(accRate - Double(analytic[draft])) < 0.02,
+           String(format: "acc=%.3f p=%.3f", accRate, analytic[draft]))
+
+        return (passed, total, log)
+    }
+}

--- a/swift/Sources/QwispCore/SamplerGPU.swift
+++ b/swift/Sources/QwispCore/SamplerGPU.swift
@@ -45,6 +45,7 @@ public enum SamplerGPU {
         constant uint&      seedHi    [[buffer(9)]],
         constant uint&      basePos   [[buffer(10)]],
         constant uint&      useAdj    [[buffer(11)]],
+        constant float&     topP      [[buffer(12)]],   // < 1 → nucleus truncation on GPU
         uint m   [[threadgroup_position_in_grid]],
         uint tid [[thread_position_in_threadgroup]],
         uint tgs [[threads_per_threadgroup]])
@@ -58,43 +59,66 @@ public enum SamplerGPU {
         int d = draftToks[m];
         bool greedy = invT <= 0.0f;
         uint posSalt = seedHi ^ (basePos + m);
+        #define LADJ(v) ((float)row[v] + (useAdj ? logitAdj[v] : 0.0f))
 
+        // pass 1: max adjusted logit (stable softmax reference).
         float locMax = -INFINITY;
-        float locFS = -INFINITY; int locFI = 0x7fffffff;   // Gumbel argmax (full)
-        float locRS = -INFINITY; int locRI = 0x7fffffff;   // Gumbel argmax (excl draft)
+        for (uint v = tid; v < V; v += tgs) locMax = max(locMax, LADJ(v));
+        rMax[tid] = locMax; threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint s = tgs/2; s > 0; s >>= 1) { if (tid < s) rMax[tid] = max(rMax[tid], rMax[tid+s]); threadgroup_barrier(mem_flags::mem_threadgroup); }
+        float gmax = rMax[0]; threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        bool doTopP = (!greedy) && (topP < 0.999f);
+        float Lthr = -INFINITY;   // nucleus membership: LADJ(v) >= Lthr
+        float Znuc = 0.0f;        // sum of weights w=exp((L-gmax)*invT) over the nucleus
+
+        if (!greedy) {
+            // pass 2: full normalizer Zfull.
+            float locZ = 0.0f;
+            for (uint v = tid; v < V; v += tgs) locZ += exp((LADJ(v) - gmax) * invT);
+            rZ[tid] = locZ; threadgroup_barrier(mem_flags::mem_threadgroup);
+            for (uint s = tgs/2; s > 0; s >>= 1) { if (tid < s) rZ[tid] += rZ[tid+s]; threadgroup_barrier(mem_flags::mem_threadgroup); }
+            float Zfull = rZ[0]; Znuc = Zfull; threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            if (doTopP) {
+                // Bisect the weight threshold thr∈[0,1] (w=1 at argmax): largest thr whose kept mass
+                // still covers topP → the smallest nucleus. ~22 full-vocab reductions.
+                float lo = 0.0f, hi = 1.0f;
+                float target = topP * Zfull;
+                for (int it = 0; it < 22; it++) {
+                    float mid = (lo + hi) * 0.5f;
+                    float locS = 0.0f;
+                    for (uint v = tid; v < V; v += tgs) { float w = exp((LADJ(v) - gmax) * invT); if (w >= mid) locS += w; }
+                    rZ[tid] = locS; threadgroup_barrier(mem_flags::mem_threadgroup);
+                    for (uint s = tgs/2; s > 0; s >>= 1) { if (tid < s) rZ[tid] += rZ[tid+s]; threadgroup_barrier(mem_flags::mem_threadgroup); }
+                    float S = rZ[0];
+                    if (S >= target) { lo = mid; Znuc = S; } else { hi = mid; }
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+                }
+                Lthr = (lo > 0.0f) ? (gmax + log(lo) / invT) : -INFINITY;   // w>=lo ⟺ L>=gmax+log(lo)/invT
+            }
+        }
+
+        // Gumbel-max categorical over the nucleus (full + excluding the draft).
+        float locFS = -INFINITY; int locFI = 0x7fffffff;
+        float locRS = -INFINITY; int locRI = 0x7fffffff;
         for (uint v = tid; v < V; v += tgs) {
-            float L = (float)row[v] + (useAdj ? logitAdj[v] : 0.0f);
-            if (L > locMax) locMax = L;
-            float score;
-            if (greedy) { score = L; }
-            else { score = L * invT + (-log(-log(u01(qhash(seedLo, posSalt, v))))); }
+            float L = LADJ(v);
+            if (doTopP && L < Lthr) continue;                     // outside nucleus
+            float score = greedy ? L : (L * invT + (-log(-log(u01(qhash(seedLo, posSalt, v))))));
             if (score > locFS || (score == locFS && (int)v < locFI)) { locFS = score; locFI = (int)v; }
             if ((int)v != d && (score > locRS || (score == locRS && (int)v < locRI))) { locRS = score; locRI = (int)v; }
         }
-        rMax[tid] = locMax; rFS[tid] = locFS; rFI[tid] = locFI; rRS[tid] = locRS; rRI[tid] = locRI;
+        rFS[tid] = locFS; rFI[tid] = locFI; rRS[tid] = locRS; rRI[tid] = locRI;
         threadgroup_barrier(mem_flags::mem_threadgroup);
-        for (uint s = tgs / 2; s > 0; s >>= 1) {
+        for (uint s = tgs/2; s > 0; s >>= 1) {
             if (tid < s) {
-                if (rMax[tid+s] > rMax[tid]) rMax[tid] = rMax[tid+s];
                 if (rFS[tid+s] > rFS[tid] || (rFS[tid+s]==rFS[tid] && rFI[tid+s]<rFI[tid])) { rFS[tid]=rFS[tid+s]; rFI[tid]=rFI[tid+s]; }
                 if (rRS[tid+s] > rRS[tid] || (rRS[tid+s]==rRS[tid] && rRI[tid+s]<rRI[tid])) { rRS[tid]=rRS[tid+s]; rRI[tid]=rRI[tid+s]; }
             }
             threadgroup_barrier(mem_flags::mem_threadgroup);
         }
-        float gmax = rMax[0];
         int fullIdx = rFI[0], residIdx = rRI[0];
-
-        // pass 2: softmax normalizer Z (only needed for the accept probability at T>0).
-        float locZ = 0.0f;
-        if (!greedy) {
-            for (uint v = tid; v < V; v += tgs) {
-                float L = (float)row[v] + (useAdj ? logitAdj[v] : 0.0f);
-                locZ += exp((L - gmax) * invT);
-            }
-        }
-        rZ[tid] = locZ;
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-        for (uint s = tgs / 2; s > 0; s >>= 1) { if (tid < s) rZ[tid] += rZ[tid+s]; threadgroup_barrier(mem_flags::mem_threadgroup); }
 
         if (tid == 0) {
             sampFull[m]  = fullIdx;
@@ -102,10 +126,15 @@ public enum SamplerGPU {
             float pDraft;
             if (d < 0) pDraft = 0.0f;
             else if (greedy) pDraft = (d == fullIdx) ? 1.0f : 0.0f;
-            else { float Ld = (float)row[d] + (useAdj ? logitAdj[d] : 0.0f); pDraft = exp((Ld - gmax) * invT) / rZ[0]; }
+            else {
+                float Ld = LADJ(d);
+                bool inNuc = !doTopP || (Ld >= Lthr);
+                pDraft = inNuc ? (exp((Ld - gmax) * invT) / Znuc) : 0.0f;
+            }
             float coin = u01(qhash(seedLo, posSalt, 0x9999AAAAu));
             acceptOut[m] = (coin < pDraft) ? 1 : 0;
         }
+        #undef LADJ
     }
     """
 
@@ -123,7 +152,8 @@ public enum SamplerGPU {
     /// Returns (full, resid, accept) per row.
     public static func sampleRows(device: MTLDevice, queue: MTLCommandQueue,
                                   logits: [[Float]], drafts: [Int], invT: Float,
-                                  seed: UInt64, basePos: Int) -> (full: [Int], resid: [Int], accept: [Bool])? {
+                                  seed: UInt64, basePos: Int, topP: Float = 1.0,
+                                  logitAdj: [Float]? = nil) -> (full: [Int], resid: [Int], accept: [Bool])? {
         guard ensurePipeline(device), let pipe = _pipeline, let first = logits.first else { return nil }
         let M = logits.count, V = first.count
         var flat = [UInt16](repeating: 0, count: M * V)   // f16
@@ -137,6 +167,8 @@ public enum SamplerGPU {
         flat.withUnsafeBytes { lgBuf.contents().copyMemory(from: $0.baseAddress!, byteCount: M*V*2) }
         let dp = dBuf.contents().bindMemory(to: Int32.self, capacity: M)
         for m in 0..<M { dp[m] = Int32(m < drafts.count ? drafts[m] : -1) }
+        var useAdj: UInt32 = 0
+        if let adj = logitAdj { useAdj = 1; adj.withUnsafeBytes { adjBuf.contents().copyMemory(from: $0.baseAddress!, byteCount: V*4) } }
 
         let cb = queue.makeCommandBuffer()!, enc = cb.makeComputeCommandEncoder()!
         enc.setComputePipelineState(pipe)
@@ -144,10 +176,11 @@ public enum SamplerGPU {
         enc.setBuffer(dBuf, offset: 0, index: 2); enc.setBuffer(fBuf, offset: 0, index: 3)
         enc.setBuffer(rBuf, offset: 0, index: 4); enc.setBuffer(aBuf, offset: 0, index: 5)
         var it = invT, vv = UInt32(V), sl = UInt32(truncatingIfNeeded: seed), sh = UInt32(truncatingIfNeeded: seed >> 32)
-        var bp = UInt32(basePos), ua = UInt32(0)
+        var bp = UInt32(basePos), ua = useAdj, tp = topP
         enc.setBytes(&it, length: 4, index: 6); enc.setBytes(&vv, length: 4, index: 7)
         enc.setBytes(&sl, length: 4, index: 8); enc.setBytes(&sh, length: 4, index: 9)
         enc.setBytes(&bp, length: 4, index: 10); enc.setBytes(&ua, length: 4, index: 11)
+        enc.setBytes(&tp, length: 4, index: 12)
         enc.dispatchThreadgroups(MTLSize(width: M, height: 1, depth: 1),
                                  threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
         enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
@@ -216,6 +249,39 @@ public enum SamplerGPU {
         let accRate = Double(acc) / Double(N)
         ok("accept_rate_matches_p", abs(accRate - Double(analytic[draft])) < 0.02,
            String(format: "acc=%.3f p=%.3f", accRate, analytic[draft]))
+
+        // top_p on GPU: empirical dist must match the CPU nucleus-truncated dist.
+        let topPv: Float = 0.9
+        let truncCPU = Sampler.probs(logits: logits, temperature: Double(T), topP: Double(topPv))
+        var histTP = [Int](repeating: 0, count: logits.count)
+        for i in 0..<N {
+            if let r = sampleRows(device: device, queue: queue, logits: [logits], drafts: [-1],
+                                  invT: 1.0/T, seed: UInt64(i) &* 0x2545F4914F6CDD1D, basePos: i, topP: topPv) {
+                histTP[r.full[0]] += 1
+            }
+        }
+        var tvTP = 0.0
+        for i in 0..<logits.count { tvTP += abs(Double(histTP[i])/Double(N) - Double(truncCPU[i])) }
+        tvTP *= 0.5
+        ok("gpu_topp_matches_cpu", tvTP < 0.02, String(format: "TV=%.4f", tvTP))
+        // truncation actually happened: the -4.0 tail token must be excluded at top_p 0.9.
+        ok("gpu_topp_truncates_tail", histTP[logits.count - 1] == 0)
+
+        // penalties/logit_bias via logitAdj: GPU dist must match softmax(logits + adj).
+        let adj: [Float] = [0, -3, 0, 0, +2, 0, 0, 0]
+        let adjusted = zip(logits, adj).map { $0 + $1 }
+        let adjCPU = Sampler.probs(logits: adjusted, temperature: Double(T), topP: 1.0)
+        var histAdj = [Int](repeating: 0, count: logits.count)
+        for i in 0..<N {
+            if let r = sampleRows(device: device, queue: queue, logits: [logits], drafts: [-1],
+                                  invT: 1.0/T, seed: UInt64(i) &* 0x9E6C63D0676A9A99, basePos: i, logitAdj: adj) {
+                histAdj[r.full[0]] += 1
+            }
+        }
+        var tvAdj = 0.0
+        for i in 0..<logits.count { tvAdj += abs(Double(histAdj[i])/Double(N) - Double(adjCPU[i])) }
+        tvAdj *= 0.5
+        ok("gpu_logitadj_matches_cpu", tvAdj < 0.02, String(format: "TV=%.4f", tvAdj))
 
         return (passed, total, log)
     }

--- a/swift/Sources/QwispCore/SamplerGPU.swift
+++ b/swift/Sources/QwispCore/SamplerGPU.swift
@@ -20,7 +20,11 @@ public enum SamplerGPU {
 
     static let kernelSrc = """
     #include <metal_stdlib>
+    #include <metal_atomic>
     using namespace metal;
+
+    #define GPB 1024        // top_p histogram buckets
+    #define GSPAN 40.0f     // max scaled-gap covered (exp(-40) ≈ 0)
 
     inline uint qhash(uint a, uint b, uint c) {
         uint h = a * 0x9E3779B1u + 0x165667B1u;
@@ -72,30 +76,47 @@ public enum SamplerGPU {
         float Lthr = -INFINITY;   // nucleus membership: LADJ(v) >= Lthr
         float Znuc = 0.0f;        // sum of weights w=exp((L-gmax)*invT) over the nucleus
 
+        // Histogram-based top_p: bin the softmax weight by its scaled gap g=(gmax-L)*invT into GPB
+        // buckets, folded into the SAME pass that sums Zfull (no extra full-vocab traversal). The
+        // nucleus threshold is then one linear scan of the bucket cumulative mass — replaces the
+        // 14-iteration bisection (14 full passes → 1 pass + a GPB scan). Bucket edges are exact
+        // (Lthr and Znuc reference the same boundary), only the boundary token's granularity is
+        // approximate — sub-noise for sampling.
+        threadgroup atomic_uint hist[GPB];   // fixed-point mass (atomic_uint = robust; atomic_float TG is flaky)
+        threadgroup float tLthr;
         if (!greedy) {
-            // pass 2: full normalizer Zfull.
+            bool useHist = doTopP;
+            if (useHist) { for (uint b = tid; b < GPB; b += tgs) atomic_store_explicit(&hist[b], 0u, memory_order_relaxed); threadgroup_barrier(mem_flags::mem_threadgroup); }
+            const float binW = GSPAN / (float)GPB;
+            const float SCALE = 8192.0f;                    // V·SCALE < 2^32 for V≤248k
             float locZ = 0.0f;
-            for (uint v = tid; v < V; v += tgs) locZ += exp((LADJ(v) - gmax) * invT);
+            for (uint v = tid; v < V; v += tgs) {
+                float g = (gmax - LADJ(v)) * invT;          // >= 0
+                float w = exp(-g);
+                locZ += w;
+                if (useHist) { uint b = min((uint)(GPB - 1), (uint)(g / binW)); atomic_fetch_add_explicit(&hist[b], (uint)(w * SCALE), memory_order_relaxed); }
+            }
             rZ[tid] = locZ; threadgroup_barrier(mem_flags::mem_threadgroup);
             for (uint s = tgs/2; s > 0; s >>= 1) { if (tid < s) rZ[tid] += rZ[tid+s]; threadgroup_barrier(mem_flags::mem_threadgroup); }
             float Zfull = rZ[0]; Znuc = Zfull; threadgroup_barrier(mem_flags::mem_threadgroup);
 
-            if (doTopP) {
-                // Bisect the weight threshold thr∈[0,1] (w=1 at argmax): largest thr whose kept mass
-                // still covers topP → the smallest nucleus. ~22 full-vocab reductions.
-                float lo = 0.0f, hi = 1.0f;
-                float target = topP * Zfull;
-                for (int it = 0; it < 22; it++) {
-                    float mid = (lo + hi) * 0.5f;
-                    float locS = 0.0f;
-                    for (uint v = tid; v < V; v += tgs) { float w = exp((LADJ(v) - gmax) * invT); if (w >= mid) locS += w; }
-                    rZ[tid] = locS; threadgroup_barrier(mem_flags::mem_threadgroup);
-                    for (uint s = tgs/2; s > 0; s >>= 1) { if (tid < s) rZ[tid] += rZ[tid+s]; threadgroup_barrier(mem_flags::mem_threadgroup); }
-                    float S = rZ[0];
-                    if (S >= target) { lo = mid; Znuc = S; } else { hi = mid; }
-                    threadgroup_barrier(mem_flags::mem_threadgroup);
+            if (useHist) {
+                // quantized cumulative → nucleus boundary bucket bstar → Lthr.
+                if (tid == 0) {
+                    uint total = 0; for (uint b = 0; b < GPB; b++) total += atomic_load_explicit(&hist[b], memory_order_relaxed);
+                    uint targetU = (uint)(topP * (float)total);
+                    uint cum = 0; uint bstar = GPB - 1;
+                    for (uint b = 0; b < GPB; b++) { cum += atomic_load_explicit(&hist[b], memory_order_relaxed); if (cum >= targetU) { bstar = b; break; } }
+                    tLthr = gmax - (float)(bstar + 1) * binW / invT;
                 }
-                Lthr = (lo > 0.0f) ? (gmax + log(lo) / invT) : -INFINITY;   // w>=lo ⟺ L>=gmax+log(lo)/invT
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                Lthr = tLthr;
+                // real (unquantized) nucleus normalizer for the accept probability.
+                float locN = 0.0f;
+                for (uint v = tid; v < V; v += tgs) { float L = LADJ(v); if (L >= Lthr) locN += exp((L - gmax) * invT); }
+                rZ[tid] = locN; threadgroup_barrier(mem_flags::mem_threadgroup);
+                for (uint s = tgs/2; s > 0; s >>= 1) { if (tid < s) rZ[tid] += rZ[tid+s]; threadgroup_barrier(mem_flags::mem_threadgroup); }
+                Znuc = rZ[0]; threadgroup_barrier(mem_flags::mem_threadgroup);
             }
         }
 
@@ -215,7 +236,7 @@ public enum SamplerGPU {
         let logits: [Float] = [3.0, 2.0, 1.0, 0.5, 0.0, -1.0, -2.0, -4.0]
         let T: Float = 1.0
         let analytic = Sampler.probs(logits: logits, temperature: Double(T), topP: 1.0)
-        let N = 40000
+        let N = 8000
         var histGPU = [Int](repeating: 0, count: logits.count)
         for i in 0..<N {
             if let r = sampleRows(device: device, queue: queue, logits: [logits], drafts: [-1],

--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -3462,6 +3462,9 @@ public enum SeedlessFusedVerify {
             let retained: [MLXArray]
         }
         var head: HeadBufs? = nil
+        // Option B GPU sampler scratch (lazily allocated on first stepSampleRows).
+        var sSampFull: MTLBuffer? = nil, sSampResid: MTLBuffer? = nil, sSampAccept: MTLBuffer? = nil
+        var sSampDraft: MTLBuffer? = nil, sSampAdj: MTLBuffer? = nil
 
         /// head(embed/lm_head/final norm)を常駐 buffer 化して 1-CB step を有効化する。
         public func attachHead(embedW: MLXArray, embedS: MLXArray, embedB: MLXArray,
@@ -3568,6 +3571,84 @@ public enum SeedlessFusedVerify {
 
             let ptr = hd.tokensOut.contents().bindMemory(to: Int32.self, capacity: maxM)
             return (0 ..< M).map { Int(ptr[$0]) }
+        }
+
+        /// Option B GPU sampler: same 1-CB forward as stepArgmax, but the final op is spec_sample_rows
+        /// (Gumbel-max categorical + accept) instead of argmax. Returns per-row (full sample, residual
+        /// sample excluding the draft, accept flag). readback = 3·M ints (no full-logits transfer).
+        public func stepSampleRows(_ tokens: [Int32], drafts: [Int], invT: Float, seed: UInt64, basePos: Int)
+            -> (full: [Int], resid: [Int], accept: [Bool])? {
+            guard let hd = head, tokens.count <= maxM else { return nil }
+            guard SamplerGPU.ensurePipeline(device), let samp = SamplerGPU._pipeline else { return nil }
+            let M = tokens.count
+            hd.tokensIn.contents().bindMemory(to: Int32.self, capacity: maxM).update(from: tokens, count: M)
+            if sSampFull == nil {
+                sSampFull = device.makeBuffer(length: maxM * 4, options: .storageModeShared)
+                sSampResid = device.makeBuffer(length: maxM * 4, options: .storageModeShared)
+                sSampAccept = device.makeBuffer(length: maxM * 4, options: .storageModeShared)
+                sSampDraft = device.makeBuffer(length: maxM * 4, options: .storageModeShared)
+                sSampAdj = device.makeBuffer(length: max(1, hd.vocab) * 4, options: .storageModeShared)  // zeros (useAdj=0)
+            }
+            guard let sF = sSampFull, let sR = sSampResid, let sA = sSampAccept,
+                  let sD = sSampDraft, let sAdj = sSampAdj else { return nil }
+            let dp = sD.contents().bindMemory(to: Int32.self, capacity: maxM)
+            for i in 0 ..< M { dp[i] = Int32(i < drafts.count ? drafts[i] : -1) }
+
+            func encodeEmbed(_ enc: MTLComputeCommandEncoder) {
+                let ep = SeedlessFusedVerify._embedRowsPipeline!
+                enc.setComputePipelineState(ep)
+                enc.setBuffer(hd.embedW, offset: 0, index: 0); enc.setBuffer(hd.embedS, offset: 0, index: 1)
+                enc.setBuffer(hd.embedB, offset: 0, index: 2); enc.setBuffer(hd.tokensIn, offset: 0, index: 3)
+                enc.setBuffer(hBuf, offset: 0, index: 4)
+                var hh = UInt32(H), tt = UInt32(M * H)
+                enc.setBytes(&hh, length: 4, index: 5); enc.setBytes(&tt, length: 4, index: 6)
+                enc.dispatchThreads(MTLSize(width: M * H, height: 1, depth: 1),
+                                    threadsPerThreadgroup: MTLSize(width: min(ep.maxTotalThreadsPerThreadgroup, 256), height: 1, depth: 1))
+            }
+            func encodeFinalSample(_ enc: MTLComputeCommandEncoder) {
+                SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: hd.fnW, out: normed, rows: M, D: H, eps: eps)
+                if SeedlessFusedForward.lmHeadQmv {
+                    SeedlessFusedVerify.encodeQmmRows(enc, w: hd.lmW, scales: hd.lmS, biases: hd.lmB,
+                                                 x: normed, out: hd.logits, M: M, K: H, N: hd.vocab)
+                } else {
+                    let qp = SeedlessMetalForward._qmm4TiledPipeline!
+                    enc.setComputePipelineState(qp)
+                    enc.setBuffer(hd.lmW, offset: 0, index: 0); enc.setBuffer(hd.lmS, offset: 0, index: 1)
+                    enc.setBuffer(hd.lmB, offset: 0, index: 2); enc.setBuffer(normed, offset: 0, index: 3)
+                    enc.setBuffer(hd.logits, offset: 0, index: 4)
+                    var kk = Int32(H), nn = Int32(hd.vocab), mm = Int32(M)
+                    enc.setBytes(&kk, length: 4, index: 5); enc.setBytes(&nn, length: 4, index: 6); enc.setBytes(&mm, length: 4, index: 7)
+                    enc.dispatchThreadgroups(MTLSize(width: hd.vocab, height: 1, depth: 1),
+                                             threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+                }
+                enc.setComputePipelineState(samp)
+                enc.setBuffer(hd.logits, offset: 0, index: 0); enc.setBuffer(sAdj, offset: 0, index: 1)
+                enc.setBuffer(sD, offset: 0, index: 2); enc.setBuffer(sF, offset: 0, index: 3)
+                enc.setBuffer(sR, offset: 0, index: 4); enc.setBuffer(sA, offset: 0, index: 5)
+                var it = invT, vv = UInt32(hd.vocab), sl = UInt32(truncatingIfNeeded: seed)
+                var sh = UInt32(truncatingIfNeeded: seed >> 32), bp = UInt32(truncatingIfNeeded: basePos), ua = UInt32(0)
+                enc.setBytes(&it, length: 4, index: 6); enc.setBytes(&vv, length: 4, index: 7)
+                enc.setBytes(&sl, length: 4, index: 8); enc.setBytes(&sh, length: 4, index: 9)
+                enc.setBytes(&bp, length: 4, index: 10); enc.setBytes(&ua, length: 4, index: 11)
+                enc.dispatchThreadgroups(MTLSize(width: M, height: 1, depth: 1),
+                                         threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+            }
+            switch streamMode {
+            case .resident:
+                let cb = queue.makeCommandBuffer()!; let enc = cb.makeComputeCommandEncoder()!
+                encodeEmbed(enc); for L in layers { encodeLayer(enc, L, M: M) }; encodeFinalSample(enc)
+                enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+            case .bolt:
+                let cb = queue.makeCommandBuffer()!; let enc = cb.makeComputeCommandEncoder()!
+                encodeEmbed(enc); for (li, L) in layers.enumerated() { encodeLayerBolt(enc, L, M: M, li: li) }; encodeFinalSample(enc)
+                enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+            case .strict:
+                runStrictLayers(M: M, firstCBExtra: encodeEmbed, finalCBExtra: encodeFinalSample)
+            }
+            let fp = sF.contents().bindMemory(to: Int32.self, capacity: maxM)
+            let rp = sR.contents().bindMemory(to: Int32.self, capacity: maxM)
+            let ap = sA.contents().bindMemory(to: Int32.self, capacity: maxM)
+            return ((0..<M).map { Int(fp[$0]) }, (0..<M).map { Int(rp[$0]) }, (0..<M).map { ap[$0] != 0 })
         }
 
         /// spec の partial reject 用: 直前 forwardRows「1 回だけ」の cache 前進を取り消すための snapshot。

--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -3576,7 +3576,8 @@ public enum SeedlessFusedVerify {
         /// Option B GPU sampler: same 1-CB forward as stepArgmax, but the final op is spec_sample_rows
         /// (Gumbel-max categorical + accept) instead of argmax. Returns per-row (full sample, residual
         /// sample excluding the draft, accept flag). readback = 3·M ints (no full-logits transfer).
-        public func stepSampleRows(_ tokens: [Int32], drafts: [Int], invT: Float, seed: UInt64, basePos: Int)
+        public func stepSampleRows(_ tokens: [Int32], drafts: [Int], invT: Float, seed: UInt64, basePos: Int,
+                                   logitAdj: [Float]? = nil, topP: Float = 1.0)
             -> (full: [Int], resid: [Int], accept: [Bool])? {
             guard let hd = head, tokens.count <= maxM else { return nil }
             guard SamplerGPU.ensurePipeline(device), let samp = SamplerGPU._pipeline else { return nil }
@@ -3593,6 +3594,11 @@ public enum SeedlessFusedVerify {
                   let sD = sSampDraft, let sAdj = sSampAdj else { return nil }
             let dp = sD.contents().bindMemory(to: Int32.self, capacity: maxM)
             for i in 0 ..< M { dp[i] = Int32(i < drafts.count ? drafts[i] : -1) }
+            var useAdj: UInt32 = 0
+            if let adj = logitAdj, adj.count == hd.vocab {
+                useAdj = 1
+                adj.withUnsafeBytes { sAdj.contents().copyMemory(from: $0.baseAddress!, byteCount: hd.vocab * 4) }
+            }
 
             func encodeEmbed(_ enc: MTLComputeCommandEncoder) {
                 let ep = SeedlessFusedVerify._embedRowsPipeline!
@@ -3626,10 +3632,12 @@ public enum SeedlessFusedVerify {
                 enc.setBuffer(sD, offset: 0, index: 2); enc.setBuffer(sF, offset: 0, index: 3)
                 enc.setBuffer(sR, offset: 0, index: 4); enc.setBuffer(sA, offset: 0, index: 5)
                 var it = invT, vv = UInt32(hd.vocab), sl = UInt32(truncatingIfNeeded: seed)
-                var sh = UInt32(truncatingIfNeeded: seed >> 32), bp = UInt32(truncatingIfNeeded: basePos), ua = UInt32(0)
+                var sh = UInt32(truncatingIfNeeded: seed >> 32), bp = UInt32(truncatingIfNeeded: basePos)
+                var ua = useAdj, tp = topP
                 enc.setBytes(&it, length: 4, index: 6); enc.setBytes(&vv, length: 4, index: 7)
                 enc.setBytes(&sl, length: 4, index: 8); enc.setBytes(&sh, length: 4, index: 9)
                 enc.setBytes(&bp, length: 4, index: 10); enc.setBytes(&ua, length: 4, index: 11)
+                enc.setBytes(&tp, length: 4, index: 12)
                 enc.dispatchThreadgroups(MTLSize(width: M, height: 1, depth: 1),
                                          threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
             }

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -91,7 +91,7 @@ extension Tell {
         var stepLogitsRows: (([Int32]) -> [[Float]]?)? = nil
         // Option B GPU sampler: (tokens, draftPerRow, invT, seed, basePos) → per-row
         // (full sample, residual sample, accept). Returns the decision on-GPU, tiny readback.
-        var stepSampleRows: (([Int32], [Int], Float, UInt64, Int) -> (full: [Int], resid: [Int], accept: [Bool])?)? = nil
+        var stepSampleRows: (([Int32], [Int], Float, UInt64, Int, [Float]?, Float) -> (full: [Int], resid: [Int], accept: [Bool])?)? = nil
     }
 
     /// forward + lm_head logits, read back to CPU per row (for speculative sampling).
@@ -169,8 +169,8 @@ extension Tell {
         }
         backend.stepLogitsRows = makeStepLogits(engine: engine, forward: forward)   // Option B sampling (CPU)
         if fwd.head != nil {                                                        // Option B GPU sampler
-            backend.stepSampleRows = { toks, drafts, invT, seed, base in
-                fwd.stepSampleRows(toks, drafts: drafts, invT: invT, seed: seed, basePos: base)
+            backend.stepSampleRows = { toks, drafts, invT, seed, base, adj, topP in
+                fwd.stepSampleRows(toks, drafts: drafts, invT: invT, seed: seed, basePos: base, logitAdj: adj, topP: topP)
             }
         }
         return (backend, fwd)
@@ -501,7 +501,9 @@ extension Tell {
     /// work — the maxK cap is lifted. Temperature only (top_p/penalties/logit_bias use the CPU loop).
     /// T=0 (temperature 0) degenerates to argmax → byte-identical to greedy.
     static func runSpecSampleLoopGPU(promptIds: [Int32], backend: SpecBackend, engine: SeedlessEngine,
-                                     N: Int, maxK: Int, temperature: Double, seed: UInt64,
+                                     N: Int, maxK: Int, temperature: Double, topP: Double, seed: UInt64,
+                                     frequencyPenalty: Double = 0, presencePenalty: Double = 0,
+                                     logitBias: [Int: Double] = [:],
                                      isCancelled: (() -> Bool)? = nil,
                                      onToken: ((Int) -> Void)? = nil) -> [Int]? {
         guard let stepSample = backend.stepSampleRows else { return nil }
@@ -509,15 +511,36 @@ extension Tell {
         guard let lg0 = engine.logits(lastNormed, M: 1) else { return nil }
         MLX.eval([lg0])
         let invT: Float = temperature > 0 ? Float(1.0 / temperature) : -1
+        let tpF = Float(topP)
         var rng = SplitMix64(seed: seed)
-        // First token from the prefill logits (one-time CPU sample; degenerates to argmax at T=0).
-        var u = Sampler.categorical(Sampler.probs(logits: lg0[0].asArray(Float.self),
-                                                  temperature: temperature, topP: 1.0), rng: &rng)
+
+        // Penalties/logit_bias fold into a persistent per-vocab adjustment buffer (`adj`, kept in
+        // sync as tokens commit) that the kernel adds before softmax. nil = temperature-only fast path.
+        let useAdj = frequencyPenalty != 0 || presencePenalty != 0 || !logitBias.isEmpty
+        var lg0arr = lg0[0].asArray(Float.self)
+        let V = lg0arr.count
+        var adj: [Float]? = nil
+        var counts: [Int: Int] = [:]
+        if useAdj {
+            var a = [Float](repeating: 0, count: V)
+            for (t, b) in logitBias where t >= 0 && t < V { a[t] += Float(b) }
+            adj = a
+            Sampler.adjustLogits(&lg0arr, counts: [:], logitBias: logitBias)   // first token: bias only
+        }
+        var u = Sampler.categorical(Sampler.probs(logits: lg0arr, temperature: temperature, topP: topP), rng: &rng)
+
         var hist = promptIds.map { Int($0) }
         var out: [Int] = []
         var streamed = 0
         func flush() { if let onToken { while streamed < out.count { onToken(out[streamed]); streamed += 1 } } }
-        func commit(_ t: Int) { out.append(t); hist.append(t) }
+        func commit(_ t: Int) {
+            out.append(t); hist.append(t)
+            if useAdj, t >= 0, t < V {
+                let c = (counts[t] ?? 0) + 1; counts[t] = c
+                adj![t] -= Float(frequencyPenalty)
+                if c == 1 { adj![t] -= Float(presencePenalty) }
+            }
+        }
 
         while out.count < N && !(isCancelled?() ?? false) {
             flush()
@@ -527,7 +550,7 @@ extension Tell {
             let basePos = out.count   // monotonic absolute position → reproducible per-position RNG
 
             if D == 0 {
-                guard let r = stepSample([Int32(u)], [-1], invT, seed, basePos) else { return nil }
+                guard let r = stepSample([Int32(u)], [-1], invT, seed, basePos, adj, tpF) else { return nil }
                 commit(u)
                 u = r.full[0]
                 continue
@@ -535,7 +558,7 @@ extension Tell {
 
             let verifyTokens: [Int32] = [Int32(u)] + drafts.map { Int32($0) }
             let draftRows = drafts + [-1]                       // row D is the bonus (no draft)
-            guard let r = stepSample(verifyTokens, draftRows, invT, seed, basePos) else { return nil }
+            guard let r = stepSample(verifyTokens, draftRows, invT, seed, basePos, adj, tpF) else { return nil }
 
             var p = 0
             while p < D && r.accept[p] { p += 1 }

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -441,14 +441,13 @@ extension Tell {
         func commit(_ t: Int) { out.append(t); hist.append(t); counts[t, default: 0] += 1 }
         // Penalties/bias reshape logits before softmax. Penalty context = generated tokens as of the
         // step start (within-window granularity is approximate — standard for spec decoding).
-        func adjusted(_ logits: [Float]) -> [Float] {
-            var l = logits
+        let hasAdj = frequencyPenalty != 0 || presencePenalty != 0 || !logitBias.isEmpty
+        func probs(_ logits: [Float]) -> [Float] {
+            guard hasAdj else { return Sampler.probs(logits: logits, temperature: temperature, topP: topP) }
+            var l = logits   // copy only when penalties/bias actually change the logits
             Sampler.adjustLogits(&l, counts: counts, frequencyPenalty: frequencyPenalty,
                                  presencePenalty: presencePenalty, logitBias: logitBias)
-            return l
-        }
-        func probs(_ logits: [Float]) -> [Float] {
-            Sampler.probs(logits: adjusted(logits), temperature: temperature, topP: topP)
+            return Sampler.probs(logits: l, temperature: temperature, topP: topP)
         }
         func draw(_ logits: [Float]) -> Int { Sampler.categorical(probs(logits), rng: &rng) }
 

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -415,6 +415,8 @@ extension Tell {
     /// small correctness gate). Requires backend.stepLogitsRows (logits readback).
     static func runSpecSampleLoop(promptIds: [Int32], backend: SpecBackend, engine: SeedlessEngine,
                                   N: Int, maxK: Int, temperature: Double, topP: Double, seed: UInt64,
+                                  frequencyPenalty: Double = 0, presencePenalty: Double = 0,
+                                  logitBias: [Int: Double] = [:],
                                   isCancelled: (() -> Bool)? = nil,
                                   onToken: ((Int) -> Void)? = nil) -> [Int]? {
         guard let stepLogits = backend.stepLogitsRows else { return nil }
@@ -422,15 +424,27 @@ extension Tell {
         guard let lg0 = engine.logits(lastNormed, M: 1) else { return nil }
         MLX.eval([lg0])
         var rng = SplitMix64(seed: seed)
-        func draw(_ logits: [Float]) -> Int {
-            Sampler.categorical(Sampler.probs(logits: logits, temperature: temperature, topP: topP), rng: &rng)
-        }
-        var u = draw(lg0[0].asArray(Float.self))
 
         var hist = promptIds.map { Int($0) }
         var out: [Int] = []
+        var counts: [Int: Int] = [:]   // generated-token occurrences, for penalties
         var streamed = 0
         func flush() { if let onToken { while streamed < out.count { onToken(out[streamed]); streamed += 1 } } }
+        func commit(_ t: Int) { out.append(t); hist.append(t); counts[t, default: 0] += 1 }
+        // Penalties/bias reshape logits before softmax. Penalty context = generated tokens as of the
+        // step start (within-window granularity is approximate — standard for spec decoding).
+        func adjusted(_ logits: [Float]) -> [Float] {
+            var l = logits
+            Sampler.adjustLogits(&l, counts: counts, frequencyPenalty: frequencyPenalty,
+                                 presencePenalty: presencePenalty, logitBias: logitBias)
+            return l
+        }
+        func probs(_ logits: [Float]) -> [Float] {
+            Sampler.probs(logits: adjusted(logits), temperature: temperature, topP: topP)
+        }
+        func draw(_ logits: [Float]) -> Int { Sampler.categorical(probs(logits), rng: &rng) }
+
+        var u = draw(lg0[0].asArray(Float.self))
 
         while out.count < N && !(isCancelled?() ?? false) {
             flush()
@@ -440,7 +454,7 @@ extension Tell {
 
             if D == 0 {
                 guard let rows = stepLogits([Int32(u)]) else { return nil }
-                out.append(u); hist.append(u)
+                commit(u)
                 u = draw(rows[0])
                 continue
             }
@@ -453,19 +467,18 @@ extension Tell {
             var p = 0
             var rejectTok: Int? = nil
             while p < D {
-                let pp = Sampler.probs(logits: rows[p], temperature: temperature, topP: topP)
-                let (accepted, resampled) = Sampler.acceptOrResample(p: pp, draft: drafts[p], rng: &rng)
+                let (accepted, resampled) = Sampler.acceptOrResample(p: probs(rows[p]), draft: drafts[p], rng: &rng)
                 if accepted { p += 1 } else { rejectTok = resampled; break }
             }
 
             if p == D {
-                out.append(u); hist.append(u)
-                for d in drafts { out.append(d); hist.append(d) }
+                commit(u)
+                for d in drafts { commit(d) }
                 u = draw(rows[D])                                    // bonus token
             } else {
                 backend.rollback(snap)                              // undo the D+1 verify advance
-                out.append(u); hist.append(u)
-                for d in drafts.prefix(p) { out.append(d); hist.append(d) }
+                commit(u)
+                for d in drafts.prefix(p) { commit(d) }
                 let rebuildTokens: [Int32] = [Int32(u)] + drafts.prefix(p).map { Int32($0) }
                 guard let _ = backend.forward(rebuildTokens) else { return nil }   // realize accepted prefix
                 u = rejectTok!

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -89,6 +89,9 @@ extension Tell {
         // Option B (sampling): full logits per input row (readback), for speculative sampling.
         // Additive — greedy stepArgmax path is untouched.
         var stepLogitsRows: (([Int32]) -> [[Float]]?)? = nil
+        // Option B GPU sampler: (tokens, draftPerRow, invT, seed, basePos) → per-row
+        // (full sample, residual sample, accept). Returns the decision on-GPU, tiny readback.
+        var stepSampleRows: (([Int32], [Int], Float, UInt64, Int) -> (full: [Int], resid: [Int], accept: [Bool])?)? = nil
     }
 
     /// forward + lm_head logits, read back to CPU per row (for speculative sampling).
@@ -164,7 +167,12 @@ extension Tell {
         if fwd.head != nil {
             backend.chainedStepArgmax = { token, k in fwd.chainedStepArgmax(token, K: k) }
         }
-        backend.stepLogitsRows = makeStepLogits(engine: engine, forward: forward)   // Option B sampling
+        backend.stepLogitsRows = makeStepLogits(engine: engine, forward: forward)   // Option B sampling (CPU)
+        if fwd.head != nil {                                                        // Option B GPU sampler
+            backend.stepSampleRows = { toks, drafts, invT, seed, base in
+                fwd.stepSampleRows(toks, drafts: drafts, invT: invT, seed: seed, basePos: base)
+            }
+        }
         return (backend, fwd)
     }
 
@@ -482,6 +490,65 @@ extension Tell {
                 let rebuildTokens: [Int32] = [Int32(u)] + drafts.prefix(p).map { Int32($0) }
                 guard let _ = backend.forward(rebuildTokens) else { return nil }   // realize accepted prefix
                 u = rejectTok!
+            }
+        }
+        flush()
+        return Array(out.prefix(N))
+    }
+
+    /// Option B GPU sampler loop: like runSpecSampleLoop but the softmax + categorical + accept
+    /// happen on the GPU (backend.stepSampleRows), so no full-logits readback and no CPU per-vocab
+    /// work — the maxK cap is lifted. Temperature only (top_p/penalties/logit_bias use the CPU loop).
+    /// T=0 (temperature 0) degenerates to argmax → byte-identical to greedy.
+    static func runSpecSampleLoopGPU(promptIds: [Int32], backend: SpecBackend, engine: SeedlessEngine,
+                                     N: Int, maxK: Int, temperature: Double, seed: UInt64,
+                                     isCancelled: (() -> Bool)? = nil,
+                                     onToken: ((Int) -> Void)? = nil) -> [Int]? {
+        guard let stepSample = backend.stepSampleRows else { return nil }
+        guard let lastNormed = prefill(promptIds: promptIds, backend: backend) else { return nil }
+        guard let lg0 = engine.logits(lastNormed, M: 1) else { return nil }
+        MLX.eval([lg0])
+        let invT: Float = temperature > 0 ? Float(1.0 / temperature) : -1
+        var rng = SplitMix64(seed: seed)
+        // First token from the prefill logits (one-time CPU sample; degenerates to argmax at T=0).
+        var u = Sampler.categorical(Sampler.probs(logits: lg0[0].asArray(Float.self),
+                                                  temperature: temperature, topP: 1.0), rng: &rng)
+        var hist = promptIds.map { Int($0) }
+        var out: [Int] = []
+        var streamed = 0
+        func flush() { if let onToken { while streamed < out.count { onToken(out[streamed]); streamed += 1 } } }
+        func commit(_ t: Int) { out.append(t); hist.append(t) }
+
+        while out.count < N && !(isCancelled?() ?? false) {
+            flush()
+            let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: 4)
+            let D = drafts.count
+            let snap = backend.snapshot()
+            let basePos = out.count   // monotonic absolute position → reproducible per-position RNG
+
+            if D == 0 {
+                guard let r = stepSample([Int32(u)], [-1], invT, seed, basePos) else { return nil }
+                commit(u)
+                u = r.full[0]
+                continue
+            }
+
+            let verifyTokens: [Int32] = [Int32(u)] + drafts.map { Int32($0) }
+            let draftRows = drafts + [-1]                       // row D is the bonus (no draft)
+            guard let r = stepSample(verifyTokens, draftRows, invT, seed, basePos) else { return nil }
+
+            var p = 0
+            while p < D && r.accept[p] { p += 1 }
+
+            if p == D {
+                commit(u); for d in drafts { commit(d) }
+                u = r.full[D]                                   // bonus sample
+            } else {
+                backend.rollback(snap)
+                commit(u); for d in drafts.prefix(p) { commit(d) }
+                let rebuildTokens: [Int32] = [Int32(u)] + drafts.prefix(p).map { Int32($0) }
+                guard let _ = backend.forward(rebuildTokens) else { return nil }
+                u = r.resid[p]                                  // residual sample at reject row
             }
         }
         flush()

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -86,6 +86,19 @@ extension Tell {
         let snapshot: () -> Any
         let rollback: (Any) -> Void
         var chainedStepArgmax: ((Int32, Int) -> [Int]?)? = nil   // Phase II-a
+        // Option B (sampling): full logits per input row (readback), for speculative sampling.
+        // Additive — greedy stepArgmax path is untouched.
+        var stepLogitsRows: (([Int32]) -> [[Float]]?)? = nil
+    }
+
+    /// forward + lm_head logits, read back to CPU per row (for speculative sampling).
+    /// Mirrors makeStepArgmax but returns the full logits vector instead of the argmax index.
+    static func makeStepLogits(engine: SeedlessEngine, forward: @escaping ([Int32]) -> MLXArray?) -> ([Int32]) -> [[Float]]? {
+        return { tokens in
+            guard let n = forward(tokens), let l = engine.logits(n, M: tokens.count) else { return nil }
+            MLX.eval([l])
+            return (0 ..< tokens.count).map { l[$0].asArray(Float.self) }
+        }
     }
 
     /// forward+lm_head+MLX argMax による stepArgmax 合成(composed 用 fallback)。
@@ -151,6 +164,7 @@ extension Tell {
         if fwd.head != nil {
             backend.chainedStepArgmax = { token, k in fwd.chainedStepArgmax(token, K: k) }
         }
+        backend.stepLogitsRows = makeStepLogits(engine: engine, forward: forward)   // Option B sampling
         return (backend, fwd)
     }
 
@@ -388,6 +402,73 @@ extension Tell {
                     guard let _ = backend.forward(rebuildTokens) else { return nil }
                     u = evals[p]
                 }
+            }
+        }
+        flush()
+        return Array(out.prefix(N))
+    }
+
+    /// Option B (prototype): speculative-sampling decode. Same suffix-draft + snapshot/rollback
+    /// structure as the greedy non-A3 runSpecLoop, but accepts drafts by the modified rejection
+    /// rule (Sampler.acceptOrResample) so the emitted stream is distributed as the tempered/top_p
+    /// TARGET. Reduces EXACTLY to greedy at temperature 0 (byte-identical to runSpecLoop — the
+    /// small correctness gate). Requires backend.stepLogitsRows (logits readback).
+    static func runSpecSampleLoop(promptIds: [Int32], backend: SpecBackend, engine: SeedlessEngine,
+                                  N: Int, maxK: Int, temperature: Double, topP: Double, seed: UInt64,
+                                  isCancelled: (() -> Bool)? = nil,
+                                  onToken: ((Int) -> Void)? = nil) -> [Int]? {
+        guard let stepLogits = backend.stepLogitsRows else { return nil }
+        guard let lastNormed = prefill(promptIds: promptIds, backend: backend) else { return nil }
+        guard let lg0 = engine.logits(lastNormed, M: 1) else { return nil }
+        MLX.eval([lg0])
+        var rng = SplitMix64(seed: seed)
+        func draw(_ logits: [Float]) -> Int {
+            Sampler.categorical(Sampler.probs(logits: logits, temperature: temperature, topP: topP), rng: &rng)
+        }
+        var u = draw(lg0[0].asArray(Float.self))
+
+        var hist = promptIds.map { Int($0) }
+        var out: [Int] = []
+        var streamed = 0
+        func flush() { if let onToken { while streamed < out.count { onToken(out[streamed]); streamed += 1 } } }
+
+        while out.count < N && !(isCancelled?() ?? false) {
+            flush()
+            let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: 4)
+            let D = drafts.count
+            let snap = backend.snapshot()
+
+            if D == 0 {
+                guard let rows = stepLogits([Int32(u)]) else { return nil }
+                out.append(u); hist.append(u)
+                u = draw(rows[0])
+                continue
+            }
+
+            let verifyTokens: [Int32] = [Int32(u)] + drafts.map { Int32($0) }
+            guard let rows = stepLogits(verifyTokens) else { return nil }   // D+1 logits rows
+
+            // Accept the longest draft prefix under the rejection rule; on reject, `rejectTok`
+            // is the residual resample that replaces the first mismatched draft.
+            var p = 0
+            var rejectTok: Int? = nil
+            while p < D {
+                let pp = Sampler.probs(logits: rows[p], temperature: temperature, topP: topP)
+                let (accepted, resampled) = Sampler.acceptOrResample(p: pp, draft: drafts[p], rng: &rng)
+                if accepted { p += 1 } else { rejectTok = resampled; break }
+            }
+
+            if p == D {
+                out.append(u); hist.append(u)
+                for d in drafts { out.append(d); hist.append(d) }
+                u = draw(rows[D])                                    // bonus token
+            } else {
+                backend.rollback(snap)                              // undo the D+1 verify advance
+                out.append(u); hist.append(u)
+                for d in drafts.prefix(p) { out.append(d); hist.append(d) }
+                let rebuildTokens: [Int32] = [Int32(u)] + drafts.prefix(p).map { Int32($0) }
+                guard let _ = backend.forward(rebuildTokens) else { return nil }   // realize accepted prefix
+                u = rejectTok!
             }
         }
         flush()

--- a/swift/Sources/qwisp/ChatCompletion.swift
+++ b/swift/Sources/qwisp/ChatCompletion.swift
@@ -16,12 +16,15 @@ struct ChatCompletionRequest: Codable {
     let messages: [ChatMessage]
     let stream: Bool?
     let max_tokens: Int?
-    // temperature / top_p / seed are HONORED via speculative sampling (Option B).
-    // n > 1 is still ignored (single completion).
+    // temperature / top_p / seed / penalties / logit_bias are HONORED via speculative sampling
+    // (Option B). n > 1 is still ignored (single completion).
     let temperature: Double?
     let top_p: Double?
     let n: Int?
     let seed: Int?
+    let frequency_penalty: Double?
+    let presence_penalty: Double?
+    let logit_bias: [String: Double]?   // OpenAI: token-id string → bias
 }
 
 // ── Response (non-streaming) ─────────────────────────────────────────────────
@@ -50,13 +53,16 @@ struct ChatCompletionChunk: Codable {
 
 // ── CLI (`qwisp chat`) — thin in-process wrapper over the same core ──────────
 func runChat(prompt: String, tokenizer: QwispTokenizer, backend: any LLMBackend, maxTokens: Int,
-             temperature: Double = 0, topP: Double = 1.0, seed: UInt64 = 0) async {
+             temperature: Double = 0, topP: Double = 1.0, seed: UInt64 = 0,
+             frequencyPenalty: Double = 0, presencePenalty: Double = 0, logitBias: [Int: Double] = [:]) async {
     let promptIds: [Int]
     do { promptIds = try tokenizer.render(messages: [["role": "user", "content": prompt]]) }
     catch { fputs("chat: render error: \(error)\n", stderr); return }
     _ = await runGeneration(promptIds: promptIds, maxTokens: maxTokens, stopIds: tokenizer.stopTokenIds,
                             decode: { tokenizer.decode($0) }, backend: backend,
-                            temperature: temperature, topP: topP, seed: seed) { delta in
+                            temperature: temperature, topP: topP, seed: seed,
+                            frequencyPenalty: frequencyPenalty, presencePenalty: presencePenalty,
+                            logitBias: logitBias) { delta in
         fputs(delta, stdout); fflush(stdout)   // real-time token output
     }
     fputs("\n", stdout)
@@ -75,9 +81,13 @@ struct CompletionResult {
 func runGeneration(promptIds: [Int], maxTokens: Int, stopIds: [Int],
                    decode: ([Int]) -> String, backend: any LLMBackend,
                    temperature: Double = 0, topP: Double = 1.0, seed: UInt64 = 0,
+                   frequencyPenalty: Double = 0, presencePenalty: Double = 0,
+                   logitBias: [Int: Double] = [:],
                    onDelta: (String) -> Void) async -> CompletionResult {
     let opts = GenerateOptions(maxTokens: maxTokens, stopTokens: stopIds,
-                               temperature: temperature, topP: topP, seed: seed)
+                               temperature: temperature, topP: topP, seed: seed,
+                               frequencyPenalty: frequencyPenalty, presencePenalty: presencePenalty,
+                               logitBias: logitBias)
     var outIds: [Int] = []
     var emitted = ""
     var finish = "stop"

--- a/swift/Sources/qwisp/ChatCompletion.swift
+++ b/swift/Sources/qwisp/ChatCompletion.swift
@@ -16,10 +16,12 @@ struct ChatCompletionRequest: Codable {
     let messages: [ChatMessage]
     let stream: Bool?
     let max_tokens: Int?
-    // Accepted but IGNORED — the engine is lossless greedy (see runGeneration / server header).
+    // temperature / top_p / seed are HONORED via speculative sampling (Option B).
+    // n > 1 is still ignored (single completion).
     let temperature: Double?
     let top_p: Double?
     let n: Int?
+    let seed: Int?
 }
 
 // ── Response (non-streaming) ─────────────────────────────────────────────────
@@ -47,12 +49,14 @@ struct ChatCompletionChunk: Codable {
 }
 
 // ── CLI (`qwisp chat`) — thin in-process wrapper over the same core ──────────
-func runChat(prompt: String, tokenizer: QwispTokenizer, backend: any LLMBackend, maxTokens: Int) async {
+func runChat(prompt: String, tokenizer: QwispTokenizer, backend: any LLMBackend, maxTokens: Int,
+             temperature: Double = 0, topP: Double = 1.0, seed: UInt64 = 0) async {
     let promptIds: [Int]
     do { promptIds = try tokenizer.render(messages: [["role": "user", "content": prompt]]) }
     catch { fputs("chat: render error: \(error)\n", stderr); return }
     _ = await runGeneration(promptIds: promptIds, maxTokens: maxTokens, stopIds: tokenizer.stopTokenIds,
-                            decode: { tokenizer.decode($0) }, backend: backend) { delta in
+                            decode: { tokenizer.decode($0) }, backend: backend,
+                            temperature: temperature, topP: topP, seed: seed) { delta in
         fputs(delta, stdout); fflush(stdout)   // real-time token output
     }
     fputs("\n", stdout)
@@ -70,8 +74,10 @@ struct CompletionResult {
 /// maxTokens (finish_reason "length"). Transport-agnostic; GPU-free with a fake backend.
 func runGeneration(promptIds: [Int], maxTokens: Int, stopIds: [Int],
                    decode: ([Int]) -> String, backend: any LLMBackend,
+                   temperature: Double = 0, topP: Double = 1.0, seed: UInt64 = 0,
                    onDelta: (String) -> Void) async -> CompletionResult {
-    let opts = GenerateOptions(maxTokens: maxTokens, stopTokens: stopIds)
+    let opts = GenerateOptions(maxTokens: maxTokens, stopTokens: stopIds,
+                               temperature: temperature, topP: topP, seed: seed)
     var outIds: [Int] = []
     var emitted = ""
     var finish = "stop"

--- a/swift/Sources/qwisp/Server.swift
+++ b/swift/Sources/qwisp/Server.swift
@@ -55,9 +55,18 @@ final class QwispEngine: @unchecked Sendable {
         (req.n ?? 1) > 1
     }
 
+    struct SamplingParams {
+        var temperature: Double, topP: Double, seed: UInt64
+        var frequencyPenalty: Double, presencePenalty: Double, logitBias: [Int: Double]
+    }
     /// Resolve sampling from the request. temperature default 0 = greedy/lossless.
-    func sampling(_ req: ChatCompletionRequest) -> (temperature: Double, topP: Double, seed: UInt64) {
-        (req.temperature ?? 0, req.top_p ?? 1.0, UInt64(bitPattern: Int64(req.seed ?? 0)))
+    func sampling(_ req: ChatCompletionRequest) -> SamplingParams {
+        var bias: [Int: Double] = [:]
+        for (k, v) in req.logit_bias ?? [:] { if let t = Int(k) { bias[t] = v } }
+        return SamplingParams(temperature: req.temperature ?? 0, topP: req.top_p ?? 1.0,
+                              seed: UInt64(bitPattern: Int64(req.seed ?? 0)),
+                              frequencyPenalty: req.frequency_penalty ?? 0,
+                              presencePenalty: req.presence_penalty ?? 0, logitBias: bias)
     }
 
     private func prompt(_ req: ChatCompletionRequest) throws -> (ids: [Int], maxTokens: Int, stop: [Int]) {
@@ -73,7 +82,9 @@ final class QwispEngine: @unchecked Sendable {
         await lock.acquire()
         let r = await runGeneration(promptIds: p.ids, maxTokens: p.maxTokens, stopIds: p.stop,
                                     decode: { tokenizer.decode($0) }, backend: backend,
-                                    temperature: s.temperature, topP: s.topP, seed: s.seed) { _ in }
+                                    temperature: s.temperature, topP: s.topP, seed: s.seed,
+                                    frequencyPenalty: s.frequencyPenalty, presencePenalty: s.presencePenalty,
+                                    logitBias: s.logitBias) { _ in }
         await lock.release()
         let id = "chatcmpl-\(UUID().uuidString.prefix(24))"
         return ChatCompletionResponse(
@@ -105,7 +116,9 @@ final class QwispEngine: @unchecked Sendable {
         var outIds: [Int] = [], emitted = "", finish = "stop"
         let s = sampling(req)
         let opts = GenerateOptions(maxTokens: p.maxTokens, stopTokens: p.stop,
-                                   temperature: s.temperature, topP: s.topP, seed: s.seed)
+                                   temperature: s.temperature, topP: s.topP, seed: s.seed,
+                                   frequencyPenalty: s.frequencyPenalty, presencePenalty: s.presencePenalty,
+                                   logitBias: s.logitBias)
         for await tok in backend.generate(p.ids, options: opts) {
             if p.stop.contains(tok) { finish = "stop"; break }
             outIds.append(tok)

--- a/swift/Sources/qwisp/Server.swift
+++ b/swift/Sources/qwisp/Server.swift
@@ -49,9 +49,15 @@ final class QwispEngine: @unchecked Sendable {
         self.modelID = modelID
     }
 
-    /// True when the client sent sampling params the greedy engine ignores.
+    /// True when the client sent a param that is still unsupported (n > 1 only —
+    /// temperature/top_p/seed are now honored via speculative sampling).
     func samplingRequested(_ req: ChatCompletionRequest) -> Bool {
-        req.temperature != nil || req.top_p != nil || (req.n ?? 1) > 1
+        (req.n ?? 1) > 1
+    }
+
+    /// Resolve sampling from the request. temperature default 0 = greedy/lossless.
+    func sampling(_ req: ChatCompletionRequest) -> (temperature: Double, topP: Double, seed: UInt64) {
+        (req.temperature ?? 0, req.top_p ?? 1.0, UInt64(bitPattern: Int64(req.seed ?? 0)))
     }
 
     private func prompt(_ req: ChatCompletionRequest) throws -> (ids: [Int], maxTokens: Int, stop: [Int]) {
@@ -63,9 +69,11 @@ final class QwispEngine: @unchecked Sendable {
     /// Non-streaming completion.
     func complete(_ req: ChatCompletionRequest) async throws -> ChatCompletionResponse {
         let p = try prompt(req)
+        let s = sampling(req)
         await lock.acquire()
         let r = await runGeneration(promptIds: p.ids, maxTokens: p.maxTokens, stopIds: p.stop,
-                                    decode: { tokenizer.decode($0) }, backend: backend) { _ in }
+                                    decode: { tokenizer.decode($0) }, backend: backend,
+                                    temperature: s.temperature, topP: s.topP, seed: s.seed) { _ in }
         await lock.release()
         let id = "chatcmpl-\(UUID().uuidString.prefix(24))"
         return ChatCompletionResponse(
@@ -95,7 +103,9 @@ final class QwispEngine: @unchecked Sendable {
 
         try await send(Delta(role: "assistant", content: nil), nil)
         var outIds: [Int] = [], emitted = "", finish = "stop"
-        let opts = GenerateOptions(maxTokens: p.maxTokens, stopTokens: p.stop)
+        let s = sampling(req)
+        let opts = GenerateOptions(maxTokens: p.maxTokens, stopTokens: p.stop,
+                                   temperature: s.temperature, topP: s.topP, seed: s.seed)
         for await tok in backend.generate(p.ids, options: opts) {
             if p.stop.contains(tok) { finish = "stop"; break }
             outIds.append(tok)
@@ -124,7 +134,7 @@ func makeRouter(engine: QwispEngine, modelID: String) -> Router<BasicRequestCont
         let req = try await request.decode(as: ChatCompletionRequest.self, context: context)
         var headers = HTTPFields()
         if engine.samplingRequested(req) {
-            headers[warnHeader] = "sampling params ignored (greedy/lossless engine)"
+            headers[warnHeader] = "n > 1 ignored (single completion); temperature/top_p/seed are honored"
         }
         if req.stream == true {
             headers[.contentType] = "text/event-stream"
@@ -151,6 +161,6 @@ func runServe(engine: QwispEngine, modelID: String, port: Int) async throws {
         configuration: .init(address: .hostname("127.0.0.1", port: port))
     )
     print("qwisp serve → http://127.0.0.1:\(port)  (model: \(modelID))")
-    print("[qwisp serve] NOTE: sampling params (temperature/top_p/n) are ignored — greedy/lossless engine.")
+    print("[qwisp serve] NOTE: temperature/top_p/seed honored via speculative sampling (Option B); n>1 ignored. Default temperature 0 = greedy/lossless.")
     try await app.runService()
 }

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -46,8 +46,15 @@ case "chat":
         let temp = Double(env["QWISP_TEMP"] ?? "0") ?? 0
         let topP = Double(env["QWISP_TOPP"] ?? "1") ?? 1
         let seed = UInt64(env["QWISP_SEED"] ?? "0") ?? 0
+        let freqPen = Double(env["QWISP_FREQPEN"] ?? "0") ?? 0
+        let presPen = Double(env["QWISP_PRESPEN"] ?? "0") ?? 0
+        var bias: [Int: Double] = [:]   // QWISP_LOGIT_BIAS="tok:bias,tok:bias"
+        for pair in (env["QWISP_LOGIT_BIAS"] ?? "").split(separator: ",") {
+            let kv = pair.split(separator: ":"); if kv.count == 2, let t = Int(kv[0]), let b = Double(kv[1]) { bias[t] = b }
+        }
         await runChat(prompt: prompt, tokenizer: tok, backend: backend, maxTokens: maxTokens,
-                      temperature: temp, topP: topP, seed: seed)
+                      temperature: temp, topP: topP, seed: seed,
+                      frequencyPenalty: freqPen, presencePenalty: presPen, logitBias: bias)
     }
 case "selftest":
     print(await runTokenizerSelftest(modelDir: model))

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -41,12 +41,22 @@ case "chat":
             backend = try SeedlessBackend(modelDir: model)
         }
         let maxTokens = Int(ProcessInfo.processInfo.environment["QWISP_GEN"] ?? "512") ?? 512
-        await runChat(prompt: prompt, tokenizer: tok, backend: backend, maxTokens: maxTokens)
+        // Option B prototype knobs (the server uses the OpenAI API params instead).
+        let env = ProcessInfo.processInfo.environment
+        let temp = Double(env["QWISP_TEMP"] ?? "0") ?? 0
+        let topP = Double(env["QWISP_TOPP"] ?? "1") ?? 1
+        let seed = UInt64(env["QWISP_SEED"] ?? "0") ?? 0
+        await runChat(prompt: prompt, tokenizer: tok, backend: backend, maxTokens: maxTokens,
+                      temperature: temp, topP: topP, seed: seed)
     }
 case "selftest":
     print(await runTokenizerSelftest(modelDir: model))
 case "comptest":
     print(await runCompletionSelftest(modelDir: model))
+case "sampletest":
+    let (passed, total, log) = Sampler.selfCheck()   // GPU-free sampling-math check
+    print(log.joined(separator: "\n") + "\nSAMPLETEST \(passed)/\(total)")
+    if passed != total { exit(1) }
 default:
-    print("usage: qwisp [serve|chat|selftest]")
+    print("usage: qwisp [serve|chat|selftest|comptest|sampletest]")
 }

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -64,6 +64,10 @@ case "sampletest":
     let (passed, total, log) = Sampler.selfCheck()   // GPU-free sampling-math check
     print(log.joined(separator: "\n") + "\nSAMPLETEST \(passed)/\(total)")
     if passed != total { exit(1) }
+case "gpusampletest":
+    let (passed, total, log) = SamplerGPU.distributionSelfCheck()   // GPU kernel vs analytic softmax (no model)
+    print(log.joined(separator: "\n") + "\nGPUSAMPLETEST \(passed)/\(total)")
+    if passed != total { exit(1) }
 default:
     print("usage: qwisp [serve|chat|selftest|comptest|sampletest]")
 }


### PR DESCRIPTION
Prototype of **Option B** (per the sampling discussion): make `temperature`/`top_p`/`seed` actually work **without giving up speculative-decode speed**, by switching the draft-acceptance rule to **speculative sampling** (Leviathan/Chen 2023).

## The idea
qwisp's suffix draft is deterministic, so the draft distribution is `q = δ_draft`. Speculative sampling with `q(d)=1`:
- accept the drafted token `d` with probability `p(d)`,
- on reject, resample from the residual `norm(max(0, p − q))` = `p` with `d` zeroed & renormalized,
- on full accept, sample a bonus token from `p`.

`p` is the **tempered + top_p-truncated** target, so the emitted stream is distributed exactly as that target. Crucially the rule **reduces to greedy at temperature 0** (`p` one-hot at argmax → accept iff `d==argmax`) — so lossless is preserved and **T=0 is byte-identical to the current engine**. That equivalence is the small correctness gate.

## Frozen greedy path untouched (RAWTESTS 79/79)
- `Sampler.swift` — SplitMix64 RNG + softmax(temperature) + top_p nucleus + categorical + the accept rule. Pure/GPU-free; `qwisp sampletest`.
- `Tell.runSpecSampleLoop` — mirrors the greedy non-A3 `runSpecLoop` with the rejection accept; reuses `prefill`/`suffixDraft`/`snapshot`/`rollback`. **`runSpecLoop` and `stepArgmax` are unchanged.**
- `SpecBackend.stepLogitsRows` — full-logits readback built from the **existing** `forward` + `engine.logits` (no change to `SeedlessFusedVerify`). Prototype cost: per-position readback → sample-mode `maxK` capped at 8.
- Server/CLI honor `temperature`/`top_p`/`seed` (OpenAI params + `QWISP_TEMP`/`TOPP`/`SEED` for the CLI). `n>1` still ignored. **Default temperature 0 = greedy/lossless.**

## Verification (on-device)
| test | result |
|---|---|
| T=0: forced sample loop vs greedy | **BYTE-IDENTICAL** (maxK 8 vs 96) → accept rule correct, lossless preserved |
| T=2.0 top_p=1: vs greedy / across seeds | **differs / seed-varied**, same seed reproducible → genuinely sampling the tempered dist |
| `SAMPLETEST` | 7/7 (sampler math, GPU-free) |
| `RAWTESTS` / `BENCHBATCHTEST` / `COMPTEST` | 79/79 / PASS / 4/4 |

## Prototype scope / follow-ups
- Resident/fused tier; `temperature`+`top_p`+`seed`.
- Follow-ups: `presence/frequency_penalty` + `logit_bias` (CPU logit adjustments), and a **GPU sampler kernel** to lift the `maxK=8` cap (per-position CPU logits readback is the current cost) so sampling keeps full spec speed.

Branched from `main` (independent of the open `--max-tokens` / EOS-default PRs). Experiment per request — not necessarily for merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)