### PR TITLE
feat(server): cross-request prefix cache — default ON, growing arena, multi-slot (agentic 3.5x, cross-conv TTFT 27x)

### DIFF
--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -104,12 +104,21 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     // ── Cross-request prefix cache (opt-in via QWISP_PREFIX_CACHE=1) ──────────
     // Persistent per-instance fused backend + a content-boundary fullSnapshot, so consecutive
     // requests (agentic loops) re-prefill only the new suffix. Serialized by the server lock.
-    let prefixCacheEnabled = Tell.envFlag("QWISP_PREFIX_CACHE")
-    var prefixCacheCap: Int { Swift.min(contextLen, Swift.max(2048, Tell.envInt("QWISP_PREFIX_CAP", 16384))) }
+    // Design B: the arena grows monotonically to fit each request (prompt+generation) instead of a
+    // fixed generation cap, so cached mode never truncates a long answer the segmented path would allow.
+    // Multi-slot: several stride-aligned restore points along the current path let a NEW conversation
+    // reuse a shared prefix (system+tools) instead of re-prefilling it. Lossless — SuffixSpec verifies
+    // every drafted token; snapshot/restore is byte-identical (PrefixCachePoC). ~60MB / slot (GDN state).
+    public var prefixCacheForced: Bool? = nil      // test/override hook; nil → env flag
+    var prefixCacheEnabled: Bool { prefixCacheForced ?? Tell.envFlag("QWISP_PREFIX_CACHE") }
+    var prefixArenaMax: Int { Swift.min(contextLen, Swift.max(4096, Tell.envInt("QWISP_PREFIX_MAX", 65536))) }
+    var prefixSnapStride: Int { Swift.max(512, Tell.envInt("QWISP_PREFIX_SNAP_STRIDE", 2048)) }
+    var prefixMaxSlots: Int { Swift.max(2, Tell.envInt("QWISP_PREFIX_MAX_SLOTS", 6)) }
     private var prefixBackend: Tell.SpecBackend?
-    private var prefixEmptySnap: Any?          // fullSnapshot of the fresh cache, for reset
-    private var cachedContent: [Int32] = []    // content tokens currently represented in the cache
-    private var boundarySnap: Any?             // fullSnapshot taken at the last content boundary
+    private var prefixArenaLen = 0                          // current backend's maxSeqLen (0 = not built)
+    private var prefixEmptySnap: Any?                       // fullSnapshot of the fresh arena, for reset
+    private var arenaContent: [Int32] = []                  // tokens currently prefilled into the arena (one path)
+    private var prefixSlots: [(len: Int, snap: Any)] = []   // restore points along arenaContent, sorted by len
 
     /// Read `text_config.max_position_embeddings` from the checkpoint's config.json.
     /// Falls back to 32768 if absent — a sane bound that still lets any real chat reach EOS.
@@ -145,10 +154,10 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
         // context; else the caller's cap. Both clamped to the context headroom.
         let headroom = Swift.max(0, contextLen - prompt.count)
         let ceiling = options.maxTokens < 0 ? headroom : Swift.min(options.maxTokens, headroom)
-        // Prefix cache path: resident/fused, greedy, gen-prompt present, prompt fits the persistent
-        // cap with room to decode. Everything else falls through to the segmented-growth path below.
+        // Prefix cache path: resident/fused, greedy, gen-prompt present, prompt fits the arena with
+        // room to decode. Everything else falls through to the segmented-growth path below.
         if prefixCacheEnabled, !cfg.isStreaming, !options.sampling,
-           let cl = options.promptContentLen, cl < prompt.count, prompt.count + 256 <= prefixCacheCap {
+           let cl = options.promptContentLen, cl < prompt.count, prompt.count + 64 <= prefixArenaMax {
             return generateCached(prompt: prompt, contentLen: cl, ceiling: ceiling, cfg: cfg)
         }
         // First KV arena budget; grows geometrically to `ceiling` only if generation needs it.
@@ -224,49 +233,95 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
         }
     }
 
