### PR TITLE
feat(server): qwisp pull + config introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,39 +15,38 @@ can stream from flash on RAM-constrained machines, so a 35B model reaches smalle
 
 ## Requirements
 
-- **Apple Silicon Mac**, macOS 14+.
-- **Xcode with the Metal Toolchain** (the engine ships hand-written Metal kernels).
-- **The model** on disk — a Qwen3.6-35B-A3B MTPLX checkpoint (~20 GB), e.g.
-  [`Youssofal/Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16`](https://huggingface.co/Youssofal/Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16):
-
-  ```bash
-  hf download Youssofal/Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16 --local-dir ~/models/qwen3.6-a3b
-  ```
-
-  The directory must contain `config.json`, the `*.safetensors` shards, and `tokenizer.json` +
-  `chat_template.jinja`. Point qwisp at it three ways (most explicit wins): `QWISP_MODEL` env,
-  `~/.config/qwisp/config.json` (`{"model": "...", "port": 8080}`), or drop it at the default path
-  `~/.mtplx/models/Youssofal--Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16` for zero config.
+- **Apple Silicon Mac**, macOS 14+. The Homebrew binary is self-contained; **Xcode 26 / Swift 6.3**
+  is needed only to build from source.
+- **A model** (~20 GB) — a Qwen3.6-35B-A3B MTPLX checkpoint. `qwisp pull` downloads the default
+  ([`Youssofal/Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16`](https://huggingface.co/Youssofal/Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16))
+  and writes the config for you (see Quickstart). You can also point qwisp at an existing checkpoint
+  via `QWISP_MODEL` or `~/.config/qwisp/config.json`.
 - RAM sets the tier automatically: `<32 GB` streams experts from flash; `≥32 GB` keeps everything
   resident (fastest decode). 16 GB is the practical floor for interactive use.
 
 ## Quickstart
 
 ```bash
-# Build (Release; Metal Toolchain required; ~minutes on first build)
+brew install penta2himajin/qwisp/qwisp     # Apple Silicon, macOS 14+
+
+qwisp pull                                 # download the default model (~20 GB) + write config
+                                           #   …or: qwisp pull <hf-repo-id>
+
+qwisp chat "Explain MoE routing in two sentences."
+qwisp chat --max-tokens 256 "…"            # cap length (default: until EOS / context)
+
+qwisp serve                                # OpenAI-compatible server on :8080 (QWISP_PORT to change)
+brew services start qwisp                  #   …or run it as a resident background service
+
+qwisp config                               # show effective settings + where each value came from
+```
+
+Build from source instead (needs Xcode 26 / Swift 6.3):
+
+```bash
 cd swift && xcodebuild build -scheme qwisp -configuration Release \
   -destination 'platform=macOS' -derivedDataPath ./.xcode-build-rel -skipPackagePluginValidation
-BIN=swift/.xcode-build-rel/Build/Products/Release/qwisp
-
-export QWISP_MODEL=~/models/qwen3.6-a3b    # the model dir (or set it in ~/.config/qwisp/config.json)
-
-# OpenAI-compatible server (QWISP_PORT, default 8080)
-"$BIN" serve
-
-# CLI (in-process, streams to stdout). By default it generates until EOS / context;
-# --max-tokens N caps the length (like mlx-lm; -1 = unlimited, the default).
-"$BIN" chat "Explain MoE routing in two sentences."
-"$BIN" chat --max-tokens 256 "Explain MoE routing in two sentences."
+# binary at swift/.xcode-build-rel/Build/Products/Release/qwisp
 ```
 
 Talk to the server with any OpenAI client:

--- a/swift/Sources/qwisp/Config.swift
+++ b/swift/Sources/qwisp/Config.swift
@@ -6,12 +6,22 @@ import Foundation
 //   1. QWISP_MODEL / QWISP_PORT env      (dev + scripts override)
 //   2. ~/.config/qwisp/config.json       {"model": "...", "port": 8080}   (the resident source)
 //   3. built-in default                  (drop the model at ~/.mtplx/… and it just works)
-struct QwispConfig: Decodable {
+//
+// Defaults live in code (below), NOT materialized into the user's file — the file stays a sparse
+// override, so a new qwisp version's improved defaults aren't frozen out by a stale on-disk copy.
+// `qwisp config` prints the effective values; `qwisp config --defaults` emits the full default set
+// (generated here, never stale) for anyone who wants to pin one explicitly.
+struct QwispConfig: Codable {
     var model: String?
     var port: Int?
 }
 
 enum Config {
+    // ── defaults (the SSoT) ──────────────────────────────────────────────
+    static let defaultModel = FileManager.default.homeDirectoryForCurrentUser.path
+        + "/.mtplx/models/Youssofal--Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16"
+    static let defaultPort = 8080
+
     static var defaultPath: String {
         FileManager.default.homeDirectoryForCurrentUser.path + "/.config/qwisp/config.json"
     }
@@ -33,6 +43,44 @@ enum Config {
         return config.port ?? def
     }
 
+    // Where each effective value came from — for `qwisp config` transparency.
+    static func sourceOfModel(env: [String: String], config: QwispConfig) -> String {
+        env["QWISP_MODEL"] != nil ? "env" : (config.model != nil ? "config" : "default")
+    }
+    static func sourceOfPort(env: [String: String], config: QwispConfig) -> String {
+        if let e = env["QWISP_PORT"], Int(e) != nil { return "env" }
+        return config.port != nil ? "config" : "default"
+    }
+
+    // Write ONLY the model key, preserving any other keys already in the file (sparse override).
+    static func writeModel(_ path: String, to cfgPath: String = defaultPath) throws {
+        var cfg = load(path: cfgPath)
+        cfg.model = path
+        let dir = (cfgPath as NSString).deletingLastPathComponent
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let enc = JSONEncoder(); enc.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        try enc.encode(cfg).write(to: URL(fileURLWithPath: cfgPath))
+    }
+
+    // Full default set as JSON — generated from the defaults above, so it can never be stale
+    // relative to this binary. `qwisp config --defaults`.
+    static func defaultsJSON() -> String {
+        let enc = JSONEncoder(); enc.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let full = QwispConfig(model: defaultModel, port: defaultPort)
+        return (try? enc.encode(full)).flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+    }
+
+    // Human-readable effective config with per-key provenance. `qwisp config`.
+    static func effectiveReport(env: [String: String], config: QwispConfig, path: String) -> String {
+        let m = resolveModel(env: env, config: config, default: defaultModel)
+        let p = resolvePort(env: env, config: config, default: defaultPort)
+        return """
+        config file: \(path)\(FileManager.default.fileExists(atPath: path) ? "" : "  (not present)")
+          model = \(m)  [\(sourceOfModel(env: env, config: config))]
+          port  = \(p)  [\(sourceOfPort(env: env, config: config))]
+        """
+    }
+
     // GPU-free, model-free self-check — the CONFIGTEST gate.
     static func selfCheck() -> (Int, Int, [String]) {
         var passed = 0, total = 0, log: [String] = []
@@ -50,6 +98,17 @@ enum Config {
         check("default port",      resolvePort(env: [:], config: empty, default: 8080) == 8080)
         check("bad env port → config", resolvePort(env: ["QWISP_PORT": "nope"], config: cfg, default: 8080) == 9)
 
+        // source attribution
+        check("source model env",     sourceOfModel(env: ["QWISP_MODEL": "/m"], config: cfg) == "env")
+        check("source model config",  sourceOfModel(env: [:], config: cfg) == "config")
+        check("source model default", sourceOfModel(env: [:], config: empty) == "default")
+        check("source port default",  sourceOfPort(env: [:], config: empty) == "default")
+        check("source port env",      sourceOfPort(env: ["QWISP_PORT": "1"], config: empty) == "env")
+
+        // defaultsJSON carries both keys
+        let dj = defaultsJSON()
+        check("defaults json has model+port", dj.contains("\"model\"") && dj.contains("\"port\"") && dj.contains("8080"))
+
         // load(): missing file and malformed JSON both yield empty config, no throw.
         let tmp = NSTemporaryDirectory() + "qwisp-configtest-\(getpid())"
         check("missing file → empty", load(path: tmp + "/nope.json").model == nil)
@@ -58,7 +117,16 @@ enum Config {
         try? #"{"model":"/x","port":7}"#.write(toFile: tmp + ".json", atomically: true, encoding: .utf8)
         let good = load(path: tmp + ".json")
         check("valid json parsed", good.model == "/x" && good.port == 7)
+
+        // writeModel: sets model, preserves the existing port, round-trips.
+        let wpath = tmp + "-write.json"
+        try? #"{"port":1234}"#.write(toFile: wpath, atomically: true, encoding: .utf8)
+        try? writeModel("/new/model", to: wpath)
+        let after = load(path: wpath)
+        check("writeModel sets model", after.model == "/new/model")
+        check("writeModel keeps port", after.port == 1234)
         try? FileManager.default.removeItem(atPath: tmp + ".json")
+        try? FileManager.default.removeItem(atPath: wpath)
 
         return (passed, total, log)
     }

--- a/swift/Sources/qwisp/Pull.swift
+++ b/swift/Sources/qwisp/Pull.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Hub
+
+// Model acquisition. `qwisp pull` downloads a checkpoint via swift-transformers' HubApi
+// (already linked — no python / hf CLI needed) and writes its path into the config file.
+// chat/serve reuse `ensureModel` to nudge the user when no model is present.
+enum ModelStore {
+    static let defaultRepo = "Youssofal/Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16"
+
+    // A directory is a usable model if it holds a config.json (the checkpoint manifest).
+    static func isModel(_ path: String) -> Bool {
+        FileManager.default.fileExists(atPath: path + "/config.json")
+    }
+
+    // Download `repo` and point the config file at it. Returns the local model path.
+    static func pull(repo: String = defaultRepo) async throws -> String {
+        let sizeNote = repo == defaultRepo ? " (~20 GB — this takes a while)" : ""
+        FileHandle.standardError.write(Data("Downloading \(repo)\(sizeNote)…\n".utf8))
+        let hub = HubApi()
+        var lastPct = -1
+        let url = try await hub.snapshot(from: repo, matching: []) { progress in
+            let pct = Int(progress.fractionCompleted * 100)
+            if pct != lastPct {
+                lastPct = pct
+                FileHandle.standardError.write(Data("\r  \(pct)%   ".utf8))
+            }
+        }
+        FileHandle.standardError.write(Data("\r  100%\n".utf8))
+        let path = url.path
+        try Config.writeModel(path)
+        FileHandle.standardError.write(Data("Model ready: \(path)\n→ wrote \(Config.defaultPath)\n".utf8))
+        return path
+    }
+
+    // Resolve the model, and if it's absent decide what to do based on interactivity.
+    //  - interactive TTY: offer to pull now (y/N); on yes, download and return the new path.
+    //  - non-interactive (pipe) or a daemon: return nil (caller prints the hint and exits).
+    // `allowPrompt` is false for `serve` — a LaunchAgent has no TTY, must never block.
+    static func ensureModel(_ path: String, allowPrompt: Bool) async -> String? {
+        if isModel(path) { return path }
+        guard allowPrompt, isatty(STDIN_FILENO) != 0 else { return nil }
+        FileHandle.standardError.write(Data(
+            "No model found at \(path).\nDownload \(defaultRepo) (~20 GB) now? [y/N] ".utf8))
+        let answer = readLine(strippingNewline: true)?.lowercased() ?? ""
+        guard answer == "y" || answer == "yes" else { return nil }
+        return try? await pull()
+    }
+
+    static let missingModelHint = """
+    No model found. Get one with:
+        qwisp pull                 # default checkpoint (~20 GB) → writes ~/.config/qwisp/config.json
+        qwisp pull <hf-repo-id>    # a specific checkpoint
+    Or point qwisp at an existing directory via QWISP_MODEL or ~/.config/qwisp/config.json.
+    """
+}

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -8,14 +8,17 @@ import QwispCore
 // Scaffold: proves the dependency graph (Hummingbird + swift-transformers) resolves
 // and links. `serve` / `chat` are wired in follow-up sub-steps.
 
-let defaultModel = "\(FileManager.default.homeDirectoryForCurrentUser.path)/.mtplx/models/Youssofal--Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16"
 let qwispConfig = Config.load(path: Config.defaultPath)
-let model = Config.resolveModel(env: ProcessInfo.processInfo.environment, config: qwispConfig, default: defaultModel)
+let model = Config.resolveModel(env: ProcessInfo.processInfo.environment, config: qwispConfig, default: Config.defaultModel)
 
 let args = Array(CommandLine.arguments.dropFirst())
 switch args.first {
 case "serve":
-    let port = Config.resolvePort(env: ProcessInfo.processInfo.environment, config: qwispConfig, default: 8080)
+    let port = Config.resolvePort(env: ProcessInfo.processInfo.environment, config: qwispConfig, default: Config.defaultPort)
+    // A daemon has no TTY — never prompt. Missing model → fail fast with the hint.
+    if ProcessInfo.processInfo.environment["QWISP_FAKE"] != "1" && !ModelStore.isModel(model) {
+        FileHandle.standardError.write(Data((ModelStore.missingModelHint + "\n").utf8)); exit(1)
+    }
     let modelID = URL(fileURLWithPath: model).lastPathComponent
     let tok = try await QwispTokenizer(modelDir: model)
     let backend: any LLMBackend
@@ -50,16 +53,25 @@ case "chat":
     if prompt.isEmpty {
         print("usage: qwisp chat [--max-tokens N] <prompt>   (or pipe text via stdin)")
     } else {
-        let tok = try await QwispTokenizer(modelDir: model)
+        let env = ProcessInfo.processInfo.environment
+        // Ensure a model is present; interactively offer to pull one if not (TTY only).
+        let effModel: String
+        if env["QWISP_FAKE"] == "1" {
+            effModel = model
+        } else if let m = await ModelStore.ensureModel(model, allowPrompt: true) {
+            effModel = m
+        } else {
+            FileHandle.standardError.write(Data((ModelStore.missingModelHint + "\n").utf8)); exit(1)
+        }
+        let tok = try await QwispTokenizer(modelDir: effModel)
         let backend: any LLMBackend
-        if ProcessInfo.processInfo.environment["QWISP_FAKE"] == "1" {
+        if env["QWISP_FAKE"] == "1" {
             backend = FakeBackend(script: tok.encode("(fake backend) hello from qwisp chat."))
         } else {
-            backend = try SeedlessBackend(modelDir: model)
+            backend = try SeedlessBackend(modelDir: effModel)
         }
         // Option B sampling knobs (the server uses the OpenAI API params instead).
         // maxTokens comes from the --max-tokens flag above (default -1 = until EOS/context).
-        let env = ProcessInfo.processInfo.environment
         let temp = Double(env["QWISP_TEMP"] ?? "0") ?? 0
         let topP = Double(env["QWISP_TOPP"] ?? "1") ?? 1
         let seed = UInt64(env["QWISP_SEED"] ?? "0") ?? 0
@@ -89,6 +101,19 @@ case "configtest":
     let (passed, total, log) = Config.selfCheck()   // model/port resolution + config load (no GPU, no model)
     print(log.joined(separator: "\n") + "\nCONFIGTEST \(passed)/\(total)")
     if passed != total { exit(1) }
+case "pull":
+    // qwisp pull [hf-repo-id] — download a checkpoint (default: Qwen3.6-35B-A3B MTPLX) and
+    // point ~/.config/qwisp/config.json at it.
+    let repo = args.dropFirst().first ?? ModelStore.defaultRepo
+    _ = try await ModelStore.pull(repo: repo)
+case "config":
+    // qwisp config           — effective config with per-key provenance
+    // qwisp config --defaults — full default set as JSON (for pinning explicitly)
+    if args.dropFirst().first == "--defaults" {
+        print(Config.defaultsJSON())
+    } else {
+        print(Config.effectiveReport(env: ProcessInfo.processInfo.environment, config: qwispConfig, path: Config.defaultPath))
+    }
 default:
-    print("usage: qwisp [serve|chat|selftest|comptest|sampletest|configtest]")
+    print("usage: qwisp [serve|chat|pull|config|selftest|comptest|sampletest|configtest]")
 }


### PR DESCRIPTION
## What

Ships the 0.1.1 UX: in-process model acquisition + transparent config.

### `qwisp pull [hf-repo-id]`
Downloads a checkpoint via swift-transformers `HubApi` (already linked — **no python / `hf` CLI**) and writes `~/.config/qwisp/config.json` pointing at it. Default repo = `Youssofal/Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16`.

### Missing-model nudge
- `chat`: if no model and stdin is a **TTY**, offer to pull now (`y/N`); non-interactive → hint + exit.
- `serve`: a `brew services` daemon has **no TTY** → never prompts, fails fast with the hint. (This is why `pull` is a real command, not an implicit auto-download.)

### `qwisp config`
- `qwisp config` — effective settings with per-key provenance (`env` / `config` / `default`).
- `qwisp config --defaults` — full default set as JSON, generated from code so it's **never stale** vs the binary.

Defaults stay in **code** (the SSoT); the config file is a **sparse override**. We deliberately do *not* materialize all defaults into the user's file — that would freeze a version's defaults on disk and silently override future improvements. `writeModel` preserves other keys.

## Verification

- CONFIGTEST **10 → 18** (source attribution, defaults JSON, `writeModel` round-trip).
- `pull` machinery validated end-to-end against a tiny repo (download → `writeModel` → `config` shows `[config]`); test artifacts cleaned.
- Additive to the `qwisp` target, **engine untouched** → RAWTESTS **79/79**, BENCHBATCHTEST **PASS**.
- README Quickstart updated: `brew install` → `qwisp pull` → `qwisp chat` / `qwisp config`.

Ships as **v0.1.1** via `scripts/release.sh` (#23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)