### PR TITLE
feat(server): OpenAI function calling (tools / tool_calls)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,12 @@ curl -N http://127.0.0.1:8080/v1/chat/completions \
 `frequency_penalty`, `presence_penalty`, and `logit_bias` all take effect — via speculative
 sampling on the GPU, at near-greedy speed. `temperature: 0` (the default) stays deterministic and
 bit-exact to the strict greedy path. `n > 1` is ignored (single completion) and sets an
-`x-qwisp-warning` header; `tools` and `logprobs` are not supported.
+`x-qwisp-warning` header; `logprobs` is not supported.
+
+**Function calling is supported.** Pass `tools` (OpenAI function specs); the model's calls come
+back as `tool_calls` with `finish_reason: "tool_calls"`, and `role: "tool"` results feed back for
+the next turn — so agentic clients work. Parameter values are coerced to JSON scalars best-effort;
+streaming emits `tool_calls` once the call is complete (not token-incremental).
 
 **Reasoning is separated.** Qwen3.6 thinks before answering; qwisp splits that out so `content`
 is the clean answer and the thinking goes to `reasoning_content` (`delta.reasoning_content` when

--- a/swift/Sources/qwisp/ChatCompletion.swift
+++ b/swift/Sources/qwisp/ChatCompletion.swift
@@ -8,7 +8,10 @@ import QwispCore
 // ── Request ────────────────────────────────────────────────────────────────
 struct ChatMessage: Codable {
     let role: String
-    let content: String
+    let content: String?                // nil for assistant messages that are only tool_calls
+    var tool_calls: [ReqToolCall]? = nil // assistant → previous function calls (history)
+    var tool_call_id: String? = nil      // role:"tool" → which call this result answers
+    var name: String? = nil
 }
 
 struct ChatCompletionRequest: Codable {
@@ -25,6 +28,8 @@ struct ChatCompletionRequest: Codable {
     let frequency_penalty: Double?
     let presence_penalty: Double?
     let logit_bias: [String: Double]?   // OpenAI: token-id string → bias
+    var tools: [Tool]? = nil            // function-calling tool specs
+    var tool_choice: JSONValue? = nil   // accepted; the model decides (auto)
 }
 
 // Qwen3.6 is a reasoning model: the chat template injects `<think>` into the generation prompt,
@@ -39,7 +44,12 @@ func splitThink(_ s: String) -> (reasoning: String, content: String) {
 }
 
 // ── Response (non-streaming) ─────────────────────────────────────────────────
-struct ResponseMessage: Codable { let role: String; let content: String; var reasoning_content: String? = nil }
+struct ResponseMessage: Codable {
+    let role: String
+    var content: String? = nil          // nil when the turn is only tool_calls
+    var reasoning_content: String? = nil
+    var tool_calls: [ToolCall]? = nil
+}
 struct Choice: Codable { let index: Int; let message: ResponseMessage; let finish_reason: String }
 struct Usage: Codable { let prompt_tokens: Int; let completion_tokens: Int; let total_tokens: Int }
 struct ChatCompletionResponse: Codable {
@@ -52,7 +62,7 @@ struct ChatCompletionResponse: Codable {
 }
 
 // ── Response (streaming chunk) ───────────────────────────────────────────────
-struct Delta: Codable { var role: String? = nil; var content: String? = nil; var reasoning_content: String? = nil }
+struct Delta: Codable { var role: String? = nil; var content: String? = nil; var reasoning_content: String? = nil; var tool_calls: [ToolCallDelta]? = nil }
 struct ChunkChoice: Codable { let index: Int; let delta: Delta; let finish_reason: String? }
 struct ChatCompletionChunk: Codable {
     let id: String

--- a/swift/Sources/qwisp/QwispTokenizer.swift
+++ b/swift/Sources/qwisp/QwispTokenizer.swift
@@ -35,12 +35,13 @@ struct QwispTokenizer {
         tokenizer.decode(tokens: ids, skipSpecialTokens: true)
     }
 
-    /// Render chat messages → token ids (chat_template + generation prompt).
-    func render(messages: [[String: String]]) throws -> [Int] {
-        let msgs: [Message] = messages.map { $0.mapValues { $0 as any Sendable } }
-        if let chatTemplate {
-            return try tokenizer.applyChatTemplate(messages: msgs, chatTemplate: chatTemplate)
-        }
-        return try tokenizer.applyChatTemplate(messages: msgs)
+    /// Render chat messages (+ optional tool specs) → token ids (chat_template + generation prompt).
+    /// Messages/tools are `[String: any Sendable]` so they can carry tool_calls, tool results, and
+    /// arbitrary tool JSON schemas through to the Jinja template.
+    func render(messages: [[String: any Sendable]], tools: [[String: any Sendable]]? = nil) throws -> [Int] {
+        let ct: ChatTemplateArgument? = chatTemplate.map { .literal($0) }
+        return try tokenizer.applyChatTemplate(messages: messages, chatTemplate: ct,
+                                               addGenerationPrompt: true, truncation: false,
+                                               maxLength: nil, tools: tools)
     }
 }

--- a/swift/Sources/qwisp/Selftest.swift
+++ b/swift/Sources/qwisp/Selftest.swift
@@ -70,6 +70,9 @@ func runCompletionSelftest(modelDir: String) async -> String {
     let sp2 = splitThink("still thinking")
     check("think_no_close_all_reasoning", sp2.reasoning == "still thinking" && sp2.content == "")
 
+    // 8+. tool-call parsing (pure; Qwen3.6 <tool_call> → OpenAI tool_calls).
+    for (name, ok) in ToolParse.selfCheck() { check("tool_\(name)", ok) }
+
     return lines.joined(separator: "\n") + "\nCOMPTEST \(passed)/\(total)"
 }
 

--- a/swift/Sources/qwisp/Server.swift
+++ b/swift/Sources/qwisp/Server.swift
@@ -70,8 +70,8 @@ final class QwispEngine: @unchecked Sendable {
     }
 
     private func prompt(_ req: ChatCompletionRequest) throws -> (ids: [Int], maxTokens: Int, stop: [Int]) {
-        let msgs = req.messages.map { ["role": $0.role, "content": $0.content] }
-        let ids = try tokenizer.render(messages: msgs)
+        let msgs = req.messages.map { $0.renderDict }
+        let ids = try tokenizer.render(messages: msgs, tools: req.tools?.map { $0.spec })
         return (ids, req.max_tokens ?? -1, tokenizer.stopTokenIds)   // omitted → until EOS/context
     }
 
@@ -87,12 +87,15 @@ final class QwispEngine: @unchecked Sendable {
                                     logitBias: s.logitBias) { _ in }
         await lock.release()
         let id = "chatcmpl-\(UUID().uuidString.prefix(24))"
-        let (reasoning, content) = splitThink(r.text)
+        let (reasoning, afterThink) = splitThink(r.text)
+        let (content, toolCalls) = ToolParse.parse(afterThink)
+        let finish = toolCalls.isEmpty ? r.finishReason : "tool_calls"
         return ChatCompletionResponse(
             id: id, created: Int(Date().timeIntervalSince1970), model: modelID,
             choices: [Choice(index: 0, message: ResponseMessage(role: "assistant", content: content,
-                                                                reasoning_content: reasoning.isEmpty ? nil : reasoning),
-                             finish_reason: r.finishReason)],
+                                                                reasoning_content: reasoning.isEmpty ? nil : reasoning,
+                                                                tool_calls: toolCalls.isEmpty ? nil : toolCalls),
+                             finish_reason: finish)],
             usage: Usage(prompt_tokens: p.ids.count, completion_tokens: r.completionTokens,
                          total_tokens: p.ids.count + r.completionTokens))
     }