-    // Prefix-cache generation: persistent fused backend, restore the content-boundary snapshot when
-    // the new content extends the cached content, and re-prefill only the delta. Greedy only;
-    // provably lossless — SuffixSpec verifies every drafted token (see prefix-cache-poc).
+    // Prefix-cache generation (Design B + multi-slot): a persistent fused backend whose KV arena grows
+    // to fit each request, plus stride-aligned restore points along the current path. Restores the
+    // longest cached prefix of the new content and re-prefills only the delta. Greedy only; provably
+    // lossless — SuffixSpec verifies every drafted token (see prefix-cache-poc).
     private func generateCached(prompt: [Int], contentLen: Int, ceiling: Int, cfg: Config) -> AsyncStream<Int> {
         let cancel = CancelFlag()
         return AsyncStream { continuation in
             continuation.onTermination = { _ in cancel.cancel() }
             Thread.detachNewThread {
-                if self.prefixBackend == nil {
-                    guard let b = Tell.fusedBackend(engine: self.engine, maxM: cfg.maxM, maxSeqLen: self.prefixCacheCap) else {
+                // Design B: ensure the arena fits prompt + this request's generation; grow (rebuild,
+                // geometric, monotonic) if not. ponytail: unbounded/huge generations cap at
+                // prefixArenaMax (fits ≤64K total by default); >that falls through upstream. Mid-decode
+                // arena growth is the upgrade path if a real workload needs >prefixArenaMax generation.
+                let genBudget = Swift.max(1, Swift.min(ceiling, self.prefixArenaMax - prompt.count))
+                let needed = prompt.count + genBudget
+                if self.prefixBackend == nil || self.prefixArenaLen < needed {
+                    var newLen = Swift.max(self.prefixArenaLen, 16384)
+                    while newLen < needed { newLen *= 2 }
+                    newLen = Swift.min(newLen, self.prefixArenaMax)
+                    if newLen < needed { newLen = needed }
+                    guard let b = Tell.fusedBackend(engine: self.engine, maxM: cfg.maxM, maxSeqLen: newLen) else {
                         continuation.finish(); return
                     }
-                    self.prefixBackend = b
+                    self.prefixBackend = b; self.prefixArenaLen = newLen
                     self.prefixEmptySnap = b.fullSnapshot?()
+                    self.prefixSlots = []; self.arenaContent = []   // new arena → old snapshots invalid
                 }
                 let backend = self.prefixBackend!
                 let full = prompt.map { Int32($0) }
                 let content = Array(full[0 ..< contentLen])
 
-                // Reuse the content-boundary snapshot iff the new content extends the cached content;
-                // otherwise reset to empty and prefill all of content.
-                let lcp = SeedlessBackend.commonPrefixLen(content, self.cachedContent)
-                if let snap = self.boundarySnap, lcp == self.cachedContent.count {
-                    backend.fullRestore?(snap)
-                    if lcp < content.count { _ = Tell.prefill(promptIds: Array(content[lcp...]), backend: backend) }
-                } else {
-                    if let e = self.prefixEmptySnap { backend.fullRestore?(e) }
-                    _ = Tell.prefill(promptIds: content, backend: backend)
+                // Multi-slot restore: the longest cached restore point that is a prefix of the new
+                // content (positions [0..len] still hold that prefix — append-only KV). A NEW
+                // conversation sharing the system+tools prefix restores a sub-content boundary instead
+                // of re-prefilling it. Boundaries past the divergence point are stale → drop them.
+                let lcp = SeedlessBackend.commonPrefixLen(content, self.arenaContent)
+                let restoreLen = self.prefixSlots.last(where: { $0.len <= lcp })?.len ?? 0
+                if restoreLen > 0, let s = self.prefixSlots.last(where: { $0.len == restoreLen })?.snap {
+                    backend.fullRestore?(s)
+                } else if let e = self.prefixEmptySnap {
+                    backend.fullRestore?(e)
                 }
-                // Snapshot at the content boundary (for the NEXT request); record what's cached.
-                self.boundarySnap = backend.fullSnapshot?()
-                self.cachedContent = content
+                self.prefixSlots.removeAll { $0.len > lcp }
 
-                // Prefill the generation-prompt suffix + decode. prefillTokens = suffix (cache already
+                // Re-prefill the delta [restoreLen ..< contentLen], snapshotting at stride-aligned
+                // boundaries (so different conversations that share a prefix snapshot at the SAME
+                // positions → cross-conversation reuse), plus one at the content boundary.
+                var pos = restoreLen
+                while pos < contentLen {
+                    let end = Swift.min(pos - (pos % self.prefixSnapStride) + self.prefixSnapStride, contentLen)
+                    _ = Tell.prefill(promptIds: Array(content[pos ..< end]), backend: backend)
+                    if let snap = backend.fullSnapshot?() { self.prefixSlots.append((len: end, snap: snap)) }
+                    pos = end
+                }
+                if self.prefixSlots.last?.len != contentLen, let snap = backend.fullSnapshot?() {
+                    self.prefixSlots.append((len: contentLen, snap: snap))
+                }
+                self.prefixSlots.sort { $0.len < $1.len }
+                self.evictSlots()
+                self.arenaContent = content
+
+                // Prefill the generation-prompt suffix + decode. prefillTokens = suffix (arena already
                 // holds content); hist = the full prompt so SuffixSpec drafting is unchanged.
                 let genSuffix = Array(full[contentLen...])
-                let N = Swift.max(1, Swift.min(ceiling, self.prefixCacheCap - prompt.count))
                 _ = Tell.runSpecLoop(promptIds: full, backend: backend, engine: self.engine,
-                                     N: N, maxK: cfg.maxK, prefillTokens: genSuffix,
+                                     N: genBudget, maxK: cfg.maxK, prefillTokens: genSuffix,
                                      isCancelled: { cancel.isCancelled },
                                      onToken: { continuation.yield($0) })
                 continuation.finish()
             }
+        }
+    }
+
+    /// Test/override hook: drop the persistent arena + all restore points (start cold).
+    public func resetPrefixCache() {
+        prefixBackend = nil; prefixArenaLen = 0; prefixEmptySnap = nil
+        arenaContent = []; prefixSlots = []
+    }
+
+    // Cap resident snapshots (~60MB each) at prefixMaxSlots, evicting the densest neighbour so a coarse
+    // spread of low boundaries (cross-conversation reuse) and the top boundary (next turn) both survive.
+    private func evictSlots() {
+        while prefixSlots.count > prefixMaxSlots {
+            var mi = 1, mgap = Int.max
+            for i in 1 ..< prefixSlots.count {
+                let g = prefixSlots[i].len - prefixSlots[i - 1].len
+                if g < mgap { mgap = g; mi = i }
+            }
+            prefixSlots.remove(at: mi)
         }
     }
 

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -32,12 +32,17 @@ public struct GenerateOptions {
     public var frequencyPenalty: Double
     public var presencePenalty: Double
     public var logitBias: [Int: Double]
+    /// Prefix-cache boundary: number of leading prompt tokens that are stable "content" (i.e. the
+    /// prompt WITHOUT the trailing generation-prompt suffix). The cross-request cache snapshots at
+    /// this position so the next request re-prefills only the new content. nil → no caching.
+    public var promptContentLen: Int? = nil
     public var sampling: Bool {
         temperature > 0 || topP < 1.0 || frequencyPenalty != 0 || presencePenalty != 0 || !logitBias.isEmpty
     }
     public init(maxTokens: Int = 128, stopTokens: [Int] = [],
                 temperature: Double = 0, topP: Double = 1.0, seed: UInt64 = 0,
-                frequencyPenalty: Double = 0, presencePenalty: Double = 0, logitBias: [Int: Double] = [:]) {
+                frequencyPenalty: Double = 0, presencePenalty: Double = 0, logitBias: [Int: Double] = [:],
+                promptContentLen: Int? = nil) {
         self.maxTokens = maxTokens
         self.stopTokens = stopTokens
         self.temperature = temperature
@@ -46,6 +51,7 @@ public struct GenerateOptions {
         self.frequencyPenalty = frequencyPenalty
         self.presencePenalty = presencePenalty
         self.logitBias = logitBias
+        self.promptContentLen = promptContentLen
     }
 }
 
@@ -95,6 +101,16 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     let tier: SeedlessTier
     let contextLen: Int      // model context window (max_position_embeddings); caps unbounded generation.
 
+    // ── Cross-request prefix cache (opt-in via QWISP_PREFIX_CACHE=1) ──────────
+    // Persistent per-instance fused backend + a content-boundary fullSnapshot, so consecutive
+    // requests (agentic loops) re-prefill only the new suffix. Serialized by the server lock.
+    let prefixCacheEnabled = Tell.envFlag("QWISP_PREFIX_CACHE")
+    var prefixCacheCap: Int { Swift.min(contextLen, Swift.max(2048, Tell.envInt("QWISP_PREFIX_CAP", 16384))) }
+    private var prefixBackend: Tell.SpecBackend?
+    private var prefixEmptySnap: Any?          // fullSnapshot of the fresh cache, for reset
+    private var cachedContent: [Int32] = []    // content tokens currently represented in the cache
+    private var boundarySnap: Any?             // fullSnapshot taken at the last content boundary
+
     /// Read `text_config.max_position_embeddings` from the checkpoint's config.json.
     /// Falls back to 32768 if absent — a sane bound that still lets any real chat reach EOS.
     static func readContextLen(_ modelDir: String) -> Int {
@@ -129,6 +145,12 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
         // context; else the caller's cap. Both clamped to the context headroom.
         let headroom = Swift.max(0, contextLen - prompt.count)
         let ceiling = options.maxTokens < 0 ? headroom : Swift.min(options.maxTokens, headroom)
+        // Prefix cache path: resident/fused, greedy, gen-prompt present, prompt fits the persistent
+        // cap with room to decode. Everything else falls through to the segmented-growth path below.
+        if prefixCacheEnabled, !cfg.isStreaming, !options.sampling,
+           let cl = options.promptContentLen, cl < prompt.count, prompt.count + 256 <= prefixCacheCap {
+            return generateCached(prompt: prompt, contentLen: cl, ceiling: ceiling, cfg: cfg)
+        }
         // First KV arena budget; grows geometrically to `ceiling` only if generation needs it.
         let baseline = Swift.max(1, Tell.envInt("QWISP_CTX_BASELINE", 8192))
         let cancel = CancelFlag()
@@ -200,6 +222,59 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                 continuation.finish()
             }
         }
+    }
+
+    // Prefix-cache generation: persistent fused backend, restore the content-boundary snapshot when
+    // the new content extends the cached content, and re-prefill only the delta. Greedy only;
+    // provably lossless — SuffixSpec verifies every drafted token (see prefix-cache-poc).
+    private func generateCached(prompt: [Int], contentLen: Int, ceiling: Int, cfg: Config) -> AsyncStream<Int> {
+        let cancel = CancelFlag()
+        return AsyncStream { continuation in
+            continuation.onTermination = { _ in cancel.cancel() }
+            Thread.detachNewThread {
+                if self.prefixBackend == nil {
+                    guard let b = Tell.fusedBackend(engine: self.engine, maxM: cfg.maxM, maxSeqLen: self.prefixCacheCap) else {
+                        continuation.finish(); return
+                    }
+                    self.prefixBackend = b
+                    self.prefixEmptySnap = b.fullSnapshot?()
+                }
+                let backend = self.prefixBackend!
+                let full = prompt.map { Int32($0) }
+                let content = Array(full[0 ..< contentLen])
+
+                // Reuse the content-boundary snapshot iff the new content extends the cached content;
+                // otherwise reset to empty and prefill all of content.
+                let lcp = SeedlessBackend.commonPrefixLen(content, self.cachedContent)
+                if let snap = self.boundarySnap, lcp == self.cachedContent.count {
+                    backend.fullRestore?(snap)
+                    if lcp < content.count { _ = Tell.prefill(promptIds: Array(content[lcp...]), backend: backend) }
+                } else {
+                    if let e = self.prefixEmptySnap { backend.fullRestore?(e) }
+                    _ = Tell.prefill(promptIds: content, backend: backend)
+                }
+                // Snapshot at the content boundary (for the NEXT request); record what's cached.
+                self.boundarySnap = backend.fullSnapshot?()
+                self.cachedContent = content
+
+                // Prefill the generation-prompt suffix + decode. prefillTokens = suffix (cache already
+                // holds content); hist = the full prompt so SuffixSpec drafting is unchanged.
+                let genSuffix = Array(full[contentLen...])
+                let N = Swift.max(1, Swift.min(ceiling, self.prefixCacheCap - prompt.count))
+                _ = Tell.runSpecLoop(promptIds: full, backend: backend, engine: self.engine,
+                                     N: N, maxK: cfg.maxK, prefillTokens: genSuffix,
+                                     isCancelled: { cancel.isCancelled },
+                                     onToken: { continuation.yield($0) })
+                continuation.finish()
+            }
+        }
+    }
+
+    static func commonPrefixLen(_ a: [Int32], _ b: [Int32]) -> Int {
+        let n = Swift.min(a.count, b.count)
+        var i = 0
+        while i < n && a[i] == b[i] { i += 1 }
+        return i
     }
 }
 

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -101,7 +101,7 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     let tier: SeedlessTier
     let contextLen: Int      // model context window (max_position_embeddings); caps unbounded generation.
 
-    // ── Cross-request prefix cache (opt-in via QWISP_PREFIX_CACHE=1) ──────────
+    // ── Cross-request prefix cache (default ON; QWISP_PREFIX_CACHE=0 opts out) ──────────
     // Persistent per-instance fused backend + a content-boundary fullSnapshot, so consecutive
     // requests (agentic loops) re-prefill only the new suffix. Serialized by the server lock.
     // Design B: the arena grows monotonically to fit each request (prompt+generation) instead of a
@@ -110,7 +110,8 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     // reuse a shared prefix (system+tools) instead of re-prefilling it. Lossless — SuffixSpec verifies
     // every drafted token; snapshot/restore is byte-identical (PrefixCachePoC). ~60MB / slot (GDN state).
     public var prefixCacheForced: Bool? = nil      // test/override hook; nil → env flag
-    var prefixCacheEnabled: Bool { prefixCacheForced ?? Tell.envFlag("QWISP_PREFIX_CACHE") }
+    // Default ON (lossless: PREFIXE2E gate; growth removed the truncation risk). QWISP_PREFIX_CACHE=0 opts out.
+    var prefixCacheEnabled: Bool { prefixCacheForced ?? (ProcessInfo.processInfo.environment["QWISP_PREFIX_CACHE"] != "0") }
     var prefixArenaMax: Int { Swift.min(contextLen, Swift.max(4096, Tell.envInt("QWISP_PREFIX_MAX", 65536))) }
     var prefixSnapStride: Int { Swift.max(512, Tell.envInt("QWISP_PREFIX_SNAP_STRIDE", 2048)) }
     var prefixMaxSlots: Int { Swift.max(2, Tell.envInt("QWISP_PREFIX_MAX_SLOTS", 6)) }

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -76,51 +76,48 @@ extension Tell {
             return Date().timeIntervalSince(t0)
         }
 
-        // min-of-2 to damp run-to-run variance (single-run differentials were non-additive/noisy).
-        func best(_ set: () -> Void) -> Double {
-            allOff(); set(); let a = runPrefill(); let b = runPrefill(); allOff(); return Swift.min(a, b)
+        // v2: split WALL vs GPU-busy (profLastGPUMs per CB) per config. The decisive question:
+        // is prefill time GPU execution (kernel-level, capped ~22% by the skip test) or CPU-side
+        // gap (MLX embed eval + hBuf upload + normed readback + commit/wait per chunk) — the
+        // latter is a scheduling prize, lossless by construction (no math change).
+        func runAt(_ c: Int) -> (wall: Double, gpu: Double) {
+            guard let bk = Tell.fusedBackend(engine: engine, maxM: c + 8, maxSeqLen: promptLen + 128) else { return (-1, 0) }
+            var gpu = 0.0
+            let t0 = Date(); var pos = 0
+            while pos < promptLen {
+                let e = Swift.min(pos + c, promptLen)
+                _ = bk.forward(Array(prompt[pos ..< e]))
+                gpu += SeedlessFusedVerify.SeedlessFusedForward.profLastGPUMs / 1000.0
+                pos = e
+            }
+            return (Date().timeIntervalSince(t0), gpu)
         }
         func floorSet() {   // skip ALL heavy GPU compute → what remains is the irreducible floor
             SeedlessMetalForward.profSkipMixer = true          // GDN body + attention body
             SeedlessMetalForward.profSkipMoEExperts = true     // routed+shared+combine gather
             SeedlessMetalForward.profSkipSingleThread = true   // route_top8/shared_gate8
         }
-        allOff(); _ = runPrefill()                             // warmup: compile all pipelines
+        allOff(); _ = runAt(chunk)                             // warmup: compile all pipelines
+        _ = runPrefill                                          // (kept for API symmetry)
 
-        let tFull = best {}
-        // Floor swept over chunk size: if floor DROPS with bigger chunk → per-chunk dispatch/encode
-        // overhead (amortizable by larger chunk). If FLAT → per-token ops (norms/gate/KV, not amortizable).
-        var floorLines: [String] = []
-        for fc in [chunk, 256, 1024] {
-            let savedChunk = chunk
-            _ = savedChunk
-            // re-run floor at this chunk by temporarily overriding the closure's chunk via a local loop
-            func runAt(_ c: Int) -> Double {
-                guard let bk = Tell.fusedBackend(engine: engine, maxM: c + 8, maxSeqLen: promptLen + 128) else { return -1 }
-                let t0 = Date(); var pos = 0
-                while pos < promptLen { let e = Swift.min(pos + c, promptLen); _ = bk.forward(Array(prompt[pos ..< e])); pos = e }
-                return Date().timeIntervalSince(t0)
-            }
-            allOff(); floorSet(); let a = runAt(fc); let b = runAt(fc); allOff()
-            let f = Swift.min(a, b)
-            floorLines.append(String(format: "  floor @chunk=%4d        %6.1fs  %5.1f%% of full   (%d chunks)",
-                                     fc, f, 100 * f / tFull, (promptLen + fc - 1) / fc))
+        var lines = ["[prefill-bd] promptLen=\(promptLen) resident  — wall vs GPU-busy per config"]
+        func row(_ label: String, _ c: Int, floored: Bool) -> Double {
+            allOff(); if floored { floorSet() }
+            let a = runAt(c), b = runAt(c)
+            allOff()
+            let r = a.wall < b.wall ? a : b
+            lines.append(String(format: "  %@ chunk=%4d   wall %6.1fs   gpu %6.1fs   cpu-gap %6.1fs (%4.1f%%)   %.0f tok/s",
+                                label, c, r.wall, r.gpu, r.wall - r.gpu, 100 * (r.wall - r.gpu) / r.wall,
+                                Double(promptLen) / r.wall))
+            return r.wall
         }
-        // rough single-component split at the production chunk (noisy — min-of-2, may not be additive).
-        let tMixer = best { SeedlessMetalForward.profSkipMixer = true }
-        let tMoE   = best { SeedlessMetalForward.profSkipMoEExperts = true }
-        let tRoute = best { SeedlessMetalForward.profSkipSingleThread = true }
-        func pct(_ c: Double) -> String { String(format: "%6.1fs  %5.1f%%", c, 100 * c / tFull) }
-        var out = ["[prefill-bd] promptLen=\(promptLen) chunk=\(chunk) resident  (min-of-2)",
-                   String(format: "  FULL prefill            %6.1fs  (%.0f tok/s)", tFull, Double(promptLen) / tFull),
-                   "  ── rough component (t_full − t_skip, noisy) ──",
-                   "  all mixers (GDN+attn)   \(pct(tFull - tMixer))",
-                   "  MoE experts (all)       \(pct(tFull - tMoE))",
-                   "  routing single-thread   \(pct(tFull - tRoute))",
-                   "  ── FLOOR (all heavy compute skipped), swept over chunk ──"]
-        out += floorLines
-        out.append("PREFILLBD done")
-        return out.joined(separator: "\n")
+        _ = row("FULL ", chunk, floored: false)
+        _ = row("FULL ", 256, floored: false)
+        _ = row("floor", chunk, floored: true)
+        _ = row("floor", 256, floored: true)
+        _ = row("floor", 1024, floored: true)
+        lines.append("PREFILLBD done")
+        return lines.joined(separator: "\n")
     }
 
     // End-to-end lossless gate for the Design-B + multi-slot prefix cache: drives SeedlessBackend.generate

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -45,9 +45,10 @@ extension Tell {
             let seqBase = greedy(bBase, firstNormed: nBase)
 
             _ = Tell.prefill(promptIds: A, backend: bReuse)   // cache the stable content prefix
-            let snap = bReuse.snapshot()                       // content-boundary snapshot
+            // Full-state snapshot for arbitrary rewind; falls back to snapshot (composed's is already full).
+            let snap = (bReuse.fullSnapshot ?? bReuse.snapshot)()          // content-boundary snapshot
             _ = Tell.prefill(promptIds: tail, backend: bReuse) // gen prompt + generated (request-specific)
-            bReuse.rollback(snap)                              // next request rewinds past them
+            (bReuse.fullRestore ?? bReuse.rollback)(snap)      // next request rewinds past them
             let t1 = Date()
             guard let nReuse = Tell.prefill(promptIds: B, backend: bReuse) else { return "  \(label): prefill reuse nil" }
             let tSuffix = Date().timeIntervalSince(t1)
@@ -60,13 +61,13 @@ extension Tell {
         }
 
         let composed = trial("composed(full copyState)", { Tell.composedBackend(engine: engine) }, timed: false)
-        let fused = trial("fused(1-step rollback)", { Tell.fusedBackend(engine: engine, maxM: 96, maxSeqLen: maxSeqLen) }, timed: true)
-        let pass = composed.contains("byte-identical=YES")
+        let fused = trial("fused(full snapshot)", { Tell.fusedBackend(engine: engine, maxM: 96, maxSeqLen: maxSeqLen) }, timed: true)
+        let pass = composed.contains("byte-identical=YES") && fused.contains("byte-identical=YES")
         return """
         [prefix-poc] A=\(aLen) tail=\(tailLen) B=\(bLen) decodeN=\(decodeN)
         \(composed)
         \(fused)
-        PREFIXPOC \(pass ? "PASS" : "FAIL")   (composed = the full-state primitive; fused's 1-step rollback is expected to fail arbitrary rewind)
+        PREFIXPOC \(pass ? "PASS" : "FAIL")   (both paths must be byte-identical to full prefill)
         """
     }
 }

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -39,6 +39,141 @@ extension Tell {
         return lines.joined(separator: "\n") + "\nPREFILLPROBE done"
     }
 
+    // Prefill component breakdown: differential timing via profSkip flags on the raw forward.
+    // Runs a full prefill, then repeats with each component skipped; cost(X) ≈ t_full - t_skipX.
+    // Timing-only (skipped output is garbage) — attributes the cold-prefill wall to GDN-recur /
+    // GDN-matmul / attention / MoE-experts / routing / floor, so we know which lever (if any) pays.
+    // Env: QWISP_PREFILL_LEN (default 8192), QWISP_PREFILL_CHUNK (default 64).
+    public static func prefillBreakdownProbe(modelDir: String) -> String {
+        guard let store = try? WeightStore(modelDir: modelDir) else { return "[prefill-bd] load fail\nPREFILLBD done" }
+        store.residentAll()
+        let engine = SeedlessEngine.build(store: store)
+        let promptLen = Tell.envInt("QWISP_PREFILL_LEN", 8192)
+        let chunk = Tell.envInt("QWISP_PREFILL_CHUNK", 64)
+        let prompt = (0..<promptLen).map { Int32((($0 &* 7 &+ 13) % 5000) + 100) }
+
+        // reset all skip flags to a known-off baseline
+        func allOff() {
+            SeedlessMetalForward.profSkipGDNMatmul = false
+            SeedlessMetalForward.profSkipGDNRecur = false
+            SeedlessMetalForward.profSkipMixer = false
+            SeedlessMetalForward.profSkipMoEExperts = false
+            SeedlessMetalForward.profSkipMoERouted = false
+            SeedlessMetalForward.profSkipMoEShared = false
+            SeedlessMetalForward.profSkipSingleThread = false
+        }
+        // one full prefill of `prompt` at `chunk`, returns wall seconds. Fresh backend each run so
+        // KV starts empty (identical work every config).
+        func runPrefill() -> Double {
+            guard let b = Tell.fusedBackend(engine: engine, maxM: chunk + 8, maxSeqLen: promptLen + 128) else { return -1 }
+            let t0 = Date()
+            var pos = 0
+            while pos < promptLen {
+                let end = Swift.min(pos + chunk, promptLen)
+                _ = b.forward(Array(prompt[pos ..< end]))
+                pos = end
+            }
+            return Date().timeIntervalSince(t0)
+        }
+
+        // min-of-2 to damp run-to-run variance (single-run differentials were non-additive/noisy).
+        func best(_ set: () -> Void) -> Double {
+            allOff(); set(); let a = runPrefill(); let b = runPrefill(); allOff(); return Swift.min(a, b)
+        }
+        func floorSet() {   // skip ALL heavy GPU compute → what remains is the irreducible floor
+            SeedlessMetalForward.profSkipMixer = true          // GDN body + attention body
+            SeedlessMetalForward.profSkipMoEExperts = true     // routed+shared+combine gather
+            SeedlessMetalForward.profSkipSingleThread = true   // route_top8/shared_gate8
+        }
+        allOff(); _ = runPrefill()                             // warmup: compile all pipelines
+
+        let tFull = best {}
+        // Floor swept over chunk size: if floor DROPS with bigger chunk → per-chunk dispatch/encode
+        // overhead (amortizable by larger chunk). If FLAT → per-token ops (norms/gate/KV, not amortizable).
+        var floorLines: [String] = []
+        for fc in [chunk, 256, 1024] {
+            let savedChunk = chunk
+            _ = savedChunk
+            // re-run floor at this chunk by temporarily overriding the closure's chunk via a local loop
+            func runAt(_ c: Int) -> Double {
+                guard let bk = Tell.fusedBackend(engine: engine, maxM: c + 8, maxSeqLen: promptLen + 128) else { return -1 }
+                let t0 = Date(); var pos = 0
+                while pos < promptLen { let e = Swift.min(pos + c, promptLen); _ = bk.forward(Array(prompt[pos ..< e])); pos = e }
+                return Date().timeIntervalSince(t0)
+            }
+            allOff(); floorSet(); let a = runAt(fc); let b = runAt(fc); allOff()
+            let f = Swift.min(a, b)
+            floorLines.append(String(format: "  floor @chunk=%4d        %6.1fs  %5.1f%% of full   (%d chunks)",
+                                     fc, f, 100 * f / tFull, (promptLen + fc - 1) / fc))
+        }
+        // rough single-component split at the production chunk (noisy — min-of-2, may not be additive).
+        let tMixer = best { SeedlessMetalForward.profSkipMixer = true }
+        let tMoE   = best { SeedlessMetalForward.profSkipMoEExperts = true }
+        let tRoute = best { SeedlessMetalForward.profSkipSingleThread = true }
+        func pct(_ c: Double) -> String { String(format: "%6.1fs  %5.1f%%", c, 100 * c / tFull) }
+        var out = ["[prefill-bd] promptLen=\(promptLen) chunk=\(chunk) resident  (min-of-2)",
+                   String(format: "  FULL prefill            %6.1fs  (%.0f tok/s)", tFull, Double(promptLen) / tFull),
+                   "  ── rough component (t_full − t_skip, noisy) ──",
+                   "  all mixers (GDN+attn)   \(pct(tFull - tMixer))",
+                   "  MoE experts (all)       \(pct(tFull - tMoE))",
+                   "  routing single-thread   \(pct(tFull - tRoute))",
+                   "  ── FLOOR (all heavy compute skipped), swept over chunk ──"]
+        out += floorLines
+        out.append("PREFILLBD done")
+        return out.joined(separator: "\n")
+    }
+
+    // End-to-end lossless gate for the Design-B + multi-slot prefix cache: drives SeedlessBackend.generate
+    // through a scripted request sequence with the cache ON (warm: reuse/extend/cross-branch/reset) and
+    // compares each token stream to the same request generated with the cache OFF (segmented cold path).
+    // Byte-identical everywhere ⇒ the multi-slot restore + stride re-prefill + arena growth are lossless.
+    public static func prefixCacheE2E(modelDir: String) -> String {
+        guard let backend = try? SeedlessBackend(modelDir: modelDir) else { return "[prefix-e2e] load fail\nPREFIXE2E FAIL" }
+        // stride small so a shared 256-token prefix produces reusable sub-content boundaries.
+        setenv("QWISP_PREFIX_SNAP_STRIDE", "64", 1)
+
+        func toks(_ n: Int, _ salt: Int) -> [Int] { (0..<n).map { (($0 &* 7 &+ salt) % 5000) + 100 } }
+        let A = toks(256, 13)                       // shared "system+tools" prefix
+        // (content, contentLen) per request; full prompt = content + 8-token gen-prompt suffix.
+        func req(_ content: [Int]) -> (prompt: [Int], cl: Int) { (content + toks(8, 777), content.count) }
+        let c1 = A + toks(32, 1)                     // R1: A + userX
+        let c2 = c1 + toks(40, 2)                    // R2: extends R1 (intra-conversation)
+        let c3 = A + toks(32, 3)                     // R3: A + userZ (cross-conversation: shares A)
+        let c4 = toks(200, 999)                      // R4: shares nothing → cold reset (restore empty)
+        let reqs = [req(c1), req(c2), req(c3), req(c4)]
+        let maxTok = 24
+
+        final class Box: @unchecked Sendable { var v: [Int] = [] }
+        func gen(_ p: [Int], _ cl: Int) -> [Int] {
+            let box = Box()
+            let sem = DispatchSemaphore(value: 0)
+            let stream = backend.generate(p, options: GenerateOptions(maxTokens: maxTok, promptContentLen: cl))
+            Task { for await t in stream { box.v.append(t) }; sem.signal() }
+            sem.wait()
+            return box.v
+        }
+
+        // Reference: cache OFF (segmented cold path) — each request independent.
+        backend.prefixCacheForced = false
+        let ref = reqs.map { gen($0.prompt, $0.cl) }
+        // Cached: cache ON, cold start, requests in sequence so the cache warms/reuses across them.
+        backend.prefixCacheForced = true
+        backend.resetPrefixCache()
+        let got = reqs.map { gen($0.prompt, $0.cl) }
+
+        var lines = ["[prefix-e2e] 4 requests (reuse/extend/cross-branch/reset), maxTok=\(maxTok)"]
+        var pass = true
+        let labels = ["R1 cold      ", "R2 extend    ", "R3 cross-conv", "R4 reset     "]
+        for i in 0..<reqs.count {
+            let ok = ref[i] == got[i]
+            pass = pass && ok
+            lines.append("  \(labels[i])  ref=\(ref[i].count)tok  cached=\(got[i].count)tok  \(ok ? "IDENTICAL ✅" : "DIVERGE ❌")")
+            if !ok { lines.append("    ref   : \(ref[i].prefix(12))"); lines.append("    cached: \(got[i].prefix(12))") }
+        }
+        lines.append("PREFIXE2E \(pass ? "PASS" : "FAIL")")
+        return lines.joined(separator: "\n")
+    }
+
     public static func prefixCachePoC(modelDir: String) -> String {
         guard let store = try? WeightStore(modelDir: modelDir) else { return "[prefix-poc] load fail\nPREFIXPOC FAIL" }
         store.residentAll()

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -1,0 +1,72 @@
+import Foundation
+import MLX
+
+// Feasibility PoC for cross-request prefix caching (issue: agentic TTFT dominated by re-prefilling
+// the whole ~8K context every request). Proves — using ONLY shipped primitives (prefill / forward /
+// snapshot / rollback / stepArgmax), no forward-path change — that the full cross-request protocol
+//
+//     prefill(A) → snapshot S → prefill(tail we discard) → rollback(S) → prefill(B) → decode
+//
+// yields a BYTE-IDENTICAL token stream to the baseline prefill(A+B) → decode, while paying only the
+// prefill of the suffix B instead of the whole A+B. A=stable content prefix (reused across requests),
+// tail = the generation prompt + generated tokens that the next request rewinds past, B = the new
+// content appended in the next request.
+extension Tell {
+    public static func prefixCachePoC(modelDir: String) -> String {
+        guard let store = try? WeightStore(modelDir: modelDir) else { return "[prefix-poc] load fail\nPREFIXPOC FAIL" }
+        store.residentAll()
+        let engine = SeedlessEngine.build(store: store)
+
+        let aLen = 1024, tailLen = 128, bLen = 256, decodeN = 32
+        func toks(_ n: Int, _ salt: Int) -> [Int32] { (0..<n).map { Int32((($0 &* 7 &+ salt) % 5000) + 100) } }
+        let A = toks(aLen, 13), tail = toks(tailLen, 999), B = toks(bLen, 5)
+        let full = A + B
+        let maxSeqLen = A.count + tailLen + B.count + decodeN + 128
+
+        func greedy(_ backend: Tell.SpecBackend, firstNormed: MLXArray) -> [Int] {
+            guard let l0 = engine.logits(firstNormed, M: 1) else { return [] }
+            MLX.eval([l0])
+            var tok = MLX.argMax(l0[0], axis: -1).item(Int.self)
+            var out = [tok]
+            for _ in 1..<decodeN {
+                guard let nx = backend.stepArgmax([Int32(tok)])?.first else { break }
+                out.append(nx); tok = nx
+            }
+            return out
+        }
+
+        // Run the reuse protocol against a backend and compare to its own baseline. `full` builds a
+        // fresh backend each call, so the two paths share no mutable state.
+        func trial(_ label: String, _ mk: () -> Tell.SpecBackend?, timed: Bool) -> String {
+            guard let bBase = mk(), let bReuse = mk() else { return "  \(label): backend nil" }
+            let t0 = Date()
+            guard let nBase = Tell.prefill(promptIds: full, backend: bBase) else { return "  \(label): prefill base nil" }
+            let tFull = Date().timeIntervalSince(t0)
+            let seqBase = greedy(bBase, firstNormed: nBase)
+
+            _ = Tell.prefill(promptIds: A, backend: bReuse)   // cache the stable content prefix
+            let snap = bReuse.snapshot()                       // content-boundary snapshot
+            _ = Tell.prefill(promptIds: tail, backend: bReuse) // gen prompt + generated (request-specific)
+            bReuse.rollback(snap)                              // next request rewinds past them
+            let t1 = Date()
+            guard let nReuse = Tell.prefill(promptIds: B, backend: bReuse) else { return "  \(label): prefill reuse nil" }
+            let tSuffix = Date().timeIntervalSince(t1)
+            let seqReuse = greedy(bReuse, firstNormed: nReuse)
+
+            let ok = seqBase == seqReuse
+            let sp = tSuffix > 0 ? String(format: " full=%.2fs suffix=%.2fs speedup=%.1fx", tFull, tSuffix, tFull / tSuffix) : ""
+            let detail = ok ? "" : "  base=\(Array(seqBase.prefix(6))) reuse=\(Array(seqReuse.prefix(6)))"
+            return "  \(label): byte-identical=\(ok ? "YES" : "NO")\(timed ? sp : "")\(detail)"
+        }
+
+        let composed = trial("composed(full copyState)", { Tell.composedBackend(engine: engine) }, timed: false)
+        let fused = trial("fused(1-step rollback)", { Tell.fusedBackend(engine: engine, maxM: 96, maxSeqLen: maxSeqLen) }, timed: true)
+        let pass = composed.contains("byte-identical=YES")
+        return """
+        [prefix-poc] A=\(aLen) tail=\(tailLen) B=\(bLen) decodeN=\(decodeN)
+        \(composed)
+        \(fused)
+        PREFIXPOC \(pass ? "PASS" : "FAIL")   (composed = the full-state primitive; fused's 1-step rollback is expected to fail arbitrary rewind)
+        """
+    }
+}

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -12,6 +12,33 @@ import MLX
 // tail = the generation prompt + generated tokens that the next request rewinds past, B = the new
 // content appended in the next request.
 extension Tell {
+    // Prefill throughput probe: measures tok/s prefilling a fixed prompt at several chunk sizes.
+    // If larger chunks are much faster → per-forward overhead dominates (raise the chunk).
+    // If flat → per-token compute is the limit (kernel-level work). Measure-before-implement.
+    public static func prefillThroughputProbe(modelDir: String) -> String {
+        guard let store = try? WeightStore(modelDir: modelDir) else { return "[prefill-probe] load fail" }
+        store.residentAll()
+        let engine = SeedlessEngine.build(store: store)
+        let promptLen = 4096
+        let prompt = (0..<promptLen).map { Int32((($0 &* 7 &+ 13) % 5000) + 100) }
+        var lines = ["[prefill-probe] promptLen=\(promptLen), resident"]
+        for chunk in [64, 128, 256, 512] {
+            guard let b = Tell.fusedBackend(engine: engine, maxM: chunk + 8, maxSeqLen: promptLen + 128) else {
+                lines.append("  chunk=\(chunk): backend nil"); continue
+            }
+            let t0 = Date()
+            var pos = 0
+            while pos < promptLen {
+                let end = Swift.min(pos + chunk, promptLen)
+                _ = b.forward(Array(prompt[pos ..< end]))
+                pos = end
+            }
+            let dt = Date().timeIntervalSince(t0)
+            lines.append(String(format: "  chunk=%4d: %.3fs  %.0f tok/s", chunk, dt, Double(promptLen) / dt))
+        }
+        return lines.joined(separator: "\n") + "\nPREFILLPROBE done"
+    }
+
     public static func prefixCachePoC(modelDir: String) -> String {
         guard let store = try? WeightStore(modelDir: modelDir) else { return "[prefix-poc] load fail\nPREFIXPOC FAIL" }
         store.residentAll()

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -174,6 +174,42 @@ extension Tell {
         return lines.joined(separator: "\n")
     }
 
+    // Speed probe for the multi-slot cache: TTFT (time-to-first-token) for a cold request vs a
+    // cross-conversation request that shares a large prefix vs an intra-conversation extend.
+    // Shows the multi-slot win = skipping re-prefill of the shared system+tools prefix on a NEW convo.
+    // Env: QWISP_PREFIX_SHARED (shared prefix length, default 4096).
+    public static func prefixCacheSpeedProbe(modelDir: String) -> String {
+        guard let backend = try? SeedlessBackend(modelDir: modelDir) else { return "[prefix-speed] load fail\nPREFIXSPEED done" }
+        setenv("QWISP_PREFIX_SNAP_STRIDE", "2048", 1)
+        let P = Tell.envInt("QWISP_PREFIX_SHARED", 4096)
+        func toks(_ n: Int, _ salt: Int) -> [Int] { (0..<n).map { (($0 &* 7 &+ salt) % 5000) + 100 } }
+        let shared = toks(P, 13)
+        func req(_ content: [Int]) -> (p: [Int], cl: Int) { (content + toks(8, 777), content.count) }
+        let r1 = req(shared + toks(64, 1))                       // cold: cache empty
+        let r2 = req(shared + toks(64, 2))                       // cross-conversation: shares `shared`
+        let r3 = req(shared + toks(64, 2) + toks(80, 3))         // intra-conversation: extends r2
+
+        final class Box: @unchecked Sendable { var v: [Int] = []; var ttft = 0.0 }
+        func ttft(_ p: [Int], _ cl: Int) -> Double {
+            let box = Box(); let sem = DispatchSemaphore(value: 0); let t0 = Date()
+            let stream = backend.generate(p, options: GenerateOptions(maxTokens: 4, promptContentLen: cl))
+            Task { for await t in stream { if box.v.isEmpty { box.ttft = Date().timeIntervalSince(t0) }; box.v.append(t) }; sem.signal() }
+            sem.wait(); return box.ttft
+        }
+
+        backend.prefixCacheForced = true
+        backend.resetPrefixCache()
+        let cold  = ttft(r1.p, r1.cl)     // cache empty → full prefill of `shared`+tail
+        let cross = ttft(r2.p, r2.cl)     // multi-slot restores a boundary inside `shared`
+        let intra = ttft(r3.p, r3.cl)     // extends r2 → restores the top boundary
+        func fmt(_ s: Double) -> String { String(format: "%.2fs", s) }
+        return ["[prefix-speed] shared prefix=\(P) tok, resident/fused, greedy",
+                "  R1 cold (cache empty)      TTFT \(fmt(cold))",
+                String(format: "  R2 cross-conversation      TTFT %@   (%.1fx vs cold)", fmt(cross), cold / max(cross, 1e-3)),
+                String(format: "  R3 intra-conversation      TTFT %@   (%.1fx vs cold)", fmt(intra), cold / max(intra, 1e-3)),
+                "PREFIXSPEED done"].joined(separator: "\n")
+    }
+
     public static func prefixCachePoC(modelDir: String) -> String {
         guard let store = try? WeightStore(modelDir: modelDir) else { return "[prefix-poc] load fail\nPREFIXPOC FAIL" }
         store.residentAll()

--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -2689,6 +2689,20 @@ public enum SeedlessFusedVerify {
                 MLXArray(Array(UnsafeBufferPointer(start: sp, count: c.Hv * c.Dv * c.Dk)), [1, c.Hv, c.Dv, c.Dk]))
     }
 
+    /// Write a saved (conv hist, rec state) back into the CURRENT (In) side of a GDN cache —
+    /// the inverse of readGdnCache, for full-state restore (prefix caching, notes/…). The next
+    /// encode reads convHist/state, so writing there restores the layer to the snapshot exactly.
+    static func writeGdnCache(_ c: GdnCacheBufs, conv: MLXArray, rec: MLXArray) {
+        let cf = conv.asType(.float16).reshaped([-1]); cf.eval()
+        let ca = cf.asArray(Float16.self)
+        c.convHist.contents().bindMemory(to: Float16.self, capacity: (c.K - 1) * c.C)
+            .update(from: ca, count: min(ca.count, (c.K - 1) * c.C))
+        let rf = rec.asType(.float32).reshaped([-1]); rf.eval()
+        let ra = rf.asArray(Float.self)
+        c.state.contents().bindMemory(to: Float.self, capacity: c.Hv * c.Dv * c.Dk)
+            .update(from: ra, count: min(ra.count, c.Hv * c.Dv * c.Dk))
+    }
+
     /// GDN 層の常駐 scratch。
     public struct GdnScratch {
         let qkv: MTLBuffer, z: MTLBuffer, bP: MTLBuffer, aP: MTLBuffer
@@ -3668,6 +3682,27 @@ public enum SeedlessFusedVerify {
             for (i, L) in layers.enumerated() {
                 if let kv = L.kvCache { kv.len = s.kvLens[i] }
                 if let gc = L.gdnCache { gc.swapState() }
+            }
+        }
+
+        /// Full-state snapshot/restore for ARBITRARY-length rewind (cross-request prefix caching) —
+        /// additive; the 1-step spec path (snapshot/rollbackOneStep) is untouched. KV needs only its
+        /// length (forwardRows only appends, so positions 0..len stay intact and are re-prefilled
+        /// over on restore); GDN's ping-pong holds only 1 step, so its state is deep-copied.
+        public struct FullSnapshot { let kvLens: [Int]; let gdn: [(conv: MLXArray, rec: MLXArray)?] }
+        public func fullSnapshot() -> FullSnapshot {
+            let gdn = layers.map { L -> (conv: MLXArray, rec: MLXArray)? in
+                guard let gc = L.gdnCache else { return nil }
+                let (c, r) = SeedlessFusedVerify.readGdnCache(gc); return (c, r)
+            }
+            return FullSnapshot(kvLens: layers.map { $0.kvCache?.len ?? 0 }, gdn: gdn)
+        }
+        public func fullRestore(_ s: FullSnapshot) {
+            for (i, L) in layers.enumerated() {
+                if let kv = L.kvCache { kv.len = s.kvLens[i] }
+                if let gc = L.gdnCache, let g = s.gdn[i] {
+                    SeedlessFusedVerify.writeGdnCache(gc, conv: g.conv, rec: g.rec)
+                }
             }
         }
 

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -326,9 +326,13 @@ extension Tell {
     /// Returns out[0..<N] token ids.
     static func runSpecLoop(promptIds: [Int32], backend: SpecBackend, engine: SeedlessEngine,
                              N: Int, maxK: Int, useA3: Bool = false,
+                             prefillTokens: [Int32]? = nil,
                              isCancelled: (() -> Bool)? = nil,
                              onToken: ((Int) -> Void)? = nil) -> [Int]? {
-        guard let lastNormed = prefill(promptIds: promptIds, backend: backend) else { return nil }
+        // prefixCache: when the backend's cache already holds a prefix of `promptIds`, pass the
+        // remaining suffix as prefillTokens (forward appends it at the cache's current position).
+        // `hist` still uses the full promptIds so SuffixSpec drafting is unchanged (speed preserved).
+        guard let lastNormed = prefill(promptIds: prefillTokens ?? promptIds, backend: backend) else { return nil }
         guard let lg0 = engine.logits(lastNormed, M: 1) else { return nil }
         MLX.eval([lg0])
         var u = MLX.argMax(lg0[0], axis: -1).item(Int.self)

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -85,6 +85,10 @@ extension Tell {
         let stepArgmax: ([Int32]) -> [Int]?
         let snapshot: () -> Any
         let rollback: (Any) -> Void
+        // Full-state save/restore for arbitrary-length rewind (cross-request prefix caching).
+        // Distinct from snapshot/rollback (1-step spec). nil if the backend doesn't support it.
+        var fullSnapshot: (() -> Any)? = nil
+        var fullRestore: ((Any) -> Void)? = nil
         var chainedStepArgmax: ((Int32, Int) -> [Int]?)? = nil   // Phase II-a
         // Option B (sampling): full logits per input row (readback), for speculative sampling.
         // Additive — greedy stepArgmax path is untouched.
@@ -162,6 +166,11 @@ extension Tell {
                 guard let s = snap as? SeedlessFusedVerify.SeedlessFusedForward.Snapshot else { return }
                 fwd.rollbackOneStep(s)
             })
+        // Full-state save/restore (prefix caching): deep-copies GDN state so arbitrary rewind is exact.
+        backend.fullSnapshot = { fwd.fullSnapshot() }
+        backend.fullRestore = { snap in
+            if let s = snap as? SeedlessFusedVerify.SeedlessFusedForward.FullSnapshot { fwd.fullRestore(s) }
+        }
         // Phase II-a: wire chained greedy decode when the 1-CB head path is active.
         // Only resident/bolt return non-nil (strict returns nil → per-step fallback).
         if fwd.head != nil {
@@ -202,6 +211,11 @@ extension Tell {
                 guard let s = snap as? SeedlessFusedVerify.SeedlessFusedForward.Snapshot else { return }
                 fwd.rollbackOneStep(s)
             })
+        // Full-state save/restore (prefix caching): deep-copies GDN state so arbitrary rewind is exact.
+        backend.fullSnapshot = { fwd.fullSnapshot() }
+        backend.fullRestore = { snap in
+            if let s = snap as? SeedlessFusedVerify.SeedlessFusedForward.FullSnapshot { fwd.fullRestore(s) }
+        }
         // Phase II-a: wire chained greedy decode when the 1-CB head path is active.
         if fwd.head != nil {
             backend.chainedStepArgmax = { token, k in fwd.chainedStepArgmax(token, K: k) }

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -23,6 +23,7 @@ if CommandLine.arguments.contains("stream") {
         ("raw-tests", { _, _ in SeedlessVerifyTests.runAll() }),
         ("raw-spec",  { try Tell.run(modelDir: $0, refPath: $1) }),
         ("prefix-cache-poc", { md, _ in Tell.prefixCachePoC(modelDir: md) }),
+        ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),
     ]
     if let name = env["QWISP_RUN"] {
         if let r = runners.first(where: { $0.0 == name }) {

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -23,6 +23,8 @@ if CommandLine.arguments.contains("stream") {
         ("raw-tests", { _, _ in SeedlessVerifyTests.runAll() }),
         ("raw-spec",  { try Tell.run(modelDir: $0, refPath: $1) }),
         ("prefix-cache-poc", { md, _ in Tell.prefixCachePoC(modelDir: md) }),
+        ("prefill-breakdown", { md, _ in Tell.prefillBreakdownProbe(modelDir: md) }),
+        ("prefix-cache-e2e", { md, _ in Tell.prefixCacheE2E(modelDir: md) }),
         ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),
     ]
     if let name = env["QWISP_RUN"] {

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -22,6 +22,7 @@ if CommandLine.arguments.contains("stream") {
     let runners: [(String, (String, String) throws -> String)] = [
         ("raw-tests", { _, _ in SeedlessVerifyTests.runAll() }),
         ("raw-spec",  { try Tell.run(modelDir: $0, refPath: $1) }),
+        ("prefix-cache-poc", { md, _ in Tell.prefixCachePoC(modelDir: md) }),
     ]
     if let name = env["QWISP_RUN"] {
         if let r = runners.first(where: { $0.0 == name }) {

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -25,6 +25,7 @@ if CommandLine.arguments.contains("stream") {
         ("prefix-cache-poc", { md, _ in Tell.prefixCachePoC(modelDir: md) }),
         ("prefill-breakdown", { md, _ in Tell.prefillBreakdownProbe(modelDir: md) }),
         ("prefix-cache-e2e", { md, _ in Tell.prefixCacheE2E(modelDir: md) }),
+        ("prefix-cache-speed", { md, _ in Tell.prefixCacheSpeedProbe(modelDir: md) }),
         ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),
     ]
     if let name = env["QWISP_RUN"] {

--- a/swift/Sources/qwisp/ChatCompletion.swift
+++ b/swift/Sources/qwisp/ChatCompletion.swift
@@ -113,12 +113,12 @@ func runGeneration(promptIds: [Int], maxTokens: Int, stopIds: [Int],
                    decode: ([Int]) -> String, backend: any LLMBackend,
                    temperature: Double = 0, topP: Double = 1.0, seed: UInt64 = 0,
                    frequencyPenalty: Double = 0, presencePenalty: Double = 0,
-                   logitBias: [Int: Double] = [:],
+                   logitBias: [Int: Double] = [:], promptContentLen: Int? = nil,
                    onDelta: (String) -> Void) async -> CompletionResult {
     let opts = GenerateOptions(maxTokens: maxTokens, stopTokens: stopIds,
                                temperature: temperature, topP: topP, seed: seed,
                                frequencyPenalty: frequencyPenalty, presencePenalty: presencePenalty,
-                               logitBias: logitBias)
+                               logitBias: logitBias, promptContentLen: promptContentLen)
     var outIds: [Int] = []
     var emitted = ""
     var finish = "stop"

--- a/swift/Sources/qwisp/QwispTokenizer.swift
+++ b/swift/Sources/qwisp/QwispTokenizer.swift
@@ -38,10 +38,11 @@ struct QwispTokenizer {
     /// Render chat messages (+ optional tool specs) → token ids (chat_template + generation prompt).
     /// Messages/tools are `[String: any Sendable]` so they can carry tool_calls, tool results, and
     /// arbitrary tool JSON schemas through to the Jinja template.
-    func render(messages: [[String: any Sendable]], tools: [[String: any Sendable]]? = nil) throws -> [Int] {
+    func render(messages: [[String: any Sendable]], tools: [[String: any Sendable]]? = nil,
+                addGenerationPrompt: Bool = true) throws -> [Int] {
         let ct: ChatTemplateArgument? = chatTemplate.map { .literal($0) }
         return try tokenizer.applyChatTemplate(messages: messages, chatTemplate: ct,
-                                               addGenerationPrompt: true, truncation: false,
+                                               addGenerationPrompt: addGenerationPrompt, truncation: false,
                                                maxLength: nil, tools: tools)
     }
 }

--- a/swift/Sources/qwisp/Server.swift
+++ b/swift/Sources/qwisp/Server.swift
@@ -69,10 +69,13 @@ final class QwispEngine: @unchecked Sendable {
                               presencePenalty: req.presence_penalty ?? 0, logitBias: bias)
     }
 
-    private func prompt(_ req: ChatCompletionRequest) throws -> (ids: [Int], maxTokens: Int, stop: [Int]) {
+    private func prompt(_ req: ChatCompletionRequest) throws -> (ids: [Int], maxTokens: Int, stop: [Int], contentLen: Int) {
         let msgs = req.messages.map { $0.renderDict }
-        let ids = try tokenizer.render(messages: msgs, tools: req.tools?.map { $0.spec })
-        return (ids, req.max_tokens ?? -1, tokenizer.stopTokenIds)   // omitted → until EOS/context
+        let tools = req.tools?.map { $0.spec }
+        let ids = try tokenizer.render(messages: msgs, tools: tools)
+        // Content boundary (prompt WITHOUT the generation-prompt suffix) → the prefix-cache reuse point.
+        let contentLen = (try? tokenizer.render(messages: msgs, tools: tools, addGenerationPrompt: false).count) ?? ids.count
+        return (ids, req.max_tokens ?? -1, tokenizer.stopTokenIds, contentLen)   // omitted → until EOS/context
     }
 
     // One concise throughput line per request → the service log. prefix TTFT (prefill + first
@@ -96,7 +99,7 @@ final class QwispEngine: @unchecked Sendable {
                                     decode: { tokenizer.decode($0) }, backend: backend,
                                     temperature: s.temperature, topP: s.topP, seed: s.seed,
                                     frequencyPenalty: s.frequencyPenalty, presencePenalty: s.presencePenalty,
-                                    logitBias: s.logitBias) { _ in if tFirst == nil { tFirst = Date() } }
+                                    logitBias: s.logitBias, promptContentLen: p.contentLen) { _ in if tFirst == nil { tFirst = Date() } }
         await lock.release()
         logPerf("complete", prompt: p.ids.count, gen: r.completionTokens, t0: t0, tFirst: tFirst)
         let id = "chatcmpl-\(UUID().uuidString.prefix(24))"
@@ -136,7 +139,7 @@ final class QwispEngine: @unchecked Sendable {
         let opts = GenerateOptions(maxTokens: p.maxTokens, stopTokens: p.stop,
                                    temperature: s.temperature, topP: s.topP, seed: s.seed,
                                    frequencyPenalty: s.frequencyPenalty, presencePenalty: s.presencePenalty,
-                                   logitBias: s.logitBias)
+                                   logitBias: s.logitBias, promptContentLen: p.contentLen)
         let t0 = Date(); var tFirst: Date? = nil
         for await tok in backend.generate(p.ids, options: opts) {
             if p.stop.contains(tok) { finish = "stop"; break }


### PR DESCRIPTION
## Summary

Cross-request prefix KV cache for the OpenAI server, now **default ON**. Agentic loops (opencode etc.) were spending ~88% of wall time re-prefilling the same ~8.5K context every request. This PR adds an additive full-state snapshot/restore primitive on the fused forward, a persistent lazy-growing KV arena, and multi-slot stride-aligned restore points so both the next turn of a conversation *and a brand-new conversation sharing the system+tools prefix* skip re-prefill.

Measured:
- Real opencode agentic task **335s → 97s (3.5x)**; reused-request TTFT **58s → 0.5–1.75s**
- Cross-conversation TTFT on a 4096-token shared prefix: **20.75s → 0.75s (27.5x)** (`QWISP_RUN=prefix-cache-speed`)

Design:
- **Engine (additive only)**: `fullSnapshot`/`fullRestore` beside the existing 1-step `snapshot`/`rollbackOneStep` — KV saves only lengths (append-only), GDN recurrent state is deep-copied (~60MB/slot). Frozen forward math untouched.
- **Lazy-growing arena (Design B)**: grows geometrically per request (monotonic, bounded by `QWISP_PREFIX_MAX`, default 64K) — no fixed-cap truncation, which is what unblocked default-on.
- **Multi-slot**: stride-aligned restore points (`QWISP_PREFIX_SNAP_STRIDE`=2048, cap `QWISP_PREFIX_MAX_SLOTS`=6) along the current path; densest-neighbour eviction. RadixAttention-style reuse over a single linear arena.
- Scope: resident/fused + greedy only; streaming/sampling/oversize fall through to the existing segmented path. `QWISP_PREFIX_CACHE=0` opts out.

Also includes the prefill investigation that motivated the cache-first approach: prefill is 97–98% GPU-kernel-execution-bound (`prefill-breakdown` v2) with no CPU/sync prize, and kernel surgery lineage is measured NO-GO — so the realizable turn-1 lever is prefix reuse, not raw prefill speed.

## Related issue

None (worked on branch directly; handoff via HANDOFF.md).

## Verification

- [x] Tests pass — RAWTESTS **79/79**, BENCHBATCH **PASS**, COMPTEST **13/13** (server exercises the cached path now that it defaults on), TOKTEST **3/3**
- [x] Lossless gate `QWISP_RUN=prefix-cache-e2e`: cold / extend / cross-conversation / reset all **byte-identical** to the non-cached reference (4/4)
- [x] Zero new warnings in the touched files
- [x] Docs: env knobs documented in code comments; README unchanged (no user-facing flag needed — default on)

## Notes for reviewer

- `generateCached` state is mutated from the detached decode thread; safe because the server serializes requests (AsyncLock) — invariant documented in the code.
- Arena growth rebuilds the backend and drops snapshots (one cold re-warm); mid-decode growth is the documented upgrade path if a workload ever needs >64K generation.
- Snapshot memory: ≤6 slots × ~60MB ≈ 360MB worst case, resident tier only.
- Diagnostic runners added: `prefix-cache-e2e` (lossless gate), `prefix-cache-speed`, `prefill-breakdown` (v2), `prefill-probe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM