### PR TITLE
fix(server): separate reasoning from content (Qwen3.6 <think> leak)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ sampling on the GPU, at near-greedy speed. `temperature: 0` (the default) stays 
 bit-exact to the strict greedy path. `n > 1` is ignored (single completion) and sets an
 `x-qwisp-warning` header; `tools` and `logprobs` are not supported.
 
+**Reasoning is separated.** Qwen3.6 thinks before answering; qwisp splits that out so `content`
+is the clean answer and the thinking goes to `reasoning_content` (`delta.reasoning_content` when
+streaming) — it never leaks into `content`. Give reasoning models a generous `max_tokens`: a small
+cap can be spent entirely on thinking, leaving `content` empty.
+
 ## Architecture
 
 ```

--- a/swift/Sources/qwisp/ChatCompletion.swift
+++ b/swift/Sources/qwisp/ChatCompletion.swift
@@ -27,8 +27,19 @@ struct ChatCompletionRequest: Codable {
     let logit_bias: [String: Double]?   // OpenAI: token-id string → bias
 }
 
+// Qwen3.6 is a reasoning model: the chat template injects `<think>` into the generation prompt,
+// so the model emits `[reasoning]</think>[answer]`. Split that so `content` is the clean answer
+// and the thinking goes to `reasoning_content` (DeepSeek convention) instead of leaking into
+// `content`. There is no plain-content phase before `</think>`, so an output that hasn't produced
+// `</think>` yet is treated as all-reasoning (empty content).
+func splitThink(_ s: String) -> (reasoning: String, content: String) {
+    guard let r = s.range(of: "</think>") else { return (s, "") }
+    let content = String(s[r.upperBound...]).drop(while: { $0 == "\n" })
+    return (String(s[..<r.lowerBound]), String(content))
+}
+
 // ── Response (non-streaming) ─────────────────────────────────────────────────
-struct ResponseMessage: Codable { let role: String; let content: String }
+struct ResponseMessage: Codable { let role: String; let content: String; var reasoning_content: String? = nil }
 struct Choice: Codable { let index: Int; let message: ResponseMessage; let finish_reason: String }
 struct Usage: Codable { let prompt_tokens: Int; let completion_tokens: Int; let total_tokens: Int }
 struct ChatCompletionResponse: Codable {
@@ -41,7 +52,7 @@ struct ChatCompletionResponse: Codable {
 }
 
 // ── Response (streaming chunk) ───────────────────────────────────────────────
-struct Delta: Codable { var role: String?; var content: String? }
+struct Delta: Codable { var role: String? = nil; var content: String? = nil; var reasoning_content: String? = nil }
 struct ChunkChoice: Codable { let index: Int; let delta: Delta; let finish_reason: String? }
 struct ChatCompletionChunk: Codable {
     let id: String
@@ -58,12 +69,22 @@ func runChat(prompt: String, tokenizer: QwispTokenizer, backend: any LLMBackend,
     let promptIds: [Int]
     do { promptIds = try tokenizer.render(messages: [["role": "user", "content": prompt]]) }
     catch { fputs("chat: render error: \(error)\n", stderr); return }
+    // Route the reasoning to stderr and the answer to stdout, so `qwisp chat … > file` captures
+    // only the answer while the thinking still streams to the terminal.
+    var full = "", sentR = "", sentC = ""
     _ = await runGeneration(promptIds: promptIds, maxTokens: maxTokens, stopIds: tokenizer.stopTokenIds,
                             decode: { tokenizer.decode($0) }, backend: backend,
                             temperature: temperature, topP: topP, seed: seed,
                             frequencyPenalty: frequencyPenalty, presencePenalty: presencePenalty,
                             logitBias: logitBias) { delta in
-        fputs(delta, stdout); fflush(stdout)   // real-time token output
+        full += delta
+        let (r, c) = splitThink(full)
+        if r.count > sentR.count, r.hasPrefix(sentR) {
+            FileHandle.standardError.write(Data(String(r.dropFirst(sentR.count)).utf8)); sentR = r
+        }
+        if c.count > sentC.count, c.hasPrefix(sentC) {
+            fputs(String(c.dropFirst(sentC.count)), stdout); fflush(stdout); sentC = c
+        }
     }
     fputs("\n", stdout)
 }

--- a/swift/Sources/qwisp/Selftest.swift
+++ b/swift/Sources/qwisp/Selftest.swift
@@ -63,6 +63,13 @@ func runCompletionSelftest(modelDir: String) async -> String {
                                  decode: decode, backend: FakeBackend(script: helloIds)) { streamed += $0 }
     check("delta_concat", streamed == r4.text && !streamed.isEmpty)
 
+    // 5-7. splitThink: reasoning/content separation (pure; Qwen3.6 <think> handling).
+    let sp = splitThink("weighing options</think>\n\nThe answer is 42.")
+    check("think_split_content", sp.content == "The answer is 42.")
+    check("think_split_reasoning", sp.reasoning == "weighing options")
+    let sp2 = splitThink("still thinking")
+    check("think_no_close_all_reasoning", sp2.reasoning == "still thinking" && sp2.content == "")
+
     return lines.joined(separator: "\n") + "\nCOMPTEST \(passed)/\(total)"
 }
 

--- a/swift/Sources/qwisp/Server.swift
+++ b/swift/Sources/qwisp/Server.swift
@@ -87,9 +87,11 @@ final class QwispEngine: @unchecked Sendable {
                                     logitBias: s.logitBias) { _ in }
         await lock.release()
         let id = "chatcmpl-\(UUID().uuidString.prefix(24))"
+        let (reasoning, content) = splitThink(r.text)
         return ChatCompletionResponse(
             id: id, created: Int(Date().timeIntervalSince1970), model: modelID,
-            choices: [Choice(index: 0, message: ResponseMessage(role: "assistant", content: r.text),
+            choices: [Choice(index: 0, message: ResponseMessage(role: "assistant", content: content,
+                                                                reasoning_content: reasoning.isEmpty ? nil : reasoning),
                              finish_reason: r.finishReason)],
             usage: Usage(prompt_tokens: p.ids.count, completion_tokens: r.completionTokens,
                          total_tokens: p.ids.count + r.completionTokens))
@@ -112,8 +114,8 @@ final class QwispEngine: @unchecked Sendable {
         await lock.acquire()
         defer { Task { await lock.release() } }
 
-        try await send(Delta(role: "assistant", content: nil), nil)
-        var outIds: [Int] = [], emitted = "", finish = "stop"
+        try await send(Delta(role: "assistant"), nil)
+        var outIds: [Int] = [], sentR = "", sentC = "", finish = "stop"
         let s = sampling(req)
         let opts = GenerateOptions(maxTokens: p.maxTokens, stopTokens: p.stop,
                                    temperature: s.temperature, topP: s.topP, seed: s.seed,
@@ -122,13 +124,17 @@ final class QwispEngine: @unchecked Sendable {
         for await tok in backend.generate(p.ids, options: opts) {
             if p.stop.contains(tok) { finish = "stop"; break }
             outIds.append(tok)
-            let full = tokenizer.decode(outIds)
-            let d = full.hasPrefix(emitted) ? String(full[emitted.endIndex...]) : full
-            emitted = full
-            if !d.isEmpty { try await send(Delta(role: nil, content: d), nil) }
+            // Split thinking from answer: reasoning → delta.reasoning_content, answer → delta.content.
+            let (r, c) = splitThink(tokenizer.decode(outIds))
+            if r.count > sentR.count, r.hasPrefix(sentR) {
+                try await send(Delta(reasoning_content: String(r.dropFirst(sentR.count))), nil); sentR = r
+            }
+            if c.count > sentC.count, c.hasPrefix(sentC) {
+                try await send(Delta(content: String(c.dropFirst(sentC.count))), nil); sentC = c
+            }
             if p.maxTokens >= 0 && outIds.count >= p.maxTokens { finish = "length"; break }  // <0 = until EOS/context
         }
-        try await send(Delta(role: nil, content: nil), finish)
+        try await send(Delta(), finish)
         try await writer.write(ByteBuffer(string: "data: [DONE]\n\n"))
     }
 }


### PR DESCRIPTION
## Problem

Qwen3.6 is a reasoning model; its chat template injects `<think>` into the generation prompt, so the model emits `[reasoning]</think>[answer]`. qwisp put the **whole** thing into `content`, so the thinking leaked into the visible response (seen in opencode).

## Fix

Split on `</think>`: `content` is the clean answer, thinking → `reasoning_content` (DeepSeek convention). No `</think>` yet ⇒ still reasoning (empty content).

- **non-streaming**: `message.content` / `message.reasoning_content`
- **streaming**: `delta.reasoning_content` chunks, then `delta.content` chunks
- **CLI `qwisp chat`**: answer → stdout, thinking → stderr (so `qwisp chat … > file` captures only the answer)

## Verified against the live server

```json
{ "content": "4", "reasoning_head": "Thinking Process:\n1. …", "has_think_leak": false }
```
Streaming: `reasoning_content` deltas first, `content` ("4") last.

## Notes

- **Reasoning models need a generous `max_tokens`** — a small cap can be spent entirely on thinking, leaving `content` empty (documented in README).
- Additive to the `qwisp` target, **engine untouched** → RAWTESTS **79/79**, BENCHBATCHTEST **PASS**, COMPTEST **4 → 7** (`splitThink` unit checks).

Ships as **v0.1.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)