### PR TITLE
docs: refresh stale symbol names + main workflow in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ red strict cell.
 - **Lossless is defined at L1: bit-exact reproduction of the quantised greedy token stream.** The
   strict path is the reference; `bolt`/near-lossless is an opt-in speed tier. Never weaken the
   lossless definition to make a number look better.
-- **RAWTESTS 78/78 is the campaign-wide safety gate.** It must stay green through every
+- **RAWTESTS 79/79 is the campaign-wide safety gate.** It must stay green through every
   delete/rename/refactor commit. A red gate blocks the commit, not the other way around.
 - **Predictive levers lose to mechanical levers on the same slack** (engine doctrine, measured
   repeatedly). Don't re-propose prediction/prefetch schemes as speedups without new measurement.
@@ -86,12 +86,11 @@ red strict cell.
 ## Prohibitions
 
 1. Do not regenerate `refs/*.safetensors` from MLX or any non-raw-greedy source.
-2. Do not weaken, skip, or delete the locked tests (`swift/Sources/QwispCore/RawVerifyTests.swift`
-   57–78, `.locks/`). They are the lossless safety net.
-3. Do not rewrite the shipped forward path (RawSpecRunner / RawFusedVerify / RawMetalForward /
-   RawEngine / ExpertArena / ExpertSource + model layers). The productization pass **renames** it,
-   never rewrites it.
-4. Do not commit on `main` — it is the frozen pre-deletion snapshot. All work is on `feat/productize`.
+2. Do not weaken, skip, or delete the `WRITE-LOCKED` tests in
+   `swift/Sources/QwispCore/SeedlessVerifyTests.swift` (guarded by `total = 79`). They are the lossless safety net.
+3. Do not rewrite the shipped forward path (SeedlessEngine / SeedlessMetalForward / SeedlessFusedVerify /
+   Tell / ExpertArena / ExpertSource + model layers). It is frozen — refactor/rename only, never rewrite.
+4. Do not rewrite `main`'s history. Work on a topic branch (`claude/<topic>`, etc.) and open a PR to `main`.
 5. Do not run two `qwisp-poc` processes at once — the GPU is exclusive; heavy runs must be standalone.
 
 ## Git Conventions


### PR DESCRIPTION
## What

The Raw→Seedless rename shipped, but the doctrine doc (`AGENTS.md`; `CLAUDE.md` is a symlink to it) still named the pre-rename symbols and the retired frozen-`main` workflow. Verified against the actual code:

| Doc said (stale) | Reality |
|---|---|
| `RAWTESTS 78/78` | `total = 79` in `SeedlessVerifyTests.swift` |
| locked tests: `RawVerifyTests.swift` 57–78 + `.locks/` | neither exists → `WRITE-LOCKED` tests in `SeedlessVerifyTests.swift`, guarded by `total = 79` |
| forward path: `RawSpecRunner / RawFusedVerify / RawMetalForward / RawEngine` | `SeedlessEngine / SeedlessMetalForward / SeedlessFusedVerify / Tell` |
| "don't commit on `main`; work on `feat/productize`" (frozen snapshot) | `main` is the live PR target (frozen workflow ended when #13 merged) → don't rewrite `main`'s history; branch + PR |

## Why

Part of the pre-public cleanup — the doctrine doc is public-facing and pointed contributors at symbols/branches that don't exist.

## Notes

Docs-only, no code or gate impact. `CLAUDE.md → AGENTS.md` symlink, so one edit fixes both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)