@@ -125,15 +128,23 @@ final class QwispEngine: @unchecked Sendable {
             if p.stop.contains(tok) { finish = "stop"; break }
             outIds.append(tok)
             // Split thinking from answer: reasoning → delta.reasoning_content, answer → delta.content.
-            let (r, c) = splitThink(tokenizer.decode(outIds))
+            let (r, afterThink) = splitThink(tokenizer.decode(outIds))
             if r.count > sentR.count, r.hasPrefix(sentR) {
                 try await send(Delta(reasoning_content: String(r.dropFirst(sentR.count))), nil); sentR = r
             }
-            if c.count > sentC.count, c.hasPrefix(sentC) {
-                try await send(Delta(content: String(c.dropFirst(sentC.count))), nil); sentC = c
+            // Stream only the answer text before any <tool_call>; the call XML is buffered, not shown.
+            let visible = afterThink.range(of: "<tool_call>").map { String(afterThink[..<$0.lowerBound]) } ?? afterThink
+            if visible.count > sentC.count, visible.hasPrefix(sentC) {
+                try await send(Delta(content: String(visible.dropFirst(sentC.count))), nil); sentC = visible
             }
             if p.maxTokens >= 0 && outIds.count >= p.maxTokens { finish = "length"; break }  // <0 = until EOS/context
         }
+        // Buffered tool calls: parse the completed output and emit them as tool_calls deltas.
+        let (_, toolCalls) = ToolParse.parse(splitThink(tokenizer.decode(outIds)).content)
+        for (i, tc) in toolCalls.enumerated() {
+            try await send(Delta(tool_calls: [ToolCallDelta(index: i, id: tc.id, type: "function", function: tc.function)]), nil)
+        }
+        if !toolCalls.isEmpty { finish = "tool_calls" }
         try await send(Delta(), finish)
         try await writer.write(ByteBuffer(string: "data: [DONE]\n\n"))
     }

--- a/swift/Sources/qwisp/Tools.swift
+++ b/swift/Sources/qwisp/Tools.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+// OpenAI function/tool calling. Qwen3.6's chat template renders `tools` and emits calls as
+// `<tool_call><function=NAME><parameter=KEY>\nVALUE\n</parameter>…</function></tool_call>`.
+// This file: the request/response tool types, a JSON passthrough value, the output parser, and
+// the message conversion that feeds tool_calls / tool results back through the template.
+
+// ── JSON passthrough (arbitrary tool schemas / arguments through Codable + the renderer) ──────
+enum JSONValue: Codable {
+    case null, bool(Bool), int(Int), double(Double), string(String)
+    case array([JSONValue]), object([String: JSONValue])
+
+    init(from d: Decoder) throws {
+        let c = try d.singleValueContainer()
+        if c.decodeNil() { self = .null }
+        else if let b = try? c.decode(Bool.self) { self = .bool(b) }        // before Int: true/false
+        else if let i = try? c.decode(Int.self) { self = .int(i) }
+        else if let x = try? c.decode(Double.self) { self = .double(x) }
+        else if let s = try? c.decode(String.self) { self = .string(s) }
+        else if let a = try? c.decode([JSONValue].self) { self = .array(a) }
+        else if let o = try? c.decode([String: JSONValue].self) { self = .object(o) }
+        else { throw DecodingError.dataCorruptedError(in: c, debugDescription: "unsupported JSON") }
+    }
+    func encode(to e: Encoder) throws {
+        var c = e.singleValueContainer()
+        switch self {
+        case .null: try c.encodeNil()
+        case .bool(let b): try c.encode(b)
+        case .int(let i): try c.encode(i)
+        case .double(let x): try c.encode(x)
+        case .string(let s): try c.encode(s)
+        case .array(let a): try c.encode(a)
+        case .object(let o): try c.encode(o)
+        }
+    }
+    // For the chat-template renderer, which takes [String: any Sendable].
+    var sendable: any Sendable {
+        switch self {
+        case .null: return NSNull()
+        case .bool(let b): return b
+        case .int(let i): return i
+        case .double(let x): return x
+        case .string(let s): return s
+        case .array(let a): return a.map { $0.sendable }
+        case .object(let o): return o.mapValues { $0.sendable }
+        }
+    }
+}
+
+// ── Request tool types ────────────────────────────────────────────────────────
+struct Tool: Codable { let type: String?; let function: ToolFunction }
+struct ToolFunction: Codable { let name: String; let description: String?; let parameters: JSONValue? }
+struct ReqFunctionCall: Codable { let name: String; let arguments: String }   // OpenAI: arguments = JSON string
+struct ReqToolCall: Codable { let id: String?; let type: String?; let function: ReqFunctionCall }
+
+// ── Response tool types ───────────────────────────────────────────────────────
+struct FunctionCall: Codable { let name: String; let arguments: String }      // arguments = JSON string
+struct ToolCall: Codable { let id: String; let type: String; let function: FunctionCall }
+struct ToolCallDelta: Codable { let index: Int; let id: String?; let type: String?; let function: FunctionCall }
+
+// Convert request messages / tool specs into the `[String: any Sendable]` shape the template wants.
+extension ChatMessage {
+    var renderDict: [String: any Sendable] {
+        var d: [String: any Sendable] = ["role": role]
+        if let content { d["content"] = content }
+        if let tool_calls {
+            d["tool_calls"] = tool_calls.map { tc -> [String: any Sendable] in
+                let fn: [String: any Sendable] = ["name": tc.function.name,
+                                                  "arguments": ToolParse.argsToSendable(tc.function.arguments)]
+                return ["id": tc.id ?? "", "type": tc.type ?? "function", "function": fn]
+            }
+        }
+        if let tool_call_id { d["tool_call_id"] = tool_call_id }
+        if let name { d["name"] = name }
+        return d
+    }
+}
+
+extension Tool {
+    // The OpenAI tool object as a Sendable dict; the template dumps it with `tool | tojson`.
+    var spec: [String: any Sendable] {
+        guard let data = try? JSONEncoder().encode(self),
+              let v = try? JSONDecoder().decode(JSONValue.self, from: data),
+              case let .object(o) = v else { return [:] }
+        return o.mapValues { $0.sendable }
+    }
+}
+
+enum ToolParse {
+    // Parse the model's <tool_call> blocks into OpenAI tool_calls; return the remaining text as content.
+    static func parse(_ text: String) -> (content: String?, toolCalls: [ToolCall]) {
+        guard text.contains("<tool_call>") else {
+            let t = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            return (t.isEmpty ? nil : text, [])
+        }
+        var calls: [ToolCall] = []
+        for (i, block) in allMatches(text, #"<tool_call>(.*?)</tool_call>"#).enumerated() {
+            guard let name = firstMatch(block, #"<function=([^>]+)>"#) else { continue }
+            var args: [String: JSONValue] = [:]
+            for (k, v) in paramPairs(block) { args[k] = coerce(v) }
+            calls.append(ToolCall(id: "call_\(i)_\(UUID().uuidString.prefix(8))",
+                                  type: "function",
+                                  function: FunctionCall(name: name, arguments: encodeArgs(args))))
+        }
+        let stripped = replaceAll(text, #"<tool_call>.*?</tool_call>"#, "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (stripped.isEmpty ? nil : stripped, calls)
+    }
+
+    // Qwen emits parameter values as text; coerce scalars to JSON, else keep as string.
+    static func coerce(_ s: String) -> JSONValue {
+        let t = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        if t == "true" { return .bool(true) }
+        if t == "false" { return .bool(false) }
+        if t == "null" { return .null }
+        if let i = Int(t) { return .int(i) }
+        if let d = Double(t), !t.isEmpty { return .double(d) }
+        return .string(t)
+    }
+
+    static func encodeArgs(_ args: [String: JSONValue]) -> String {
+        let enc = JSONEncoder(); enc.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return (try? enc.encode(args)).flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+    }
+
+    // Convert an OpenAI arguments JSON string back into a Sendable dict for the template's |items.
+    static func argsToSendable(_ json: String) -> any Sendable {
+        guard let data = json.data(using: .utf8),
+              let v = try? JSONDecoder().decode(JSONValue.self, from: data) else { return [String: any Sendable]() }
+        return v.sendable
+    }
+
+    // ── regex helpers (dotall) ──
+    private static func re(_ p: String) -> NSRegularExpression {
+        try! NSRegularExpression(pattern: p, options: [.dotMatchesLineSeparators])
+    }
+    private static func allMatches(_ s: String, _ p: String) -> [String] {
+        let ns = s as NSString
+        return re(p).matches(in: s, range: NSRange(location: 0, length: ns.length)).compactMap {
+            $0.numberOfRanges > 1 ? ns.substring(with: $0.range(at: 1)) : nil
+        }
+    }
+    private static func firstMatch(_ s: String, _ p: String) -> String? { allMatches(s, p).first }
+    private static func replaceAll(_ s: String, _ p: String, _ r: String) -> String {
+        let ns = s as NSString
+        return re(p).stringByReplacingMatches(in: s, range: NSRange(location: 0, length: ns.length), withTemplate: r)
+    }
+    private static func paramPairs(_ block: String) -> [(String, String)] {
+        let ns = block as NSString
+        return re(#"<parameter=([^>]+)>\n?(.*?)\n?</parameter>"#)
+            .matches(in: block, range: NSRange(location: 0, length: ns.length))
+            .compactMap { m in
+                guard m.numberOfRanges > 2 else { return nil }
+                return (ns.substring(with: m.range(at: 1)), ns.substring(with: m.range(at: 2)))
+            }
+    }
+
+    // Pure self-check (GPU-free, no model) — folded into COMPTEST.
+    static func selfCheck() -> [(String, Bool)] {
+        let (c1, t1) = parse("let me check</tool_call> oops")   // malformed → no closing before open? treat as text
+        _ = (c1, t1)
+        let (content, calls) = parse("Sure.<tool_call>\n<function=get_weather>\n<parameter=city>\nTokyo\n</parameter>\n<parameter=days>\n3\n</parameter>\n</function>\n</tool_call>")
+        var out: [(String, Bool)] = []
+        out.append(("tool_name", calls.first?.function.name == "get_weather"))
+        out.append(("tool_args_json", calls.first?.function.arguments == #"{"city":"Tokyo","days":3}"#))
+        out.append(("tool_content", content == "Sure."))
+        let (c2, calls2) = parse("just text, no tools")
+        out.append(("no_tools_passthrough", c2 == "just text, no tools" && calls2.isEmpty))
+        out.append(("coerce_bool", { if case .bool(true) = coerce("true") { return true }; return false }()))
+        out.append(("coerce_string", { if case .string("hi") = coerce("hi") { return true }; return false }()))
+        return out
+    }
+}


### PR DESCRIPTION
## What

Implements OpenAI-compatible function calling, so agentic clients (opencode etc.) work against qwisp.

Qwen3.6's chat template already renders `tools` and emits calls as `<tool_call><function=NAME><parameter=K>V</parameter>…</function></tool_call>`. This wires that into the OpenAI API:

- **request**: accept `tools` / `tool_choice`; messages carry `tool_calls` (assistant history) and `role:"tool"` results, rendered back through the template (arguments JSON-string ↔ dict, as the template's `|items` expects).
- **output**: parse `<tool_call>` blocks → `tool_calls` (`id`/`type`/`function`, arguments as a JSON string; scalar values coerced best-effort), `finish_reason: "tool_calls"`.
- **streaming**: answer text before the call streams as content; the call XML is buffered and emitted as `tool_calls` deltas once complete (not token-incremental).
- new `Tools.swift`: `JSONValue` passthrough, tool types, the parser, message conversion.
- `render()` now takes `[String: any Sendable]` messages + tools via `applyChatTemplate(…, tools:)`.

## Verified end-to-end on the live server

```json
// tools request → the model calls the tool
{ "finish": "tool_calls", "content": null,
  "tool_calls": [{ "function": { "name": "get_weather", "arguments": "{\"city\":\"Tokyo\"}" } }] }

// feed the tool result back → final answer (tool-role + tool_calls history rendered)
{ "finish": "stop", "content": "The current weather in Tokyo is 18°C and sunny." }
```

## Caveats (documented in README)

- Parameter values are coerced to JSON scalars **best-effort** (Qwen emits them as text).
- Streaming `tool_calls` is **buffered** (emitted when complete), not token-incremental.

## Gates

Additive to the `qwisp` target, **engine untouched** → RAWTESTS **79/79**, BENCHBATCHTEST **PASS**, COMPTEST **4 → 13** (`splitThink` + tool-parse unit checks).

Ships as **v0.1.2** alongside #25 (reasoning split) and #26 (release notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)