### PR TITLE
feat(prefill): steel-prefill hybrid default ON — cold prefill 2.24x (451 tok/s), agentic task 1.86x

### DIFF
--- a/scripts/bench_matrix.sh
+++ b/scripts/bench_matrix.sh
@@ -43,10 +43,14 @@ else
     log="$DIR/qwisp-fm-$tag.log"
     echo "== $tag (C=$c thr=$thr) -> $log =="
     # DEFER only for slow configs' strict batch (bench_batch strips it for raw bolt calls).
+    # Tier-split canonical refs: resident (C=256) compares against refs/resident (steel-prefill
+    # hybrid canonical); streaming tiers keep refs/ (pre-hybrid canonical — hybrid is resident-only,
+    # streaming streams are unchanged by construction).
+    refsdir="$REPO/refs"; [ "$c" = 256 ] && refsdir="$REPO/refs/resident"
     if [ "$thr" != 0 ]; then
-      QWISP_THROTTLE_DEFER=1 "$REPO/scripts/bench_batch.sh" "$c" "$GEN" "$thr" "$methods" > "$log" 2>&1
+      QWISP_BENCH_REFS="$refsdir" QWISP_THROTTLE_DEFER=1 "$REPO/scripts/bench_batch.sh" "$c" "$GEN" "$thr" "$methods" > "$log" 2>&1
     else
-      "$REPO/scripts/bench_batch.sh" "$c" "$GEN" "$thr" "$methods" > "$log" 2>&1
+      QWISP_BENCH_REFS="$refsdir" "$REPO/scripts/bench_batch.sh" "$c" "$GEN" "$thr" "$methods" > "$log" 2>&1
     fi
     echo "EXIT=$?" >> "$log"
     tail -n +2 "$log" | grep -E '^  (suffix-spec|bolt) +(code|agentic|longctx|shortnl) ' || true

--- a/swift/Sources/QwispCore/GroupedMoEPoC.swift
+++ b/swift/Sources/QwispCore/GroupedMoEPoC.swift
@@ -692,9 +692,59 @@ public enum GroupedMoEPoC {
             let teArr = MLXArray(tileExpert, [Gt])
             _ = timeEval(3) { MLX.gatherQuantizedMatmul(xgArr, wq, scales: sc, biases: bi, rhsIndices: teArr, transpose: true, groupSize: 64, bits: 4, mode: .affine, sortedIndices: true) }
             let tSteel = timeEval(10) { MLX.gatherQuantizedMatmul(xgArr, wq, scales: sc, biases: bi, rhsIndices: teArr, transpose: true, groupSize: 64, bits: 4, mode: .affine, sortedIndices: true) }
+            // VALUE correctness: steel-CSR re-scattered vs production-shape gather (different kernels
+            // → not bit-equal; rel err ~1e-3 = same semantics, large = wrong rhsIndices broadcast)
+            var relV = -1.0
+            do {
+                let yP = MLX.gatherQuantizedMatmul(xe, wq, scales: sc, biases: bi, rhsIndices: indsArr, transpose: true, groupSize: 64, bits: 4, mode: .affine, sortedIndices: false)
+                let yS = MLX.gatherQuantizedMatmul(xgArr, wq, scales: sc, biases: bi, rhsIndices: teArr, transpose: true, groupSize: 64, bits: 4, mode: .affine, sortedIndices: true)
+                MLX.eval([yP, yS])
+                let ap = yP.reshaped([-1]).asArray(Float16.self)          // [T,Ktop,1,N] flat = mk-major
+                let as_ = yS.reshaped([-1]).asArray(Float16.self)         // [Gt,R,N] flat = tile-major
+                var pos = [Int: Int]()
+                for (ti, rows) in tileRows.enumerated() { for (ri, mk) in rows.enumerated() { pos[Int(mk)] = ti * R + ri } }
+                var nv = 0.0, dv = 0.0
+                for mk in 0..<(T * Ktop) {
+                    let o1 = mk * N, o2 = pos[mk]! * N
+                    for j in 0..<N { nv += abs(Double(ap[o1+j]) - Double(as_[o2+j])); dv += abs(Double(ap[o1+j])) }
+                }
+                relV = nv / Swift.max(dv, 1e-9)
+            }
+            // FULL-CHAIN value check: g→u→swiglu→d in steel-CSR tile space vs production per-pair shapes.
+            // Isolates the d-shape (K=512→N=2048) steel gather semantics, never value-verified before.
+            var relChain = -1.0
+            do {
+                let wf2 = MLXRandom.normal([E, K, N]).asType(.float16)     // "down": [E, H=K? no: E, out=K(2048), in=N(512)]
+                let (dq, ds, dbO) = MLX.quantized(wf2, groupSize: 64, bits: 4, mode: .affine)
+                let db = dbO!
+                // production: per-pair
+                let gP = MLX.gatherQuantizedMatmul(xe, wq, scales: sc, biases: bi, rhsIndices: indsArr, transpose: true, groupSize: 64, bits: 4, mode: .affine, sortedIndices: false)
+                let gPs = gP * Float16(0.01)   // scale down: synthetic weights overflow f16 in silu(g)*g
+                let hP = (gPs * MLX.sigmoid(gPs)) * gPs                     // [T,Ktop,1,N]
+                let hPr = hP.reshaped([T * Ktop, 1, 1, N])
+                let indsFlat = indsArr.reshaped([T * Ktop, 1])
+                let dP = MLX.gatherQuantizedMatmul(hPr, dq, scales: ds, biases: db, rhsIndices: indsFlat, transpose: true, groupSize: 64, bits: 4, mode: .affine, sortedIndices: false)
+                // steel-CSR: tile space
+                let gS = MLX.gatherQuantizedMatmul(xgArr, wq, scales: sc, biases: bi, rhsIndices: teArr, transpose: true, groupSize: 64, bits: 4, mode: .affine, sortedIndices: true)
+                let gSs = gS * Float16(0.01)
+                let hS = (gSs * MLX.sigmoid(gSs)) * gSs                     // matches hP transform
+                let dS = MLX.gatherQuantizedMatmul(hS, dq, scales: ds, biases: db, rhsIndices: teArr, transpose: true, groupSize: 64, bits: 4, mode: .affine, sortedIndices: true)
+                MLX.eval([dP, dS])
+                let a = dP.reshaped([-1]).asArray(Float16.self)             // mk-major [T*Ktop, K]
+                let b = dS.reshaped([-1]).asArray(Float16.self)             // tile-major [Gt,R,K]
+                var pos = [Int: Int]()
+                for (ti, rows) in tileRows.enumerated() { for (ri, mk) in rows.enumerated() { pos[Int(mk)] = ti * R + ri } }
+                var nv = 0.0, dv = 0.0
+                let NN = K   // down output dim = K (2048) in this synthetic setup
+                for mk in 0..<(T * Ktop) {
+                    let o1 = mk * NN, o2 = pos[mk]! * NN
+                    for j in 0..<NN { nv += abs(Double(a[o1+j]) - Double(b[o2+j])); dv += abs(Double(a[o1+j])) }
+                }
+                relChain = nv / Swift.max(dv, 1e-9)
+            }
             let padFactor = Double(Gt * R) / Double(T * Ktop)
-            out.append(String(format: "  T=%4d  prod(qmv) %7.3fms | steel-CSR %7.3fms  %5.2fx  (tiles=%d pad=%.2fx)",
-                              T, tProd, tSteel, tProd / tSteel, Gt, padFactor))
+            out.append(String(format: "  T=%4d  prod(qmv) %7.3fms | steel-CSR %7.3fms  %5.2fx  (tiles=%d pad=%.2fx)  valErr %.2e %@  chainErr %.2e %@",
+                              T, tProd, tSteel, tProd / tSteel, Gt, padFactor, relV, relV < 5e-3 ? "✅" : "SEMANTICS❌", relChain, relChain < 5e-3 ? "✅" : "CHAIN❌"))
             // (3) tile-composition invariance at this T: recompute with a DIFFERENT composition
             // (shuffle rows into tiles of the same expert differently: reverse order within expert)
             if T == 256 {

--- a/swift/Sources/QwispCore/GroupedMoEPoC.swift
+++ b/swift/Sources/QwispCore/GroupedMoEPoC.swift
@@ -1,0 +1,457 @@
+import Foundation
+import Metal
+import MLX
+
+// Grouped-MoE gather kernel PoC (prefill kernel-speedup recon, branch claude/prefill-kernel).
+//
+// Hypothesis (from prefill-stage-profile): prefill MoE (50.8% of prefill GPU time) is flat in
+// chunk size because gqmm4_rows assigns one threadgroup per (row, expert) PAIR — every row
+// assigned to an expert re-reads that expert's full weight slab from DRAM (union >> SLC at
+// prefill M, so the hardware cannot amortize; 484e401's own analysis says explicit grouping
+// only wins when working set > L2 — decode B=8 didn't qualify, prefill does).
+//
+// Prototype: gqmm4_grouped_rows — one threadgroup per (EXPERT GROUP, n-tile). The tg loops the
+// R rows routed to that expert; the 4-output-row × K weight slice it walks (~4KB) stays in L1
+// across the R iterations, so DRAM weight traffic drops ~R×. Bit-exact BY CONSTRUCTION: the
+// per-(row, out_row) instruction sequence (ld16 / qd4 K-walk / simd_sum) is byte-identical to
+// gqmm4_rows — only the tg→work mapping changes, and rows are independent outputs.
+//
+// This is measurement-only scaffolding: synthetic weights/routing, self-contained pipelines.
+// Production wiring happens only if this bench wins (then via devloop, RAWTESTS-gated).
+public enum GroupedMoEPoC {
+    nonisolated(unsafe) static var pipeRef: MTLComputePipelineState?
+    nonisolated(unsafe) static var pipeGrp: MTLComputePipelineState?
+    nonisolated(unsafe) static var pipeGrp2: MTLComputePipelineState?
+    nonisolated(unsafe) static var pipeNoDeq: MTLComputePipelineState?
+
+    static let kernelSrc = """
+    #include <metal_stdlib>
+    using namespace metal;
+    inline float ld16(const device half* x, thread float* xt) {
+        float sum = 0.0f;
+        for (int i = 0; i < 16; i += 4) {
+            sum += x[i] + x[i+1] + x[i+2] + x[i+3];
+            xt[i] = x[i]; xt[i+1] = x[i+1]/16.0f; xt[i+2] = x[i+2]/256.0f; xt[i+3] = x[i+3]/4096.0f;
+        }
+        return sum;
+    }
+    inline float qd4(const device uint8_t* w, const thread float* xt, float scale, float bias, float sum) {
+        float accum = 0.0f;
+        const device uint16_t* ws = (const device uint16_t*)w;
+        for (int i = 0; i < 4; i++) {
+            accum += (xt[4*i]   * (float)(ws[i] & 0x000f) +
+                      xt[4*i+1] * (float)(ws[i] & 0x00f0) +
+                      xt[4*i+2] * (float)(ws[i] & 0x0f00) +
+                      xt[4*i+3] * (float)(ws[i] & 0xf000));
+        }
+        return scale * accum + sum * bias;
+    }
+
+    // Reference: verbatim gqmm4_rows structure (one tg per (row,expert) pair).
+    kernel void gq_ref(device const uint32_t* w      [[buffer(0)]],
+                       device const half*     scales [[buffer(1)]],
+                       device const half*     biases [[buffer(2)]],
+                       device const half*     x      [[buffer(3)]],
+                       device const int*      inds   [[buffer(4)]],
+                       device half*           y      [[buffer(5)]],
+                       constant int& in_vec_size  [[buffer(6)]],
+                       constant int& out_vec_size [[buffer(7)]],
+                       constant int& ktop         [[buffer(8)]],
+                       constant uint& lhsPer      [[buffer(9)]],
+                       uint3 tid      [[threadgroup_position_in_grid]],
+                       uint  simd_gid [[simdgroup_index_in_threadgroup]],
+                       uint  simd_lid [[thread_index_in_simdgroup]]) {
+        constexpr int packs_per_thread = 2, results_per_simdgroup = 4;
+        constexpr int bytes_per_pack = 4, values_per_thread = 16;
+        constexpr int block_size = 512, scale_step_per_thread = 4;
+        const device uint8_t* ws = (const device uint8_t*)w;
+        typedef float U;
+        thread U x_thread[16];
+        thread U result[4] = {0};
+        const int in_vec_size_w = in_vec_size / 2;
+        const int in_vec_size_g = in_vec_size / 64;
+        uint mk = tid.z;
+        uint e = (uint)inds[mk];
+        ws     += (size_t)e * out_vec_size * in_vec_size_w;
+        scales += (size_t)e * out_vec_size * in_vec_size_g;
+        biases += (size_t)e * out_vec_size * in_vec_size_g;
+        const int out_row = tid.y * 8 + simd_gid * results_per_simdgroup;
+        ws     += out_row * in_vec_size_w + simd_lid * packs_per_thread * bytes_per_pack;
+        scales += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+        biases += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+        x += (size_t)(lhsPer ? mk : mk / (uint)ktop) * in_vec_size + simd_lid * values_per_thread;
+        y += (size_t)mk * out_vec_size + out_row;
+        for (int k = 0; k < in_vec_size; k += block_size) {
+            U sum = ld16(x, x_thread);
+            for (int row = 0; row < results_per_simdgroup; row++) {
+                auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
+                const device half* sl = scales + row * in_vec_size_g;
+                const device half* bl = biases + row * in_vec_size_g;
+                U s = sl[0]; U b = bl[0];
+                result[row] += qd4(wl, x_thread, s, b, sum);
+            }
+            ws += block_size / 2;
+            scales += block_size / 64; biases += block_size / 64; x += block_size;
+        }
+        for (int row = 0; row < results_per_simdgroup; row++) {
+            result[row] = simd_sum(result[row]);
+            if (simd_lid == 0) y[row] = (half)result[row];
+        }
+    }
+
+    // Grouped: one tg per (expert group, n-tile); loops the R rows of the group. Per-(row,out_row)
+    // arithmetic sequence identical to gq_ref; the tg's 4-row weight slice stays hot in L1 across r.
+    kernel void gq_grouped(device const uint32_t* w      [[buffer(0)]],
+                           device const half*     scales [[buffer(1)]],
+                           device const half*     biases [[buffer(2)]],
+                           device const half*     x      [[buffer(3)]],
+                           device const int*      gExpert [[buffer(4)]],   // [G]
+                           device const int*      gRowOff [[buffer(5)]],   // [G+1] CSR offsets
+                           device const int*      gRowIdx [[buffer(6)]],   // [M*Ktop] mk indices
+                           device half*           y      [[buffer(7)]],
+                           constant int& in_vec_size  [[buffer(8)]],
+                           constant int& out_vec_size [[buffer(9)]],
+                           constant int& ktop         [[buffer(10)]],
+                           constant uint& lhsPer      [[buffer(11)]],
+                           uint3 tid      [[threadgroup_position_in_grid]],
+                           uint  simd_gid [[simdgroup_index_in_threadgroup]],
+                           uint  simd_lid [[thread_index_in_simdgroup]]) {
+        constexpr int packs_per_thread = 2, results_per_simdgroup = 4;
+        constexpr int bytes_per_pack = 4, values_per_thread = 16;
+        constexpr int block_size = 512, scale_step_per_thread = 4;
+        const device uint8_t* ws0 = (const device uint8_t*)w;
+        typedef float U;
+        const int in_vec_size_w = in_vec_size / 2;
+        const int in_vec_size_g = in_vec_size / 64;
+        uint g = tid.z;
+        uint e = (uint)gExpert[g];
+        ws0    += (size_t)e * out_vec_size * in_vec_size_w;
+        scales += (size_t)e * out_vec_size * in_vec_size_g;
+        biases += (size_t)e * out_vec_size * in_vec_size_g;
+        const int out_row = tid.y * 8 + simd_gid * results_per_simdgroup;
+        ws0    += out_row * in_vec_size_w + simd_lid * packs_per_thread * bytes_per_pack;
+        scales += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+        biases += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+        const int i0 = gRowOff[g], i1 = gRowOff[g + 1];
+        for (int i = i0; i < i1; ++i) {
+            uint mk = (uint)gRowIdx[i];
+            const device half* xr = x + (size_t)(lhsPer ? mk : mk / (uint)ktop) * in_vec_size + simd_lid * values_per_thread;
+            device half* yr = y + (size_t)mk * out_vec_size + out_row;
+            thread U x_thread[16];
+            thread U result[4] = {0};
+            auto wsr = ws0;
+            auto sr = scales; auto br = biases;
+            for (int k = 0; k < in_vec_size; k += block_size) {
+                U sum = ld16(xr, x_thread);
+                for (int row = 0; row < results_per_simdgroup; row++) {
+                    auto wl = (const device uint8_t*)(wsr + row * in_vec_size_w);
+                    const device half* sl = sr + row * in_vec_size_g;
+                    const device half* bl = br + row * in_vec_size_g;
+                    U s = sl[0]; U b = bl[0];
+                    result[row] += qd4(wl, x_thread, s, b, sum);
+                }
+                wsr += block_size / 2;
+                sr += block_size / 64; br += block_size / 64; xr += block_size;
+            }
+            for (int row = 0; row < results_per_simdgroup; row++) {
+                result[row] = simd_sum(result[row]);
+                if (simd_lid == 0) yr[row] = (half)result[row];
+            }
+        }
+    }
+    // v2: threadgroup-shared UNPACKED weights — the (float)(ws & mask) dequant converts are done
+    // ONCE per (group, K-block) and shared across the group's rows (dequant is ~half the inner-loop
+    // ALU and the per-pair kernel is ALU-bound, per v1). Bit-exact: the shared values are the exact
+    // floats qd4 computes, and each (row, out_row) accumulates them in the identical i/block order
+    // with the identical simd_sum. Groups are capped at R_MAX=8 rows (register accumulators).
+    kernel void gq_grouped2(device const uint32_t* w      [[buffer(0)]],
+                            device const half*     scales [[buffer(1)]],
+                            device const half*     biases [[buffer(2)]],
+                            device const half*     x      [[buffer(3)]],
+                            device const int*      gExpert [[buffer(4)]],
+                            device const int*      gRowOff [[buffer(5)]],
+                            device const int*      gRowIdx [[buffer(6)]],
+                            device half*           y      [[buffer(7)]],
+                            constant int& in_vec_size  [[buffer(8)]],
+                            constant int& out_vec_size [[buffer(9)]],
+                            constant int& ktop         [[buffer(10)]],
+                            constant uint& lhsPer      [[buffer(11)]],
+                            uint3 tid      [[threadgroup_position_in_grid]],
+                            uint  simd_gid [[simdgroup_index_in_threadgroup]],
+                            uint  simd_lid [[thread_index_in_simdgroup]]) {
+        constexpr int packs_per_thread = 2, results_per_simdgroup = 4;
+        constexpr int bytes_per_pack = 4, values_per_thread = 16;
+        constexpr int block_size = 512, scale_step_per_thread = 4;
+        constexpr int R_MAX = 8;
+        const device uint8_t* ws0 = (const device uint8_t*)w;
+        typedef float U;
+        threadgroup float wsh[8][512];                       // [simd_gid*4+row][block value]
+        const int in_vec_size_w = in_vec_size / 2;
+        const int in_vec_size_g = in_vec_size / 64;
+        uint g = tid.z;
+        uint e = (uint)gExpert[g];
+        ws0    += (size_t)e * out_vec_size * in_vec_size_w;
+        scales += (size_t)e * out_vec_size * in_vec_size_g;
+        biases += (size_t)e * out_vec_size * in_vec_size_g;
+        const int out_row = tid.y * 8 + simd_gid * results_per_simdgroup;
+        ws0    += out_row * in_vec_size_w + simd_lid * packs_per_thread * bytes_per_pack;
+        scales += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+        biases += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+        const int i0 = gRowOff[g];
+        const int R = min(gRowOff[g + 1] - i0, R_MAX);
+        thread U result[R_MAX][4] = {{0}};
+        thread U x_thread[16];
+        auto wsr = ws0; auto sr = scales; auto br = biases;
+        for (int k = 0; k < in_vec_size; k += block_size) {
+            // unpack this K-block's 4 weight rows (per simdgroup) into shared memory — exactly the
+            // masked floats qd4 uses; each lane converts its own 16-value slice per row.
+            for (int row = 0; row < results_per_simdgroup; row++) {
+                const device uint16_t* wl = (const device uint16_t*)(wsr + row * in_vec_size_w);
+                threadgroup float* dst = wsh[simd_gid * results_per_simdgroup + row] + simd_lid * values_per_thread;
+                for (int i = 0; i < 4; i++) {
+                    uint16_t v = wl[i];
+                    dst[4*i]   = (float)(v & 0x000f);
+                    dst[4*i+1] = (float)(v & 0x00f0);
+                    dst[4*i+2] = (float)(v & 0x0f00);
+                    dst[4*i+3] = (float)(v & 0xf000);
+                }
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+            for (int r = 0; r < R; ++r) {
+                uint mk = (uint)gRowIdx[i0 + r];
+                const device half* xr = x + (size_t)(lhsPer ? mk : mk / (uint)ktop) * in_vec_size + k + simd_lid * values_per_thread;
+                U sum = ld16(xr, x_thread);
+                for (int row = 0; row < results_per_simdgroup; row++) {
+                    const threadgroup float* wf = wsh[simd_gid * results_per_simdgroup + row] + simd_lid * values_per_thread;
+                    const device half* sl = sr + row * in_vec_size_g;
+                    const device half* bl = br + row * in_vec_size_g;
+                    U s = sl[0]; U b = bl[0];
+                    U accum = 0.0f;
+                    for (int i = 0; i < 4; i++) {
+                        accum += (x_thread[4*i]   * wf[4*i] +
+                                  x_thread[4*i+1] * wf[4*i+1] +
+                                  x_thread[4*i+2] * wf[4*i+2] +
+                                  x_thread[4*i+3] * wf[4*i+3]);
+                    }
+                    result[r][row] += s * accum + sum * b;
+                }
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+            wsr += block_size / 2;
+            sr += block_size / 64; br += block_size / 64;
+        }
+        for (int r = 0; r < R; ++r) {
+            uint mk = (uint)gRowIdx[i0 + r];
+            device half* yr = y + (size_t)mk * out_vec_size + out_row;
+            for (int row = 0; row < results_per_simdgroup; row++) {
+                U v = simd_sum(result[r][row]);
+                if (simd_lid == 0) yr[row] = (half)v;
+            }
+        }
+    }
+
+    // Timing-only: gq_ref with the dequant ALU (mask+convert) REMOVED — multiplies the raw packed
+    // uint16 reinterpreted as float (garbage output). Isolates the dequant tax: if this is not much
+    // faster than gq_ref, the kernel is FMA/load-bound and NO dequant-sharing scheme can win.
+    kernel void gq_nodeq(device const uint32_t* w      [[buffer(0)]],
+                         device const half*     scales [[buffer(1)]],
+                         device const half*     biases [[buffer(2)]],
+                         device const half*     x      [[buffer(3)]],
+                         device const int*      inds   [[buffer(4)]],
+                         device half*           y      [[buffer(5)]],
+                         constant int& in_vec_size  [[buffer(6)]],
+                         constant int& out_vec_size [[buffer(7)]],
+                         constant int& ktop         [[buffer(8)]],
+                         constant uint& lhsPer      [[buffer(9)]],
+                         uint3 tid      [[threadgroup_position_in_grid]],
+                         uint  simd_gid [[simdgroup_index_in_threadgroup]],
+                         uint  simd_lid [[thread_index_in_simdgroup]]) {
+        constexpr int packs_per_thread = 2, results_per_simdgroup = 4;
+        constexpr int bytes_per_pack = 4, values_per_thread = 16;
+        constexpr int block_size = 512, scale_step_per_thread = 4;
+        const device uint8_t* ws = (const device uint8_t*)w;
+        typedef float U;
+        thread U x_thread[16];
+        thread U result[4] = {0};
+        const int in_vec_size_w = in_vec_size / 2;
+        const int in_vec_size_g = in_vec_size / 64;
+        uint mk = tid.z;
+        uint e = (uint)inds[mk];
+        ws     += (size_t)e * out_vec_size * in_vec_size_w;
+        scales += (size_t)e * out_vec_size * in_vec_size_g;
+        biases += (size_t)e * out_vec_size * in_vec_size_g;
+        const int out_row = tid.y * 8 + simd_gid * results_per_simdgroup;
+        ws     += out_row * in_vec_size_w + simd_lid * packs_per_thread * bytes_per_pack;
+        scales += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+        biases += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+        x += (size_t)(lhsPer ? mk : mk / (uint)ktop) * in_vec_size + simd_lid * values_per_thread;
+        y += (size_t)mk * out_vec_size + out_row;
+        for (int k = 0; k < in_vec_size; k += block_size) {
+            U sum = ld16(x, x_thread);
+            for (int row = 0; row < results_per_simdgroup; row++) {
+                const device uint16_t* wl = (const device uint16_t*)(ws + row * in_vec_size_w);
+                const device half* sl = scales + row * in_vec_size_g;
+                const device half* bl = biases + row * in_vec_size_g;
+                U s = sl[0]; U b = bl[0];
+                U accum = 0.0f;
+                for (int i = 0; i < 4; i++) {
+                    // same loads, same FMA count — mask+convert dropped (as_type reinterpret)
+                    accum += (x_thread[4*i]   * as_type<half>(wl[i]) +
+                              x_thread[4*i+1] * as_type<half>(wl[i]) +
+                              x_thread[4*i+2] * as_type<half>(wl[i]) +
+                              x_thread[4*i+3] * as_type<half>(wl[i]));
+                }
+                result[row] += s * accum + sum * b;
+            }
+            ws += block_size / 2;
+            scales += block_size / 64; biases += block_size / 64; x += block_size;
+        }
+        for (int row = 0; row < results_per_simdgroup; row++) {
+            result[row] = simd_sum(result[row]);
+            if (simd_lid == 0) y[row] = (half)result[row];
+        }
+    }
+    """
+
+    static func compile(_ device: MTLDevice) -> Bool {
+        if pipeRef != nil { return true }
+        do {
+            let lib = try device.makeLibrary(source: kernelSrc, options: nil)
+            pipeRef = try device.makeComputePipelineState(function: lib.makeFunction(name: "gq_ref")!)
+            pipeGrp = try device.makeComputePipelineState(function: lib.makeFunction(name: "gq_grouped")!)
+            pipeGrp2 = try device.makeComputePipelineState(function: lib.makeFunction(name: "gq_grouped2")!)
+            pipeNoDeq = try device.makeComputePipelineState(function: lib.makeFunction(name: "gq_nodeq")!)
+            return true
+        } catch { print("[grouped-moe] compile: \(error)"); return false }
+    }
+
+    // Deterministic LCG (no seeded RNG dependency; reproducible bench).
+    struct LCG { var s: UInt64; mutating func next() -> UInt64 { s = s &* 6364136223846793005 &+ 1442695040888963407; return s >> 33 } }
+
+    public static func bench() -> String {
+        guard let device = MTLCreateSystemDefaultDevice(), let queue = device.makeCommandQueue(),
+              compile(device) else { return "[grouped-moe] setup fail\nGROUPEDMOE done" }
+        let E = 256, Ktop = 8
+        var out = ["[grouped-moe] gq_ref (per-pair, production structure) vs gq_grouped (per-expert, L1 reuse)",
+                   "  E=\(E) Ktop=\(Ktop), synthetic weights, uniform-random routing (worst case for grouping)"]
+
+        // shapes: g/u proj (K=2048→N=512, x per token) and d proj (K=512→N=2048, x per pair)
+        for (label, K, N, lhsPer) in [("g/u 2048→512", 2048, 512, false), ("d   512→2048", 512, 2048, true)] {
+            var rng = LCG(s: 42)
+            // weights: [E, N, K/8] uint32 + scales/biases [E, N, K/64] f16 (small values, exactness-irrelevant)
+            let wCount = E * N * K / 8
+            let wBuf = device.makeBuffer(length: wCount * 4, options: .storageModeShared)!
+            let wp = wBuf.contents().bindMemory(to: UInt32.self, capacity: wCount)
+            for i in 0..<wCount { wp[i] = UInt32(truncatingIfNeeded: rng.next()) }
+            let sCount = E * N * K / 64
+            let sBuf = device.makeBuffer(length: sCount * 2, options: .storageModeShared)!
+            let bBuf = device.makeBuffer(length: sCount * 2, options: .storageModeShared)!
+            let sp = sBuf.contents().bindMemory(to: Float16.self, capacity: sCount)
+            let bp = bBuf.contents().bindMemory(to: Float16.self, capacity: sCount)
+            for i in 0..<sCount { sp[i] = Float16(Double(rng.next() % 1000) / 50000.0 + 0.001); bp[i] = Float16(Double(rng.next() % 1000) / 100000.0) }
+
+            out.append("  ── \(label) (lhsPer=\(lhsPer ? 1 : 0)) ──")
+            for M in [64, 256, 1024] {
+                // routing: per token, 8 distinct experts of E
+                var inds = [Int32](); inds.reserveCapacity(M * Ktop)
+                for _ in 0..<M {
+                    var seen = Set<Int32>()
+                    while seen.count < Ktop { seen.insert(Int32(rng.next() % UInt64(E))) }
+                    inds.append(contentsOf: seen.sorted())
+                }
+                // x rows: per token (g/u) or per pair (d)
+                let xRows = lhsPer ? M * Ktop : M
+                let xBuf = device.makeBuffer(length: xRows * K * 2, options: .storageModeShared)!
+                let xp = xBuf.contents().bindMemory(to: Float16.self, capacity: xRows * K)
+                for i in 0..<(xRows * K) { xp[i] = Float16(Double(rng.next() % 2000) / 1000.0 - 1.0) }
+                let indsBuf = device.makeBuffer(bytes: inds, length: inds.count * 4, options: .storageModeShared)!
+                // CSR groups: rows per expert
+                var byExpert = [[Int32]](repeating: [], count: E)
+                for (mk, e) in inds.enumerated() { byExpert[Int(e)].append(Int32(mk)) }
+                var gExpert = [Int32](), gRowOff: [Int32] = [0], gRowIdx = [Int32]()
+                for e in 0..<E where !byExpert[e].isEmpty {
+                    gExpert.append(Int32(e)); gRowIdx.append(contentsOf: byExpert[e]); gRowOff.append(Int32(gRowIdx.count))
+                }
+                let G = gExpert.count
+                let geBuf = device.makeBuffer(bytes: gExpert, length: G * 4, options: .storageModeShared)!
+                let goBuf = device.makeBuffer(bytes: gRowOff, length: (G + 1) * 4, options: .storageModeShared)!
+                let giBuf = device.makeBuffer(bytes: gRowIdx, length: gRowIdx.count * 4, options: .storageModeShared)!
+                // v2 CSR: same row order, groups split at R_MAX=8 (register accumulators bound)
+                var gExpert2 = [Int32](), gRowOff2: [Int32] = [0]
+                for gi in 0..<G {
+                    var lo = Int(gRowOff[gi])
+                    let hi = Int(gRowOff[gi + 1])
+                    while lo < hi {
+                        let take = Swift.min(8, hi - lo)
+                        gExpert2.append(gExpert[gi]); gRowOff2.append(Int32(lo + take)); lo += take
+                    }
+                }
+                let G2 = gExpert2.count
+                let geBuf2 = device.makeBuffer(bytes: gExpert2, length: G2 * 4, options: .storageModeShared)!
+                let goBuf2 = device.makeBuffer(bytes: gRowOff2, length: (G2 + 1) * 4, options: .storageModeShared)!
+                let yRef = device.makeBuffer(length: M * Ktop * N * 2, options: .storageModeShared)!
+                let yGrp = device.makeBuffer(length: M * Ktop * N * 2, options: .storageModeShared)!
+                let yGrp2 = device.makeBuffer(length: M * Ktop * N * 2, options: .storageModeShared)!
+
+                var kk = Int32(K), nn = Int32(N), kt = Int32(Ktop), lp: UInt32 = lhsPer ? 1 : 0
+                func encRef(_ enc: MTLComputeCommandEncoder) {
+                    enc.setComputePipelineState(pipeRef!)
+                    enc.setBuffer(wBuf, offset: 0, index: 0); enc.setBuffer(sBuf, offset: 0, index: 1); enc.setBuffer(bBuf, offset: 0, index: 2)
+                    enc.setBuffer(xBuf, offset: 0, index: 3); enc.setBuffer(indsBuf, offset: 0, index: 4); enc.setBuffer(yRef, offset: 0, index: 5)
+                    enc.setBytes(&kk, length: 4, index: 6); enc.setBytes(&nn, length: 4, index: 7); enc.setBytes(&kt, length: 4, index: 8)
+                    enc.setBytes(&lp, length: 4, index: 9)
+                    enc.dispatchThreadgroups(MTLSize(width: 1, height: N / 8, depth: M * Ktop), threadsPerThreadgroup: MTLSize(width: 32, height: 2, depth: 1))
+                }
+                func encGrp(_ enc: MTLComputeCommandEncoder) {
+                    enc.setComputePipelineState(pipeGrp!)
+                    enc.setBuffer(wBuf, offset: 0, index: 0); enc.setBuffer(sBuf, offset: 0, index: 1); enc.setBuffer(bBuf, offset: 0, index: 2)
+                    enc.setBuffer(xBuf, offset: 0, index: 3); enc.setBuffer(geBuf, offset: 0, index: 4); enc.setBuffer(goBuf, offset: 0, index: 5)
+                    enc.setBuffer(giBuf, offset: 0, index: 6); enc.setBuffer(yGrp, offset: 0, index: 7)
+                    enc.setBytes(&kk, length: 4, index: 8); enc.setBytes(&nn, length: 4, index: 9); enc.setBytes(&kt, length: 4, index: 10)
+                    enc.setBytes(&lp, length: 4, index: 11)
+                    enc.dispatchThreadgroups(MTLSize(width: 1, height: N / 8, depth: G), threadsPerThreadgroup: MTLSize(width: 32, height: 2, depth: 1))
+                }
+                func encGrp2(_ enc: MTLComputeCommandEncoder) {
+                    enc.setComputePipelineState(pipeGrp2!)
+                    enc.setBuffer(wBuf, offset: 0, index: 0); enc.setBuffer(sBuf, offset: 0, index: 1); enc.setBuffer(bBuf, offset: 0, index: 2)
+                    enc.setBuffer(xBuf, offset: 0, index: 3); enc.setBuffer(geBuf2, offset: 0, index: 4); enc.setBuffer(goBuf2, offset: 0, index: 5)
+                    enc.setBuffer(giBuf, offset: 0, index: 6); enc.setBuffer(yGrp2, offset: 0, index: 7)
+                    enc.setBytes(&kk, length: 4, index: 8); enc.setBytes(&nn, length: 4, index: 9); enc.setBytes(&kt, length: 4, index: 10)
+                    enc.setBytes(&lp, length: 4, index: 11)
+                    enc.dispatchThreadgroups(MTLSize(width: 1, height: N / 8, depth: G2), threadsPerThreadgroup: MTLSize(width: 32, height: 2, depth: 1))
+                }
+                func encNoDeq(_ enc: MTLComputeCommandEncoder) {
+                    enc.setComputePipelineState(pipeNoDeq!)
+                    enc.setBuffer(wBuf, offset: 0, index: 0); enc.setBuffer(sBuf, offset: 0, index: 1); enc.setBuffer(bBuf, offset: 0, index: 2)
+                    enc.setBuffer(xBuf, offset: 0, index: 3); enc.setBuffer(indsBuf, offset: 0, index: 4); enc.setBuffer(yGrp2, offset: 0, index: 5)
+                    enc.setBytes(&kk, length: 4, index: 6); enc.setBytes(&nn, length: 4, index: 7); enc.setBytes(&kt, length: 4, index: 8)
+                    enc.setBytes(&lp, length: 4, index: 9)
+                    enc.dispatchThreadgroups(MTLSize(width: 1, height: N / 8, depth: M * Ktop), threadsPerThreadgroup: MTLSize(width: 32, height: 2, depth: 1))
+                }
+                func gpuTime(_ iters: Int, _ enc1: (MTLComputeCommandEncoder) -> Void) -> Double {
+                    let cb = queue.makeCommandBuffer()!
+                    let enc = cb.makeComputeCommandEncoder()!
+                    for _ in 0..<iters { enc1(enc) }
+                    enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+                    return (cb.gpuEndTime - cb.gpuStartTime) * 1000.0 / Double(iters)
+                }
+                _ = gpuTime(2, encRef); _ = gpuTime(2, encGrp); _ = gpuTime(2, encGrp2)   // warmup
+                let tR = gpuTime(10, encRef)
+                let tG = gpuTime(10, encGrp)
+                let tG2 = gpuTime(10, encGrp2)
+                _ = gpuTime(2, encNoDeq)
+                let tN = gpuTime(10, encNoDeq)
+                // bit-exact: single clean dispatch each, byte compare
+                _ = gpuTime(1, encRef); _ = gpuTime(1, encGrp); _ = gpuTime(1, encGrp2)
+                let same = memcmp(yRef.contents(), yGrp.contents(), M * Ktop * N * 2) == 0
+                let same2 = memcmp(yRef.contents(), yGrp2.contents(), M * Ktop * N * 2) == 0
+                let rowsPerE = Double(M * Ktop) / Double(G)
+                out.append(String(format: "  M=%4d (%4.1f r/e) ref %7.3f | grp %6.3f %4.2fx%@ | grp2 %6.3f %4.2fx%@ | noDeq %6.3f %4.2fx(timing-only)",
+                                  M, rowsPerE, tR, tG, tR / tG, same ? "✅" : "❌",
+                                  tG2, tR / tG2, same2 ? "✅" : "❌", tN, tR / tN))
+            }
+        }
+        out.append("GROUPEDMOE done")
+        return out.joined(separator: "\n")
+    }
+}

--- a/swift/Sources/QwispCore/GroupedMoEPoC.swift
+++ b/swift/Sources/QwispCore/GroupedMoEPoC.swift
@@ -610,4 +610,132 @@ public enum GroupedMoEPoC {
         out.append("DENSEBENCH done")
         return out.joined(separator: "\n")
     }
+
+    // steel-route-bench: (1) MLX steel dense speed at prefill shapes (vs recorded scalar qmv
+    // baselines from dense-tiled-bench), (2) steel GATHER via CSR tiling — rows sorted by expert
+    // into fixed R=16 tiles (pad w/ zeros) so the inner matmul is M=16 => gather_qmm_t (matrix
+    // units) instead of production-shape gather_qmv (inner M=1), (3) tile-composition invariance
+    // (a row's output must not depend on which rows/pads share its tile), (4) MLX eval launch
+    // overhead (the raw-CB<->MLX sync cost per hybrid boundary).
+    public static func steelRouteBench() -> String {
+        var out = ["[steel-route] MLX steel dense + CSR-tiled steel gather"]
+        var rng = LCG(s: 99)
+        func randX(_ rows: Int, _ K: Int) -> MLXArray {
+            let a = (0..<(rows*K)).map { _ in Float16(Double(rng.next() % 2000) / 1000.0 - 1.0) }
+            return MLXArray(a, [rows, K])
+        }
+        func timeEval(_ iters: Int, _ f: () -> MLXArray) -> Double {
+            var best = Double.infinity
+            for _ in 0..<2 {
+                let t0 = Date()
+                for _ in 0..<iters { let y = f(); y.eval() }
+                best = Swift.min(best, Date().timeIntervalSince(t0) * 1000.0 / Double(iters))
+            }
+            return best
+        }
+        // ── (1) dense steel vs recorded scalar baselines ──
+        let scalarMs: [String: [Int: Double]] = [
+            "inproj 2048→12352": [64: 1.88, 256: 7.51, 1024: 30.03],
+            "qkv    2048→5120":  [64: 0.77, 256: 3.15, 1024: 12.39],
+            "shared 2048→512":   [64: 0.08, 256: 0.31, 1024: 1.24],
+            "d/out   512→2048":  [64: 0.11, 256: 0.42, 1024: 1.67]]
+        for (label, K, N) in [("inproj 2048→12352", 2048, 12352), ("qkv    2048→5120", 2048, 5120),
+                              ("shared 2048→512", 2048, 512), ("d/out   512→2048", 512, 2048)] {
+            let wf = MLXRandom.normal([N, K]).asType(.float16)
+            let (wq, sc, biOpt) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine)
+            guard let bi = biOpt else { return "[steel-route] biases nil" }
+            MLX.eval([wq, sc, bi])
+            var line = "  \(label): "
+            for M in [64, 256, 1024] {
+                let x = randX(M, K); x.eval()
+                _ = timeEval(3) { MLX.quantizedMatmul(x, wq, scales: sc, biases: bi, transpose: true, groupSize: 64, bits: 4) }
+                let t = timeEval(10) { MLX.quantizedMatmul(x, wq, scales: sc, biases: bi, transpose: true, groupSize: 64, bits: 4) }
+                let base = scalarMs[label]?[M] ?? 0
+                line += String(format: "M%d %.2fms(%.1fx)  ", M, t, base / t)
+            }
+            out.append(line)
+        }
+        // ── (2)(3) steel gather via CSR R=16 tiles ──
+        let E = 256, Ktop = 8, K = 2048, N = 512, R = 16
+        let wf = MLXRandom.normal([E, N, K]).asType(.float16)
+        let (wq, sc, biOpt) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine)
+        guard let bi = biOpt else { return "[steel-route] gw nil" }
+        MLX.eval([wq, sc, bi])
+        out.append("  ── gather K=2048→N=512, E=256, top-8, R=16 tiles ──")
+        for T in [64, 256, 1024] {
+            var inds = [Int32]()
+            for _ in 0..<T { var s = Set<Int32>(); while s.count < Ktop { s.insert(Int32(rng.next() % UInt64(E))) }; inds.append(contentsOf: s.sorted()) }
+            let x = randX(T, K); x.eval()
+            let indsArr = MLXArray(inds, [T, Ktop])
+            // production shape: x[T,1,1,K], rhsIndices [T,Ktop] → inner M=1 gather_qmv
+            let xe = x.expandedDimensions(axes: [-2, -3])
+            _ = timeEval(3) { MLX.gatherQuantizedMatmul(xe, wq, scales: sc, biases: bi, rhsIndices: indsArr, transpose: true, groupSize: 64, bits: 4, mode: .affine, sortedIndices: false) }
+            let tProd = timeEval(10) { MLX.gatherQuantizedMatmul(xe, wq, scales: sc, biases: bi, rhsIndices: indsArr, transpose: true, groupSize: 64, bits: 4, mode: .affine, sortedIndices: false) }
+            // CSR tiles: rows (pair index mk uses x row mk/Ktop) grouped by expert, fixed R=16, zero-pad
+            var byE = [[Int32]](repeating: [], count: E)
+            for (mk, e) in inds.enumerated() { byE[Int(e)].append(Int32(mk)) }
+            var tileExpert = [Int32](), tileRows = [[Int32]]()   // each tile: expert + up-to-16 mk
+            for e in 0..<E {
+                var lo = 0
+                while lo < byE[e].count { tileExpert.append(Int32(e)); tileRows.append(Array(byE[e][lo ..< Swift.min(lo+R, byE[e].count)])); lo += R }
+            }
+            let Gt = tileExpert.count
+            let xh = x.asArray(Float16.self)
+            var xg = [Float16](repeating: 0, count: Gt * R * K)
+            for (ti, rows) in tileRows.enumerated() {
+                for (ri, mk) in rows.enumerated() {
+                    let src = Int(mk) / Ktop * K
+                    for k in 0..<K { xg[(ti * R + ri) * K + k] = xh[src + k] }
+                }
+            }
+            let xgArr = MLXArray(xg, [Gt, R, K]); xgArr.eval()
+            let teArr = MLXArray(tileExpert, [Gt])
+            _ = timeEval(3) { MLX.gatherQuantizedMatmul(xgArr, wq, scales: sc, biases: bi, rhsIndices: teArr, transpose: true, groupSize: 64, bits: 4, mode: .affine, sortedIndices: true) }
+            let tSteel = timeEval(10) { MLX.gatherQuantizedMatmul(xgArr, wq, scales: sc, biases: bi, rhsIndices: teArr, transpose: true, groupSize: 64, bits: 4, mode: .affine, sortedIndices: true) }
+            let padFactor = Double(Gt * R) / Double(T * Ktop)
+            out.append(String(format: "  T=%4d  prod(qmv) %7.3fms | steel-CSR %7.3fms  %5.2fx  (tiles=%d pad=%.2fx)",
+                              T, tProd, tSteel, tProd / tSteel, Gt, padFactor))
+            // (3) tile-composition invariance at this T: recompute with a DIFFERENT composition
+            // (shuffle rows into tiles of the same expert differently: reverse order within expert)
+            if T == 256 {
+                var tileRows2 = [[Int32]](), tileExpert2 = [Int32]()
+                for e in 0..<E {
+                    let rev = byE[e].reversed().map { $0 }
+                    var lo = 0
+                    while lo < rev.count { tileExpert2.append(Int32(e)); tileRows2.append(Array(rev[lo ..< Swift.min(lo+R, rev.count)])); lo += R }
+                }
+                var xg2 = [Float16](repeating: 0, count: tileExpert2.count * R * K)
+                for (ti, rows) in tileRows2.enumerated() {
+                    for (ri, mk) in rows.enumerated() {
+                        let src = Int(mk) / Ktop * K
+                        for k in 0..<K { xg2[(ti * R + ri) * K + k] = xh[src + k] }
+                    }
+                }
+                let xg2Arr = MLXArray(xg2, [tileExpert2.count, R, K])
+                let y1 = MLX.gatherQuantizedMatmul(xgArr, wq, scales: sc, biases: bi, rhsIndices: teArr, transpose: true, groupSize: 64, bits: 4, mode: .affine, sortedIndices: true)
+                let y2 = MLX.gatherQuantizedMatmul(xg2Arr, wq, scales: sc, biases: bi, rhsIndices: MLXArray(tileExpert2, [tileExpert2.count]), transpose: true, groupSize: 64, bits: 4, mode: .affine, sortedIndices: true)
+                MLX.eval([y1, y2])
+                // compare per-mk outputs across the two compositions
+                let a1 = y1.asArray(Float16.self), a2 = y2.asArray(Float16.self)
+                var ok = true
+                var pos1 = [Int32: Int](), pos2 = [Int32: Int]()
+                for (ti, rows) in tileRows.enumerated() { for (ri, mk) in rows.enumerated() { pos1[mk] = ti * R + ri } }
+                for (ti, rows) in tileRows2.enumerated() { for (ri, mk) in rows.enumerated() { pos2[mk] = ti * R + ri } }
+                outer: for mk in pos1.keys {
+                    let o1 = pos1[mk]! * N, o2 = pos2[mk]! * N
+                    for j in 0..<N where a1[o1 + j] != a2[o2 + j] { ok = false; break outer }
+                }
+                out.append("    tile-composition invariance @T=256: \(ok ? "IDENTICAL ✅" : "DIFFER ❌")")
+            }
+        }
+        // ── (4) MLX eval launch overhead (per hybrid boundary) ──
+        let wSmall = MLXRandom.normal([512, 512]).asType(.float16)
+        let (wq2, sc2, bi2o) = MLX.quantized(wSmall, groupSize: 64, bits: 4, mode: .affine)
+        let xs = randX(16, 512)
+        MLX.eval([wq2, sc2, bi2o!, xs])
+        let tiny = timeEval(50) { MLX.quantizedMatmul(xs, wq2, scales: sc2, biases: bi2o!, transpose: true, groupSize: 64, bits: 4) }
+        out.append(String(format: "  eval launch overhead (tiny qmm M=16): %.3fms/boundary → ~%.0fms/chunk at 80 boundaries", tiny, tiny * 80))
+        out.append("STEELROUTE done")
+        return out.joined(separator: "\n")
+    }
 }

--- a/swift/Sources/QwispCore/GroupedMoEPoC.swift
+++ b/swift/Sources/QwispCore/GroupedMoEPoC.swift
@@ -454,4 +454,160 @@ public enum GroupedMoEPoC {
         out.append("GROUPEDMOE done")
         return out.joined(separator: "\n")
     }
+
+    // Probe B (matrix-unit-canonical route): DENSE qmm — production scalar qmv structure vs the
+    // production qmm4_tiled structure (TG-shared dequant, M-invariant per locked test 10) at
+    // PREFILL M on real dense shapes. Decides whether tiled-for-prefill buys the dense share.
+    nonisolated(unsafe) static var pipeDenseRef: MTLComputePipelineState?
+    nonisolated(unsafe) static var pipeDenseTiled: MTLComputePipelineState?
+    static let denseSrc = """
+    #include <metal_stdlib>
+    using namespace metal;
+    inline float ld16(const device half* x, thread float* xt) {
+        float sum = 0.0f;
+        for (int i = 0; i < 16; i += 4) {
+            sum += x[i] + x[i+1] + x[i+2] + x[i+3];
+            xt[i] = x[i]; xt[i+1] = x[i+1]/16.0f; xt[i+2] = x[i+2]/256.0f; xt[i+3] = x[i+3]/4096.0f;
+        }
+        return sum;
+    }
+    inline float qd4(const device uint8_t* w, const thread float* xt, float scale, float bias, float sum) {
+        float accum = 0.0f;
+        const device uint16_t* ws = (const device uint16_t*)w;
+        for (int i = 0; i < 4; i++) {
+            accum += (xt[4*i]   * (float)(ws[i] & 0x000f) +
+                      xt[4*i+1] * (float)(ws[i] & 0x00f0) +
+                      xt[4*i+2] * (float)(ws[i] & 0x0f00) +
+                      xt[4*i+3] * (float)(ws[i] & 0xf000));
+        }
+        return scale * accum + sum * bias;
+    }
+    // production qmm4 structure batched over M rows: grid (1, N/8, M), tg per (row, n-tile)
+    kernel void dq_ref(device const uint32_t* w [[buffer(0)]], device const half* scales [[buffer(1)]],
+                       device const half* biases [[buffer(2)]], device const half* x [[buffer(3)]],
+                       device half* y [[buffer(4)]],
+                       constant int& in_vec_size [[buffer(5)]], constant int& out_vec_size [[buffer(6)]],
+                       uint3 tid [[threadgroup_position_in_grid]],
+                       uint simd_gid [[simdgroup_index_in_threadgroup]],
+                       uint simd_lid [[thread_index_in_simdgroup]]) {
+        constexpr int packs_per_thread = 2, results_per_simdgroup = 4;
+        constexpr int bytes_per_pack = 4, values_per_thread = 16;
+        constexpr int block_size = 512, scale_step_per_thread = 4;
+        const device uint8_t* ws = (const device uint8_t*)w;
+        typedef float U;
+        thread U x_thread[16];
+        thread U result[4] = {0};
+        const int in_vec_size_w = in_vec_size / 2;
+        const int in_vec_size_g = in_vec_size / 64;
+        uint m = tid.z;
+        const int out_row = tid.y * 8 + simd_gid * results_per_simdgroup;
+        ws     += out_row * in_vec_size_w + simd_lid * packs_per_thread * bytes_per_pack;
+        scales += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+        biases += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+        x += (size_t)m * in_vec_size + simd_lid * values_per_thread;
+        y += (size_t)m * out_vec_size + out_row;
+        for (int k = 0; k < in_vec_size; k += block_size) {
+            U sum = ld16(x, x_thread);
+            for (int row = 0; row < results_per_simdgroup; row++) {
+                auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
+                const device half* sl = scales + row * in_vec_size_g;
+                const device half* bl = biases + row * in_vec_size_g;
+                U s = sl[0]; U b = bl[0];
+                result[row] += qd4(wl, x_thread, s, b, sum);
+            }
+            ws += block_size / 2;
+            scales += block_size / 64; biases += block_size / 64; x += block_size;
+        }
+        for (int row = 0; row < results_per_simdgroup; row++) {
+            result[row] = simd_sum(result[row]);
+            if (simd_lid == 0) y[row] = (half)result[row];
+        }
+    }
+    // production qmm4_tiled structure (verbatim): tg per output column, TG-shared dequant, M-loop
+    kernel void dq_tiled(device const uint32_t* w [[buffer(0)]], device const half* scales [[buffer(1)]],
+                         device const half* biases [[buffer(2)]], device const half* x [[buffer(3)]],
+                         device half* y [[buffer(4)]], constant int& K [[buffer(5)]], constant int& N [[buffer(6)]],
+                         constant int& M [[buffer(7)]],
+                         uint n [[threadgroup_position_in_grid]], uint lid [[thread_position_in_threadgroup]],
+                         uint tgs [[threads_per_threadgroup]]) {
+        threadgroup float wdq[2048];
+        threadgroup float red[256];
+        int Kg = K / 64;
+        for (int k = (int)lid; k < K; k += (int)tgs) {
+            uint pack = w[n * (K/8) + k/8];
+            uint nib = (pack >> (4*(k%8))) & 0xf;
+            int g = k/64;
+            wdq[k] = (float)scales[n*Kg+g] * (float)nib + (float)biases[n*Kg+g];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (int m = 0; m < M; m++) {
+            float acc = 0.0f;
+            for (int k = (int)lid; k < K; k += (int)tgs) acc += (float)x[m*K+k] * wdq[k];
+            red[lid] = acc; threadgroup_barrier(mem_flags::mem_threadgroup);
+            for (uint s = tgs/2; s > 0; s >>= 1) { if (lid < s) red[lid] += red[lid+s]; threadgroup_barrier(mem_flags::mem_threadgroup); }
+            if (lid == 0) y[m*N + n] = (half)red[0];
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+    }
+    """
+
+    public static func denseBench() -> String {
+        guard let device = MTLCreateSystemDefaultDevice(), let queue = device.makeCommandQueue() else { return "[dense-bench] no device\nDENSEBENCH done" }
+        if pipeDenseRef == nil {
+            do {
+                let lib = try device.makeLibrary(source: denseSrc, options: nil)
+                pipeDenseRef = try device.makeComputePipelineState(function: lib.makeFunction(name: "dq_ref")!)
+                pipeDenseTiled = try device.makeComputePipelineState(function: lib.makeFunction(name: "dq_tiled")!)
+            } catch { return "[dense-bench] compile: \(error)\nDENSEBENCH done" }
+        }
+        var out = ["[dense-bench] scalar qmv structure vs qmm4_tiled structure — dense prefill shapes (K<=2048)"]
+        var rng = LCG(s: 7)
+        // real dense shapes: GDN in_proj (2048->12352), attn qkv+gate (2048->~5120), MoE shared g/u (2048->512), d (512->2048)
+        for (label, K, N) in [("GDN inproj 2048→12352", 2048, 12352), ("attn qkv  2048→5120", 2048, 5120), ("shared g/u 2048→512", 2048, 512), ("d/out      512→2048", 512, 2048)] {
+            let wCount = N * K / 8
+            let wBuf = device.makeBuffer(length: wCount * 4, options: .storageModeShared)!
+            let wp = wBuf.contents().bindMemory(to: UInt32.self, capacity: wCount)
+            for i in 0..<wCount { wp[i] = UInt32(truncatingIfNeeded: rng.next()) }
+            let sCount = N * K / 64
+            let sBuf = device.makeBuffer(length: sCount * 2, options: .storageModeShared)!
+            let bBuf = device.makeBuffer(length: sCount * 2, options: .storageModeShared)!
+            let sp = sBuf.contents().bindMemory(to: Float16.self, capacity: sCount)
+            let bp = bBuf.contents().bindMemory(to: Float16.self, capacity: sCount)
+            for i in 0..<sCount { sp[i] = Float16(Double(rng.next() % 1000) / 50000.0 + 0.001); bp[i] = Float16(Double(rng.next() % 1000) / 100000.0) }
+            var line = "  \(label): "
+            for M in [64, 256, 1024] {
+                let xBuf = device.makeBuffer(length: M * K * 2, options: .storageModeShared)!
+                let xp = xBuf.contents().bindMemory(to: Float16.self, capacity: M * K)
+                for i in 0..<(M * K) { xp[i] = Float16(Double(rng.next() % 2000) / 1000.0 - 1.0) }
+                let yBuf = device.makeBuffer(length: M * N * 2, options: .storageModeShared)!
+                var kk = Int32(K), nn = Int32(N), mm = Int32(M)
+                func encR(_ enc: MTLComputeCommandEncoder) {
+                    enc.setComputePipelineState(pipeDenseRef!)
+                    enc.setBuffer(wBuf, offset: 0, index: 0); enc.setBuffer(sBuf, offset: 0, index: 1); enc.setBuffer(bBuf, offset: 0, index: 2)
+                    enc.setBuffer(xBuf, offset: 0, index: 3); enc.setBuffer(yBuf, offset: 0, index: 4)
+                    enc.setBytes(&kk, length: 4, index: 5); enc.setBytes(&nn, length: 4, index: 6)
+                    enc.dispatchThreadgroups(MTLSize(width: 1, height: N / 8, depth: M), threadsPerThreadgroup: MTLSize(width: 32, height: 2, depth: 1))
+                }
+                func encT(_ enc: MTLComputeCommandEncoder) {
+                    enc.setComputePipelineState(pipeDenseTiled!)
+                    enc.setBuffer(wBuf, offset: 0, index: 0); enc.setBuffer(sBuf, offset: 0, index: 1); enc.setBuffer(bBuf, offset: 0, index: 2)
+                    enc.setBuffer(xBuf, offset: 0, index: 3); enc.setBuffer(yBuf, offset: 0, index: 4)
+                    enc.setBytes(&kk, length: 4, index: 5); enc.setBytes(&nn, length: 4, index: 6); enc.setBytes(&mm, length: 4, index: 7)
+                    enc.dispatchThreadgroups(MTLSize(width: N, height: 1, depth: 1), threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+                }
+                func t(_ e: (MTLComputeCommandEncoder) -> Void) -> Double {
+                    let cb = queue.makeCommandBuffer()!; let enc = cb.makeComputeCommandEncoder()!
+                    for _ in 0..<8 { e(enc) }
+                    enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+                    return (cb.gpuEndTime - cb.gpuStartTime) * 1000.0 / 8.0
+                }
+                _ = t(encR); _ = t(encT)
+                let tR = t(encR), tT = t(encT)
+                line += String(format: "M%d %.2f/%.2fms %.2fx  ", M, tR, tT, tR / tT)
+            }
+            out.append(line)
+        }
+        out.append("DENSEBENCH done")
+        return out.joined(separator: "\n")
+    }
 }

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -192,7 +192,9 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                     let sb: Tell.SpecBackend? = cfg.isStreaming
                         ? Tell.streamingBackend(engine: self.engine, modelDir: self.modelDir,
                                                 maxM: cfg.maxM, maxSeqLen: maxSeqLen, C: cfg.c).map { $0.0 }
-                        : Tell.fusedBackend(engine: self.engine, maxM: cfg.maxM, maxSeqLen: maxSeqLen)
+                        : Tell.fusedBackend(engine: self.engine,
+                                            maxM: Tell.envFlag("QWISP_HYBRID_PREFILL") ? Swift.max(cfg.maxM, 1032) : cfg.maxM,
+                                            maxSeqLen: maxSeqLen)
                     guard let backend = sb else { break }
                     let onTok: (Int) -> Void = { continuation.yield($0) }
                     // Each segment dispatches to greedy or sampling. Sampling keeps its own state
@@ -254,7 +256,9 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                     while newLen < needed { newLen *= 2 }
                     newLen = Swift.min(newLen, self.prefixArenaMax)
                     if newLen < needed { newLen = needed }
-                    guard let b = Tell.fusedBackend(engine: self.engine, maxM: cfg.maxM, maxSeqLen: newLen) else {
+                    // Steel-prefill hybrid wants chunk=1024 → bump maxM (scratch ~200MB, resident tier).
+                    let mm = Tell.envFlag("QWISP_HYBRID_PREFILL") ? Swift.max(cfg.maxM, 1032) : cfg.maxM
+                    guard let b = Tell.fusedBackend(engine: self.engine, maxM: mm, maxSeqLen: newLen) else {
                         continuation.finish(); return
                     }
                     self.prefixBackend = b; self.prefixArenaLen = newLen

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -193,7 +193,7 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                         ? Tell.streamingBackend(engine: self.engine, modelDir: self.modelDir,
                                                 maxM: cfg.maxM, maxSeqLen: maxSeqLen, C: cfg.c).map { $0.0 }
                         : Tell.fusedBackend(engine: self.engine,
-                                            maxM: Tell.envFlag("QWISP_HYBRID_PREFILL") ? Swift.max(cfg.maxM, 1032) : cfg.maxM,
+                                            maxM: ProcessInfo.processInfo.environment["QWISP_HYBRID_PREFILL"] != "0" ? Swift.max(cfg.maxM, 1032) : cfg.maxM,
                                             maxSeqLen: maxSeqLen)
                     guard let backend = sb else { break }
                     let onTok: (Int) -> Void = { continuation.yield($0) }
@@ -257,7 +257,7 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                     newLen = Swift.min(newLen, self.prefixArenaMax)
                     if newLen < needed { newLen = needed }
                     // Steel-prefill hybrid wants chunk=1024 → bump maxM (scratch ~200MB, resident tier).
-                    let mm = Tell.envFlag("QWISP_HYBRID_PREFILL") ? Swift.max(cfg.maxM, 1032) : cfg.maxM
+                    let mm = ProcessInfo.processInfo.environment["QWISP_HYBRID_PREFILL"] != "0" ? Swift.max(cfg.maxM, 1032) : cfg.maxM
                     guard let b = Tell.fusedBackend(engine: self.engine, maxM: mm, maxSeqLen: newLen) else {
                         continuation.finish(); return
                     }

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -207,6 +207,62 @@ extension Tell {
                 "PREFIXSPEED done"].joined(separator: "\n")
     }
 
+    // Prefill stage profile (kernel-speedup recon): ① raw path — per-stage GPU time via
+    // forwardRowsProfiled (CB-split, exact math) bucketed into GDN/attn/MoE, swept over chunk size.
+    // ② MLX path — same prompt chunk-prefilled through QwispModel (MLX gather_qmm uses matrix-unit
+    // kernels at M>=14), as free evidence of what a GEMM-structured MoE kernel buys at prefill M.
+    // Env: QWISP_PREFILL_LEN (default 2048).
+    public static func prefillStageProfile(modelDir: String) -> String {
+        guard let store = try? WeightStore(modelDir: modelDir) else { return "[stage-prof] load fail\nSTAGEPROF done" }
+        store.residentAll()
+        let engine = SeedlessEngine.build(store: store)
+        let promptLen = Tell.envInt("QWISP_PREFILL_LEN", 2048)
+        let promptI32 = (0..<promptLen).map { Int32((($0 &* 7 &+ 13) % 5000) + 100) }
+        var lines = ["[stage-prof] promptLen=\(promptLen) resident"]
+
+        // ① raw per-stage GPU time, chunk sweep
+        lines.append("  ── raw path: per-stage GPU ms (CB-split, exact) ──")
+        for chunk in [64, 256, 1024] {
+            guard let (fwd, _) = engine.makeFused(maxM: chunk + 8, maxSeqLen: promptLen + 128) else {
+                lines.append("  chunk=\(chunk): makeFused nil"); continue
+            }
+            var g = 0.0, a = 0.0, m = 0.0
+            let t0 = Date(); var pos = 0
+            while pos < promptLen {
+                let end = Swift.min(pos + chunk, promptLen)
+                let x = engine.embed(tokens: Array(promptI32[pos ..< end]))
+                guard let t = fwd.forwardRowsProfiled(x, M: end - pos) else { break }
+                g += t.gdn; a += t.attn; m += t.moe
+                pos = end
+            }
+            let wall = Date().timeIntervalSince(t0)
+            let tot = g + a + m
+            lines.append(String(format: "  chunk=%4d  GDN %6.2fs (%4.1f%%)  attn %6.2fs (%4.1f%%)  MoE %6.2fs (%4.1f%%)  | stageSum %5.1fs  wall %5.1fs  %.0f tok/s",
+                                chunk, g/1000, 100*g/tot, a/1000, 100*a/tot, m/1000, 100*m/tot,
+                                tot/1000, wall, Double(promptLen)/wall))
+        }
+
+        // ② MLX path (matrix-unit gather_qmm at M>=14): same prompt, chunked cached prefill
+        lines.append("  ── MLX path (QwispModel, gather_qmm matrix-unit) ──")
+        let model = QwispModel(store: store)
+        let ids = promptI32.map { Int($0) }
+        for chunk in [64, 256] {
+            let caches = model.makeCaches()
+            let t0 = Date(); var pos = 0
+            while pos < promptLen {
+                let end = Swift.min(pos + chunk, promptLen)
+                let (hidden, _) = model.forwardHidden(MLXArray(ids[pos ..< end].map { Int32($0) }).reshaped([1, end - pos]),
+                                                      caches: caches)
+                MLX.eval(hidden)
+                pos = end
+            }
+            let wall = Date().timeIntervalSince(t0)
+            lines.append(String(format: "  chunk=%4d  wall %5.1fs  %.0f tok/s", chunk, wall, Double(promptLen)/wall))
+        }
+        lines.append("STAGEPROF done")
+        return lines.joined(separator: "\n")
+    }
+
     public static func prefixCachePoC(modelDir: String) -> String {
         guard let store = try? WeightStore(modelDir: modelDir) else { return "[prefix-poc] load fail\nPREFIXPOC FAIL" }
         store.residentAll()

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -324,6 +324,69 @@ extension Tell {
         return lines.joined(separator: "\n")
     }
 
+    // Hybrid-prefill estimate: measures the steel-replaceable sub-stage costs (GDN matmuls, GDN
+    // recurrence, MoE routed gather, MoE shared) by warm-buffer skip differentials (KV/GDN state
+    // reset via fullRestore between runs; buffers stay numerically sane after a warm pass, avoiding
+    // the cold-garbage artifact that invalidated v1), then folds in the MEASURED steel ratios
+    // (steel-route-bench @1a41c38) + sync/copy overheads to print the projected hybrid speedup.
+    // Additivity of the differentials is reported as a sanity check.
+    public static func hybridEstimate(modelDir: String) -> String {
+        guard let store = try? WeightStore(modelDir: modelDir) else { return "[hybrid-est] load fail\nHYBRIDEST done" }
+        store.residentAll()
+        let engine = SeedlessEngine.build(store: store)
+        let promptLen = Tell.envInt("QWISP_PREFILL_LEN", 2048)
+        let prompt = (0..<promptLen).map { Int32((($0 &* 7 &+ 13) % 5000) + 100) }
+        func allOff() {
+            SeedlessMetalForward.profSkipGDNMatmul = false
+            SeedlessMetalForward.profSkipGDNRecur = false
+            SeedlessMetalForward.profSkipMoERouted = false
+            SeedlessMetalForward.profSkipMoEShared = false
+        }
+        var out = ["[hybrid-est] promptLen=\(promptLen) resident — sub-stage differentials (warm) + steel fold-in"]
+        // measured steel speedups (steel-route-bench): [chunk: (gdnMatmul, moeRouted, moeShared)]
+        // gdnMatmul = blend of inproj (3.8x@256, 4.3x@1024) and outproj (~1.4x@256, ~3.3x@1024) → ~3.0/4.0
+        let steel: [Int: (gdnMat: Double, moeR: Double, moeS: Double)] = [
+            256:  (3.0, 1.40, 1.0),
+            1024: (4.0, 2.24, 2.3)]
+        for chunk in [256, 1024] {
+            guard let b = Tell.fusedBackend(engine: engine, maxM: chunk + 8, maxSeqLen: promptLen + 128) else { continue }
+            guard let empty = b.fullSnapshot?() else { continue }
+            func prefill() -> Double {
+                b.fullRestore?(empty)
+                let t0 = Date(); var pos = 0
+                while pos < promptLen {
+                    let e = Swift.min(pos + chunk, promptLen)
+                    _ = b.forward(Array(prompt[pos ..< e])); pos = e
+                }
+                return Date().timeIntervalSince(t0)
+            }
+            allOff(); _ = prefill()                                  // warm: sane buffers + pipelines
+            func timed(_ set: () -> Void) -> Double {
+                allOff(); set()
+                let a = prefill(), c = prefill()
+                allOff(); return Swift.min(a, c)
+            }
+            let full  = timed {}
+            let dGMat = full - timed { SeedlessMetalForward.profSkipGDNMatmul = true }
+            let dGRec = full - timed { SeedlessMetalForward.profSkipGDNRecur = true }
+            let dMoER = full - timed { SeedlessMetalForward.profSkipMoERouted = true }
+            let dMoES = full - timed { SeedlessMetalForward.profSkipMoEShared = true }
+            let parts = dGMat + dGRec + dMoER + dMoES
+            let r = steel[chunk]!
+            let boundaries = Double(promptLen / chunk) * (30.0 * 2 + 40.0 * 2)   // per chunk: GDN 2/layer + MoE 2/layer
+            let sync = boundaries * 0.263e-3
+            let copies = Double(promptLen / chunk) * 0.015 * Double(chunk) / 1024.0   // ~15ms/chunk@1024 measured-class memcpy
+            let hybrid = full - dGMat * (1 - 1 / r.gdnMat) - dMoER * (1 - 1 / r.moeR) - dMoES * (1 - 1 / r.moeS) + sync + copies
+            out.append(String(format: "  chunk=%4d  full %5.2fs (%.0f tok/s)", chunk, full, Double(promptLen) / full))
+            out.append(String(format: "    sub-stage: GDNmat %5.2fs  GDNrec %5.2fs  MoErouted %5.2fs  MoEshared %5.2fs  (sum %.2fs = %.0f%% of full — additivity check)",
+                              dGMat, dGRec, dMoER, dMoES, parts, 100 * parts / full))
+            out.append(String(format: "    HYBRID est: %5.2fs (%.0f tok/s)  → %.2fx   [steel %0.1f/%0.2f/%0.1fx, sync %.2fs, copies %.2fs]",
+                              hybrid, Double(promptLen) / hybrid, full / hybrid, r.gdnMat, r.moeR, r.moeS, sync, copies))
+        }
+        out.append("HYBRIDEST done")
+        return out.joined(separator: "\n")
+    }
+
     public static func prefixCachePoC(modelDir: String) -> String {
         guard let store = try? WeightStore(modelDir: modelDir) else { return "[prefix-poc] load fail\nPREFIXPOC FAIL" }
         store.residentAll()

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -387,6 +387,92 @@ extension Tell {
         return out.joined(separator: "\n")
     }
 
+    // Stage-1 gate for the steel-prefill hybrid: (a) model-math sanity — hybrid final normed must be
+    // CLOSE to raw (different rounding, tiny rel err; catches mis-wired buffers/slices), (b)
+    // determinism — two hybrid runs byte-identical, (c) split-invariance — chunk 512 vs 1024 byte-
+    // identical (steel padding pins every M into one kernel class), (d) speed — hybrid vs raw prefill.
+    public static func hybridPrefillBench(modelDir: String) -> String {
+        guard let store = try? WeightStore(modelDir: modelDir) else { return "[hybrid-bench] load fail\nHYBRIDBENCH FAIL" }
+        store.residentAll()
+        let engine = SeedlessEngine.build(store: store)
+        let promptLen = Tell.envInt("QWISP_PREFILL_LEN", 2048)
+        let prompt = (0..<promptLen).map { Int32((($0 &* 7 &+ 13) % 5000) + 100) }
+
+        func mkBackend(_ hybrid: Bool) -> Tell.SpecBackend? {
+            setenv("QWISP_HYBRID_PREFILL", hybrid ? "1" : "0", 1)
+            return Tell.fusedBackend(engine: engine, maxM: 1032, maxSeqLen: promptLen + 128)
+        }
+        // prefill via Tell.prefill (uses hybrid closure + chunk automatically); returns final normed row.
+        func run(_ b: Tell.SpecBackend, chunk: Int? = nil) -> [Float16]? {
+            var bb = b
+            if let c = chunk { bb.hybridChunk = c }
+            guard let n = Tell.prefill(promptIds: prompt, backend: bb) else { return nil }
+            n.eval()
+            return n.reshaped([-1]).asArray(Float16.self)
+        }
+        var out = ["[hybrid-bench] promptLen=\(promptLen) resident, maxM=1032"]
+
+        guard let rawB = mkBackend(false) else { return "[hybrid-bench] raw backend nil\nHYBRIDBENCH FAIL" }
+        let tR0 = Date(); guard let rawOut = run(rawB) else { return "[hybrid-bench] raw run nil\nHYBRIDBENCH FAIL" }
+        let tRaw = Date().timeIntervalSince(tR0)
+
+        guard let hyB = mkBackend(true), hyB.forwardHybrid != nil else { return "[hybrid-bench] hybrid backend nil\nHYBRIDBENCH FAIL" }
+        let tH0 = Date(); guard let hy1 = run(hyB) else { return "[hybrid-bench] hybrid run nil\nHYBRIDBENCH FAIL" }
+        let tHy = Date().timeIntervalSince(tH0)
+
+        // (a) model-math sanity: rel err of final normed row
+        var num = 0.0, den = 0.0
+        for i in 0..<rawOut.count { num += abs(Double(hy1[i]) - Double(rawOut[i])); den += abs(Double(rawOut[i])) }
+        let rel = num / Swift.max(den, 1e-9)
+        // (b) determinism: fresh hybrid backend, same run
+        guard let hyB2 = mkBackend(true), let hy2 = run(hyB2) else { return "[hybrid-bench] hy2 nil\nHYBRIDBENCH FAIL" }
+        let det = hy1 == hy2
+        // (c) split-invariance: chunk 512 on a fresh hybrid backend
+        guard let hyB3 = mkBackend(true), let hy3 = run(hyB3, chunk: 512) else { return "[hybrid-bench] hy3 nil\nHYBRIDBENCH FAIL" }
+        let splitInv = hy1 == hy3
+
+        out.append(String(format: "  raw    prefill %5.2fs (%.0f tok/s)  [chunk 64]", tRaw, Double(promptLen) / tRaw))
+        out.append(String(format: "  hybrid prefill %5.2fs (%.0f tok/s)  [chunk 1024]  → %.2fx", tHy, Double(promptLen) / tHy, tRaw / tHy))
+        // (a2) single-op wiring sanity: steel qkv on layer-0 weights vs f32-x reference (~1e-3 = correct)
+        var relOp = -1.0
+        if let g0 = engine.layers.first(where: { $0.gdn != nil })?.gdn {
+            let xt = MLXRandom.normal([64, 2048]).asType(.float16)
+            let ys = MLX.quantizedMatmul(xt, g0.qkvWq, scales: g0.qkvSc, biases: g0.qkvBi, transpose: true, groupSize: 64, bits: 4)
+            let yr = MLX.quantizedMatmul(xt.asType(.float32), g0.qkvWq, scales: g0.qkvSc.asType(.float32), biases: g0.qkvBi.asType(.float32), transpose: true, groupSize: 64, bits: 4)
+            MLX.eval([ys, yr])
+            let a = ys.asType(.float32).reshaped([-1]).asArray(Float.self)
+            let b = yr.reshaped([-1]).asArray(Float.self)
+            var n2 = 0.0, d2 = 0.0
+            for i in 0..<a.count { n2 += Double(abs(a[i] - b[i])); d2 += Double(abs(b[i])) }
+            relOp = n2 / Swift.max(d2, 1e-9)
+        }
+        // (a3) fidelity-family baseline: full-MLX (QwispModel) prefill final hidden vs raw
+        let model = QwispModel(store: store)
+        let caches = model.makeCaches()
+        var mlxLast: [Float16] = []
+        var pos = 0
+        while pos < promptLen {
+            let end = Swift.min(pos + 64, promptLen)
+            let ids = prompt[pos ..< end].map { Int32($0) }
+            let (hidden, _) = model.forwardHidden(MLXArray(ids).reshaped([1, end - pos]), caches: caches)
+            hidden.eval()
+            if end == promptLen { mlxLast = hidden[0, end - pos - 1].asType(.float16).reshaped([-1]).asArray(Float16.self) }
+            pos = end
+        }
+        var nM = 0.0, dM = 0.0
+        for i in 0..<Swift.min(mlxLast.count, rawOut.count) { nM += abs(Double(mlxLast[i]) - Double(rawOut[i])); dM += abs(Double(rawOut[i])) }
+        let relMLX = nM / Swift.max(dM, 1e-9)
+        out.append(String(format: "  (a) rel err vs raw      : %.2e   [single-op steel vs f32-ref: %.2e; full-MLX vs raw baseline: %.2e]", rel, relOp, relMLX))
+        let sane = relOp < 5e-3 && rel < Swift.max(2 * relMLX, 1e-2)
+        out.append("      wiring \(relOp < 5e-3 ? "OK ✅" : "MISWIRED ❌"), fidelity \(rel < Swift.max(2 * relMLX, 1e-2) ? "IN-FAMILY ✅ (≤2x full-MLX baseline)" : "OUT ❌")")
+        out.append("  (b) determinism         : \(det ? "IDENTICAL ✅" : "DIVERGE ❌")")
+        out.append("  (c) split-inv (512 vs 1024): \(splitInv ? "IDENTICAL ✅" : "DIVERGE ❌")")
+        let pass = sane && det && splitInv
+        out.append("HYBRIDBENCH \(pass ? "PASS" : "FAIL")")
+        setenv("QWISP_HYBRID_PREFILL", "0", 1)
+        return out.joined(separator: "\n")
+    }
+
     public static func prefixCachePoC(modelDir: String) -> String {
         guard let store = try? WeightStore(modelDir: modelDir) else { return "[prefix-poc] load fail\nPREFIXPOC FAIL" }
         store.residentAll()

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -259,6 +259,29 @@ extension Tell {
             let wall = Date().timeIntervalSince(t0)
             lines.append(String(format: "  chunk=%4d  wall %5.1fs  %.0f tok/s", chunk, wall, Double(promptLen)/wall))
         }
+        // MLX GDN stage attribution (GatedDeltaNetLayer prof counters; eval barriers inflate wall,
+        // stage sums still attribute where MLX spends its GDN time vs our sequential T-loop kernel).
+        StreamingMoEBlock.profileLayers = true
+        StreamingMoEBlock.tGdnInproj = 0; StreamingMoEBlock.tGdnConv = 0
+        StreamingMoEBlock.tGdnKernel = 0; StreamingMoEBlock.tGdnOut = 0
+        do {
+            let caches = model.makeCaches()
+            let t0 = Date(); var pos = 0
+            while pos < promptLen {
+                let end = Swift.min(pos + 64, promptLen)
+                let (hidden, _) = model.forwardHidden(MLXArray(ids[pos ..< end].map { Int32($0) }).reshaped([1, end - pos]),
+                                                      caches: caches)
+                MLX.eval(hidden)
+                pos = end
+            }
+            let wall = Date().timeIntervalSince(t0)
+            func s(_ ns: UInt64) -> Double { Double(ns) / 1e9 }
+            lines.append(String(format: "  MLX GDN stages (c64, barriered wall %.1fs): inproj %.2fs  conv %.2fs  recur-kernel %.2fs  out %.2fs  | GDN total %.2fs",
+                                wall, s(StreamingMoEBlock.tGdnInproj), s(StreamingMoEBlock.tGdnConv),
+                                s(StreamingMoEBlock.tGdnKernel), s(StreamingMoEBlock.tGdnOut),
+                                s(StreamingMoEBlock.tGdnInproj + StreamingMoEBlock.tGdnConv + StreamingMoEBlock.tGdnKernel + StreamingMoEBlock.tGdnOut)))
+        }
+        StreamingMoEBlock.profileLayers = false
         lines.append("STAGEPROF done")
         return lines.joined(separator: "\n")
     }

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -286,6 +286,44 @@ extension Tell {
         return lines.joined(separator: "\n")
     }
 
+    // Verification ① for the MLX-dense-prefill route: per-element M-invariance of MLX
+    // quantizedMatmul. Row r's output must be bit-identical no matter how many other rows share
+    // the call (and under zero-padding), or split-point-invariant prefill via MLX dense is dead.
+    // MLX dispatches qmv (M<14, scalar) vs steel qmm (M>=14, matrix units) — the padding variant
+    // tests whether pinning ALL prefill matmuls to the steel class (pad M up to >=14) is coherent.
+    public static func mlxQmmInvariance(modelDir: String) -> String {
+        var lines = ["[mlx-qmm-minv] MLX quantizedMatmul per-element M-invariance (value-equality per row)"]
+        for (label, K, N) in [("2048→512", 2048, 512), ("2048→12352", 2048, 12352)] {
+            let wf = MLXRandom.normal([N, K]).asType(.float16)
+            let (wq, sc, biOpt) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine)
+            guard let bi = biOpt else { return "[mlx-qmm-minv] biases nil" }
+            let xAll = MLXRandom.normal([1024, K]).asType(.float16)
+            MLX.eval([wq, sc, bi, xAll])
+            func qmm(_ x: MLXArray) -> MLXArray {
+                let y = MLX.quantizedMatmul(x, wq, scales: sc, biases: bi, transpose: true, groupSize: 64, bits: 4)
+                y.eval(); return y
+            }
+            let full = qmm(xAll)                                   // M=1024 reference
+            func rowsEqual(_ a: MLXArray, _ b: MLXArray) -> Bool {
+                let d = MLX.all(a .== b)
+                d.eval(); return d.item(Bool.self)
+            }
+            lines.append("  ── \(label) ──")
+            for M in [1, 8, 13, 14, 16, 64, 256] {
+                let out = qmm(xAll[0..<M])
+                let ok = rowsEqual(out, full[0..<M])
+                lines.append("    M=\(M)\tvs M=1024 rows[0..<\(M)]: \(ok ? "IDENTICAL ✅" : "DIFFER ❌")")
+            }
+            // zero-pad variant: 3 real rows + 13 zero rows = M=16 call; real rows vs full
+            let pad = MLX.concatenated([xAll[0..<3], MLXArray.zeros([13, K]).asType(.float16)], axis: 0)
+            let outPad = qmm(pad)
+            let okPad = rowsEqual(outPad[0..<3], full[0..<3])
+            lines.append("    M=3+13pad(=16)\tvs M=1024 rows[0..<3]: \(okPad ? "IDENTICAL ✅" : "DIFFER ❌")")
+        }
+        lines.append("MLXQMMMINV done")
+        return lines.joined(separator: "\n")
+    }
+
     public static func prefixCachePoC(modelDir: String) -> String {
         guard let store = try? WeightStore(modelDir: modelDir) else { return "[prefix-poc] load fail\nPREFIXPOC FAIL" }
         store.residentAll()

--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -2159,11 +2159,14 @@ public enum SeedlessFusedVerify {
 
     /// attention 層 × M 行の全段を既存 encoder に encode。演算列は attnLayerRows と 1:1。
     /// kv.len は encode 時点の baseLen として読み、呼び出し側が encode 後に kv.len += M する。
+    // hybridDense: q/k/v arrive via MLX steel into sc.qOut/kOut/vOut; o_proj computed via MLX
+    // steel from sc.gated afterwards. Default false = existing path, untouched.
     static func encodeAttnLayerRows(_ enc: MTLComputeCommandEncoder, x: MTLBuffer, out: MTLBuffer,
                                     w: AttnLayerBufs, sc: AttnScratch, kv: KVCacheBufs,
                                     M: Int, H: Int,
                                     numHeads: Int = 16, numKV: Int = 2, headDim: Int = 256,
-                                    ropeDim: Int = 64, ropeBase: Float = 1e7, eps: Float = 1e-6) {
+                                    ropeDim: Int = 64, ropeBase: Float = 1e7, eps: Float = 1e-6,
+                                    hybridDense: Bool = false) {
         let baseLen = kv.len
         let qd2 = 2 * headDim
         let scale = Float(pow(Double(headDim), -0.5))
@@ -2171,7 +2174,9 @@ public enum SeedlessFusedVerify {
         // A1(fuseATTN): 3 separate qmm4 dispatches → 1 demux dispatch(−2 per attn layer).
         // Cat weights built at prepare time; bit-exact by qmm4_inproj_demux_rows construction.
         // 原子別 kill-switch(bisect/構成用): QWISP_FUSE_A1=0 で A1 のみ無効。
-        if SeedlessFusedForward.fuseATTN,
+        if hybridDense {
+            // q/k/v computed via MLX steel into sc.qOut/kOut/vOut before this encode.
+        } else if SeedlessFusedForward.fuseATTN,
            SeedlessFusedForward.fuseA1Enabled,
            let cw = w.catQkvW, let cs = w.catQkvS, let cb = w.catQkvB, let dummy = w.catQkvDummy {
             let Nq = numHeads * qd2, Nk = numKV * headDim, Nv = numKV * headDim
@@ -2214,7 +2219,9 @@ public enum SeedlessFusedVerify {
         // ⑥ sigmoid gate → o_proj
         encodeSigmoidMul(enc, attnOut: sc.attnOut, qOut: sc.qOut, gated: sc.gated,
                          headDim: headDim, qd2: qd2, total: M * numHeads * headDim)
-        encodeQmmRows(enc, w: w.oW, scales: w.oS, biases: w.oB, x: sc.gated, out: out, M: M, K: numHeads * headDim, N: H)
+        if !hybridDense {
+            encodeQmmRows(enc, w: w.oW, scales: w.oS, biases: w.oB, x: sc.gated, out: out, M: M, K: numHeads * headDim, N: H)
+        }
     }
 
     /// Stage B の pipeline warm。
@@ -3722,6 +3729,9 @@ public enum SeedlessFusedVerify {
         public var hybridGdnW: [Int: (qkv: (MLXArray, MLXArray, MLXArray),
                                       z: (MLXArray, MLXArray, MLXArray),
                                       out: (MLXArray, MLXArray, MLXArray))] = [:]
+        // Per-layer attn q/k/v/o triples for the steel dense swap.
+        public var hybridAttnW: [Int: (q: (MLXArray, MLXArray, MLXArray), k: (MLXArray, MLXArray, MLXArray),
+                                       v: (MLXArray, MLXArray, MLXArray), o: (MLXArray, MLXArray, MLXArray))] = [:]
         // Per-layer MoE expert weights (gate/up/down triples) for the steel-CSR routed gather.
         public var hybridMoEW: [Int: (g: (MLXArray, MLXArray, MLXArray),
                                       u: (MLXArray, MLXArray, MLXArray),
@@ -3786,9 +3796,16 @@ public enum SeedlessFusedVerify {
             return MLXArray(Array(UnsafeBufferPointer(start: p, count: rows * cols)), [rows, cols])
         }
         private func arrToBuf(_ a: MLXArray, _ b: MTLBuffer, _ count: Int) {
-            let v = a.asType(.float16).reshaped([-1]); v.eval()
-            let arr = v.asArray(Float16.self)
-            b.contents().bindMemory(to: Float16.self, capacity: count).update(from: arr, count: count)
+            let v = a.asType(.float16)
+            v.eval()
+            // single memcpy via noCopy MTLBuffer wrap when contiguous; Array-copy fallback otherwise
+            if let (device, _) = SeedlessMetalForward.ensure(),
+               let src = v.asMTLBuffer(device: device, noCopy: true) {
+                memcpy(b.contents(), src.contents(), count * 2)
+            } else {
+                let arr = v.reshaped([-1]).asArray(Float16.self)
+                b.contents().bindMemory(to: Float16.self, capacity: count).update(from: arr, count: count)
+            }
         }
 
         /// Hybrid prefill forward: raw skeleton (norms/conv/recurrence/attention/MoE — all
@@ -3824,8 +3841,10 @@ public enum SeedlessFusedVerify {
                     SeedlessFusedVerify.encodeRmsNormRows(enc(), x: hBuf, w: L.inputLN, out: normed, rows: M, D: H, eps: eps)
                     flush()
                     let xa = bufToArr(normed, M, H)
-                    arrToBuf(steelQmm(xa, hw.qkv, M: M), gdnSc.qkv, M * convDim)
-                    arrToBuf(steelQmm(xa, hw.z, M: M), gdnSc.z, M * valueDim)
+                    let yQkv = steelQmm(xa, hw.qkv, M: M), yZ = steelQmm(xa, hw.z, M: M)
+                    MLX.eval([yQkv, yZ])
+                    arrToBuf(yQkv, gdnSc.qkv, M * convDim)
+                    arrToBuf(yZ, gdnSc.z, M * valueDim)
                     SeedlessFusedVerify.encodeGdnLayerRows(enc(), x: normed, out: mixerOut, w: gw, sc: gdnSc, cache: gc,
                                                       M: M, H: H, numKHeads: numKHeads, numVHeads: numVHeads,
                                                       headKDim: headKDim, headVDim: headVDim,
@@ -3840,8 +3859,30 @@ public enum SeedlessFusedVerify {
                         SeedlessFusedVerify.encodeResidAdd(enc(), h: hBuf, r: mixerOut, total: M * H)
                         SeedlessFusedVerify.encodeRmsNormRows(enc(), x: hBuf, w: L.postLN, out: postNorm, rows: M, D: H, eps: eps)
                     }
+                } else if !L.isLinear, let aw = L.attn, let kv = L.kvCache, let hwA = hybridAttnW[li] {
+                    SeedlessFusedVerify.encodeRmsNormRows(enc(), x: hBuf, w: L.inputLN, out: normed, rows: M, D: H, eps: eps)
+                    flush()
+                    let xa = bufToArr(normed, M, H)
+                    let yQ = steelQmm(xa, hwA.q, M: M), yK = steelQmm(xa, hwA.k, M: M), yV = steelQmm(xa, hwA.v, M: M)
+                    MLX.eval([yQ, yK, yV])
+                    arrToBuf(yQ, attnSc.qOut, M * numHeads * headDim * 2)
+                    arrToBuf(yK, attnSc.kOut, M * numKV * headDim)
+                    arrToBuf(yV, attnSc.vOut, M * numKV * headDim)
+                    SeedlessFusedVerify.encodeAttnLayerRows(enc(), x: normed, out: mixerOut, w: aw, sc: attnSc, kv: kv,
+                                                       M: M, H: H, numHeads: numHeads, numKV: numKV, headDim: headDim,
+                                                       ropeDim: ropeDim, ropeBase: ropeBase, eps: eps, hybridDense: true)
+                    kv.len += M
+                    flush()
+                    arrToBuf(steelQmm(bufToArr(attnSc.gated, M, numHeads * headDim), hwA.o, M: M), mixerOut, M * H)
+                    if SeedlessFusedForward.fuseGDN, SeedlessFusedVerify._gdnResidPostNormRowsPipeline != nil {
+                        SeedlessFusedVerify.encodeGdnResidPostNormRows(enc(), h: hBuf, r: mixerOut,
+                                                                  w: L.postLN, postNorm: postNorm, M: M, H: H, eps: eps)
+                    } else {
+                        SeedlessFusedVerify.encodeResidAdd(enc(), h: hBuf, r: mixerOut, total: M * H)
+                        SeedlessFusedVerify.encodeRmsNormRows(enc(), x: hBuf, w: L.postLN, out: postNorm, rows: M, D: H, eps: eps)
+                    }
                 } else {
-                    encodePreMoE(enc(), L, M: M)   // raw mixer (attn layers etc.), incl. resid+postnorm
+                    encodePreMoE(enc(), L, M: M)   // raw mixer fallback, incl. resid+postnorm
                 }
                 // ── MoE ──
                 if let mw = hybridMoEW[li] {

--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -3706,6 +3706,36 @@ public enum SeedlessFusedVerify {
             }
         }
 
+        /// Measurement-only prefill profiler: resident forward with per-stage CB splits, bucketing
+        /// GPU time into (GDN mixer, attn mixer, MoE block). Encode order and kernels are identical
+        /// to forwardRows resident mode — only CB boundaries differ — so cache state advances
+        /// exactly the same and the token math is unchanged. Adds ~2 sync/layer of CPU overhead,
+        /// which inflates wall time but NOT the per-CB gpu times being reported.
+        public func forwardRowsProfiled(_ x: MLXArray, M: Int) -> (gdn: Double, attn: Double, moe: Double)? {
+            guard M <= maxM else { return nil }
+            let xf = x.asType(.float16).reshaped([-1]); xf.eval()
+            let arr = xf.asArray(Float16.self)
+            hBuf.contents().bindMemory(to: Float16.self, capacity: maxM * H).update(from: arr, count: M * H)
+            var tGdn = 0.0, tAttn = 0.0, tMoe = 0.0
+            func timed(_ body: (MTLComputeCommandEncoder) -> Void) -> Double {
+                let cb = queue.makeCommandBuffer()!
+                let enc = cb.makeComputeCommandEncoder()!
+                body(enc)
+                enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+                return (cb.gpuEndTime - cb.gpuStartTime) * 1000.0
+            }
+            for L in layers {
+                let t1 = timed { enc in self.encodePreMoE(enc, L, M: M) }
+                if L.isLinear { tGdn += t1 } else { tAttn += t1 }
+                tMoe += timed { enc in
+                    SeedlessFusedVerify.encodeMoEBlockRows(enc, x: self.postNorm, out: self.moeOut, w: L.moe, sc: self.moeSc,
+                                                      M: M, E: L.E, I: L.I, Ktop: L.Ktop, H: self.H)
+                    SeedlessFusedVerify.encodeResidAdd(enc, h: self.hBuf, r: self.moeOut, total: M * self.H)
+                }
+            }
+            return (tGdn, tAttn, tMoe)
+        }
+
         /// テスト比較用: 層 i の cache を MLX で読む(gdn: (conv, rec) / attn: (k, v))。
         public func readLayerCache(_ i: Int) -> (MLXArray?, MLXArray?) {
             let L = layers[i]

--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -2731,12 +2731,16 @@ public enum SeedlessFusedVerify {
 
     /// GDN 層 × M 行の全段を既存 encoder に encode。演算列は gdnLayerRows と 1:1。
     /// encode 後に cache.swapState() を呼ぶこと(state ping-pong)。
+    // hybridDense (steel-prefill hybrid, additive): true → ① encodes only the tiny a/b projections
+    // (qkv/z are computed via MLX steel INTO sc.qkv/sc.z before this encode) and ⑦ out_proj is
+    // skipped (computed via MLX steel FROM sc.outV after). Default false = existing path, untouched.
     static func encodeGdnLayerRows(_ enc: MTLComputeCommandEncoder, x: MTLBuffer, out: MTLBuffer,
                                    w: GdnLayerBufs, sc: GdnScratch, cache: GdnCacheBufs,
                                    M: Int, H: Int,
                                    numKHeads: Int = 16, numVHeads: Int = 32,
                                    headKDim: Int = 128, headVDim: Int = 128,
-                                   convKernel: Int = 4, eps: Float = 1e-6) {
+                                   convKernel: Int = 4, eps: Float = 1e-6,
+                                   hybridDense: Bool = false) {
         let keyDim = headKDim * numKHeads
         let valueDim = headVDim * numVHeads
         let convDim = keyDim * 2 + valueDim
@@ -2745,7 +2749,11 @@ public enum SeedlessFusedVerify {
         // qmm4_inproj_demux_rows 1 dispatch で qkv/z/bP/aP の 4 buffer に書き分ける(−3/層)。
         // dot 演算は既存 qmm4_rows と同一順 = bit-exact by construction。catInProjW は
         // prepareGdnLayerBufs が fuseGDN||QWISP_PROF_AB 時のみ build(nil なら flag-off 4 dispatch へ)。
-        if SeedlessFusedForward.fuseGDN, let cw = w.catInProjW, let cs = w.catInProjS, let cb = w.catInProjB,
+        if hybridDense {
+            // qkv/z arrive via MLX steel; only the tiny a/b projections stay raw here.
+            encodeQmmRows(enc, w: w.bW, scales: w.bS, biases: w.bB, x: x, out: sc.bP, M: M, K: H, N: numVHeads)
+            encodeQmmRows(enc, w: w.aW, scales: w.aS, biases: w.aB, x: x, out: sc.aP, M: M, K: H, N: numVHeads)
+        } else if SeedlessFusedForward.fuseGDN, let cw = w.catInProjW, let cs = w.catInProjS, let cb = w.catInProjB,
            w.totalInProjN == convDim + valueDim + numVHeads + numVHeads {
             encodeQmmInProjDemuxRows(enc, w: cw, scales: cs, biases: cb, x: x,
                                      outQkv: sc.qkv, outZ: sc.z, outB: sc.bP, outA: sc.aP,
@@ -2812,8 +2820,10 @@ public enum SeedlessFusedVerify {
                               rows: M * numVHeads, D: headVDim, eps: eps, promoteF32: w.promoteRMS)
             encodeGate(enc, z: sc.z, normed: sc.normed, outV: sc.outV, total: M * valueDim, promote: w.promoteRMS)
         }
-        // ⑦ out_proj
-        encodeQmmRows(enc, w: w.outW, scales: w.outS, biases: w.outB, x: sc.outV, out: out, M: M, K: valueDim, N: H)
+        // ⑦ out_proj (hybridDense → computed via MLX steel from sc.outV afterwards)
+        if !hybridDense {
+            encodeQmmRows(enc, w: w.outW, scales: w.outS, biases: w.outB, x: sc.outV, out: out, M: M, K: valueDim, N: H)
+        }
     }
 
     /// Stage C の pipeline warm(recurrent は #define 次元固定なので実次元で warm)。
@@ -3704,6 +3714,162 @@ public enum SeedlessFusedVerify {
                     SeedlessFusedVerify.writeGdnCache(gc, conv: g.conv, rec: g.rec)
                 }
             }
+        }
+
+        // ── Steel-prefill hybrid (claude/prefill-kernel): GDN dense matmuls via MLX steel ──────
+        // Per-layer MLX weight triples (qkv / z / out_proj), keyed by layer array index. Set by the
+        // backend builder when QWISP_HYBRID_PREFILL=1; empty → forwardRowsHybrid == forwardRows.
+        public var hybridGdnW: [Int: (qkv: (MLXArray, MLXArray, MLXArray),
+                                      z: (MLXArray, MLXArray, MLXArray),
+                                      out: (MLXArray, MLXArray, MLXArray))] = [:]
+        // Per-layer MoE expert weights (gate/up/down triples) for the steel-CSR routed gather.
+        public var hybridMoEW: [Int: (g: (MLXArray, MLXArray, MLXArray),
+                                      u: (MLXArray, MLXArray, MLXArray),
+                                      d: (MLXArray, MLXArray, MLXArray))] = [:]
+
+        // Steel-CSR routed MoE gather: rows sorted by expert into fixed R=16 tiles (pad rows point
+        // at row 0 — content-irrelevant, per-element invariance proven) → gather_qmm_t matrix units
+        // (2.24x @T=1024 vs per-pair qmv). Reads sc.inds (route must be flushed), writes sc.d in mk
+        // order; scores/shared/combine stay raw. Deterministic + tile-composition-invariant.
+        private func steelMoEGather(M: Int, E: Int, Ktop: Int,
+                                    mw: (g: (MLXArray, MLXArray, MLXArray), u: (MLXArray, MLXArray, MLXArray), d: (MLXArray, MLXArray, MLXArray))) {
+            let R = 16
+            let ip = moeSc.inds.contents().bindMemory(to: Int32.self, capacity: M * Ktop)
+            var byE = [[Int32]](repeating: [], count: E)
+            for mk in 0 ..< (M * Ktop) { byE[Int(ip[mk])].append(Int32(mk)) }
+            var tileE = [Int32](), rowSrc = [Int32](), invIdx = [Int32](repeating: 0, count: M * Ktop)
+            for e in 0 ..< E where !byE[e].isEmpty {
+                let rows = byE[e]
+                var lo = 0
+                while lo < rows.count {
+                    let tileIdx = tileE.count
+                    tileE.append(Int32(e))
+                    for r in 0 ..< R {
+                        if lo + r < rows.count {
+                            let mk = rows[lo + r]
+                            invIdx[Int(mk)] = Int32(tileIdx * R + r)
+                            rowSrc.append(mk / Int32(Ktop))
+                        } else { rowSrc.append(0) }
+                    }
+                    lo += R
+                }
+            }
+            let Gt = tileE.count
+            let xa = bufToArr(postNorm, M, H)
+            let xg = MLX.take(xa, MLXArray(rowSrc), axis: 0).reshaped([Gt, R, H])
+            let te = MLXArray(tileE)
+            func gq(_ x: MLXArray, _ w: (MLXArray, MLXArray, MLXArray)) -> MLXArray {
+                MLX.gatherQuantizedMatmul(x, w.0, scales: w.1, biases: w.2, rhsIndices: te,
+                                          transpose: true, groupSize: 64, bits: 4, mode: .affine,
+                                          sortedIndices: true)
+            }
+            let g = gq(xg, mw.g), u = gq(xg, mw.u)
+            let h = g * MLX.sigmoid(g) * u
+            let d = gq(h, mw.d)
+            let dm = MLX.take(d.reshaped([Gt * R, H]), MLXArray(invIdx), axis: 0)
+            arrToBuf(dm, moeSc.d, M * Ktop * H)
+        }
+
+        // Steel qmm with M pinned into the steel kernel class (M>=14) by zero-padding — per-element
+        // M-invariance and padding bit-identity are proven (mlx-qmm-minv) → split-invariant prefill.
+        private func steelQmm(_ x: MLXArray, _ w: (MLXArray, MLXArray, MLXArray), M: Int) -> MLXArray {
+            var xi = x
+            if M < 14 {
+                xi = MLX.concatenated([x, MLXArray.zeros([14 - M, x.dim(1)]).asType(.float16)], axis: 0)
+            }
+            let y = MLX.quantizedMatmul(xi, w.0, scales: w.1, biases: w.2,
+                                        transpose: true, groupSize: 64, bits: 4)
+            return M < 14 ? y[0 ..< M] : y
+        }
+        private func bufToArr(_ b: MTLBuffer, _ rows: Int, _ cols: Int) -> MLXArray {
+            let p = b.contents().bindMemory(to: Float16.self, capacity: rows * cols)
+            return MLXArray(Array(UnsafeBufferPointer(start: p, count: rows * cols)), [rows, cols])
+        }
+        private func arrToBuf(_ a: MLXArray, _ b: MTLBuffer, _ count: Int) {
+            let v = a.asType(.float16).reshaped([-1]); v.eval()
+            let arr = v.asArray(Float16.self)
+            b.contents().bindMemory(to: Float16.self, capacity: count).update(from: arr, count: count)
+        }
+
+        /// Hybrid prefill forward: raw skeleton (norms/conv/recurrence/attention/MoE — all
+        /// split-invariance-proven) with the GDN qkv/z/out_proj matmuls computed via MLX steel
+        /// (2-4.3x at prefill M). Cache bookkeeping identical to forwardRows; 2 CB boundaries per
+        /// GDN layer. NOT bit-identical to forwardRows (steel rounds differently) — a deliberate
+        /// new canonical prefill config (refs re-canonicalization gated). Deterministic and
+        /// chunk/split-invariant by construction. Resident mode only; else falls back.
+        public func forwardRowsHybrid(_ x: MLXArray, M: Int, finalNormW: MTLBuffer? = nil) -> MLXArray? {
+            guard M <= maxM else { return nil }
+            if hybridGdnW.isEmpty { return forwardRows(x, M: M, finalNormW: finalNormW) }
+            if case .resident = streamMode {} else { return forwardRows(x, M: M, finalNormW: finalNormW) }
+            let xf = x.asType(.float16).reshaped([-1]); xf.eval()
+            let arr = xf.asArray(Float16.self)
+            hBuf.contents().bindMemory(to: Float16.self, capacity: maxM * H).update(from: arr, count: M * H)
+
+            var curCB: MTLCommandBuffer? = nil
+            var curEnc: MTLComputeCommandEncoder? = nil
+            func enc() -> MTLComputeCommandEncoder {
+                if curEnc == nil { curCB = queue.makeCommandBuffer()!; curEnc = curCB!.makeComputeCommandEncoder()! }
+                return curEnc!
+            }
+            func flush() {
+                guard let cb = curCB else { return }
+                curEnc!.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+                curEnc = nil; curCB = nil
+            }
+            let keyDim = numKHeads * headKDim, valueDim = numVHeads * headVDim
+            let convDim = keyDim * 2 + valueDim
+            for (li, L) in layers.enumerated() {
+                // ── mixer ──
+                if L.isLinear, let gw = L.gdn, let gc = L.gdnCache, let hw = hybridGdnW[li] {
+                    SeedlessFusedVerify.encodeRmsNormRows(enc(), x: hBuf, w: L.inputLN, out: normed, rows: M, D: H, eps: eps)
+                    flush()
+                    let xa = bufToArr(normed, M, H)
+                    arrToBuf(steelQmm(xa, hw.qkv, M: M), gdnSc.qkv, M * convDim)
+                    arrToBuf(steelQmm(xa, hw.z, M: M), gdnSc.z, M * valueDim)
+                    SeedlessFusedVerify.encodeGdnLayerRows(enc(), x: normed, out: mixerOut, w: gw, sc: gdnSc, cache: gc,
+                                                      M: M, H: H, numKHeads: numKHeads, numVHeads: numVHeads,
+                                                      headKDim: headKDim, headVDim: headVDim,
+                                                      convKernel: convKernel, eps: eps, hybridDense: true)
+                    gc.swapState()
+                    flush()
+                    arrToBuf(steelQmm(bufToArr(gdnSc.outV, M, valueDim), hw.out, M: M), mixerOut, M * H)
+                    if SeedlessFusedForward.fuseGDN, SeedlessFusedVerify._gdnResidPostNormRowsPipeline != nil {
+                        SeedlessFusedVerify.encodeGdnResidPostNormRows(enc(), h: hBuf, r: mixerOut,
+                                                                  w: L.postLN, postNorm: postNorm, M: M, H: H, eps: eps)
+                    } else {
+                        SeedlessFusedVerify.encodeResidAdd(enc(), h: hBuf, r: mixerOut, total: M * H)
+                        SeedlessFusedVerify.encodeRmsNormRows(enc(), x: hBuf, w: L.postLN, out: postNorm, rows: M, D: H, eps: eps)
+                    }
+                } else {
+                    encodePreMoE(enc(), L, M: M)   // raw mixer (attn layers etc.), incl. resid+postnorm
+                }
+                // ── MoE ──
+                if let mw = hybridMoEW[li] {
+                    SeedlessFusedVerify.encodeMoERouteRows(enc(), x: postNorm, w: L.moe, sc: moeSc,
+                                                      M: M, E: L.E, H: H, Ktop: L.Ktop)
+                    flush()
+                    steelMoEGather(M: M, E: L.E, Ktop: L.Ktop, mw: mw)
+                    // combine (sc.d × scores → sc.y) lives inside encodeMoEGatherRowsRange in the raw
+                    // path, which the hybrid skips — encode it here or sharedRows reads stale sc.y.
+                    SeedlessFusedVerify.encodeCombineRows(enc(), d: moeSc.d, scores: moeSc.scores, y: moeSc.y,
+                                                     Ktop: L.Ktop, N: H, M: M,
+                                                     dByteOffset: 0, scoresOffset: 0, yByteOffset: 0)
+                    SeedlessFusedVerify.encodeMoESharedRows(enc(), x: postNorm, out: moeOut, w: L.moe, sc: moeSc,
+                                                       M: M, I: L.I, H: H, Ktop: L.Ktop)
+                    SeedlessFusedVerify.encodeResidAdd(enc(), h: hBuf, r: moeOut, total: M * H)
+                } else {
+                    SeedlessFusedVerify.encodeMoEBlockRows(enc(), x: postNorm, out: moeOut, w: L.moe, sc: moeSc,
+                                                      M: M, E: L.E, I: L.I, Ktop: L.Ktop, H: H)
+                    SeedlessFusedVerify.encodeResidAdd(enc(), h: hBuf, r: moeOut, total: M * H)
+                }
+            }
+            if let fw = finalNormW {
+                SeedlessFusedVerify.encodeRmsNormRows(enc(), x: hBuf, w: fw, out: normed, rows: M, D: H, eps: eps)
+            }
+            flush()
+            let src = finalNormW != nil ? normed : hBuf
+            let ptr = src.contents().bindMemory(to: Float16.self, capacity: maxM * H)
+            return MLXArray(Array(UnsafeBufferPointer(start: ptr, count: M * H)), [M, H])
         }
 
         /// Measurement-only prefill profiler: resident forward with per-stage CB splits, bucketing

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -177,7 +177,9 @@ extension Tell {
         }
         // Steel-prefill hybrid (opt-in): wire per-layer GDN MLX weights + the hybrid forward.
         // Chunk = min(1024, maxM): steel wins grow with chunk; callers wanting 1024 pass maxM>=1024.
-        if Tell.envFlag("QWISP_HYBRID_PREFILL") {
+        // Steel-prefill hybrid: default ON (canonical since refs re-canonicalization);
+        // QWISP_HYBRID_PREFILL=0 opts out (pre-hybrid canonical stream).
+        if ProcessInfo.processInfo.environment["QWISP_HYBRID_PREFILL"] != "0" {
             var hw: [Int: (qkv: (MLXArray, MLXArray, MLXArray), z: (MLXArray, MLXArray, MLXArray), out: (MLXArray, MLXArray, MLXArray))] = [:]
             for (i, spec) in engine.layers.enumerated() {
                 guard let g = spec.gdn else { continue }
@@ -251,7 +253,9 @@ extension Tell {
         }
         // Steel-prefill hybrid (opt-in): wire per-layer GDN MLX weights + the hybrid forward.
         // Chunk = min(1024, maxM): steel wins grow with chunk; callers wanting 1024 pass maxM>=1024.
-        if Tell.envFlag("QWISP_HYBRID_PREFILL") {
+        // Steel-prefill hybrid: default ON (canonical since refs re-canonicalization);
+        // QWISP_HYBRID_PREFILL=0 opts out (pre-hybrid canonical stream).
+        if ProcessInfo.processInfo.environment["QWISP_HYBRID_PREFILL"] != "0" {
             var hw: [Int: (qkv: (MLXArray, MLXArray, MLXArray), z: (MLXArray, MLXArray, MLXArray), out: (MLXArray, MLXArray, MLXArray))] = [:]
             for (i, spec) in engine.layers.enumerated() {
                 guard let g = spec.gdn else { continue }

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -184,6 +184,12 @@ extension Tell {
                 hw[i] = (qkv: (g.qkvWq, g.qkvSc, g.qkvBi), z: (g.zWq, g.zSc, g.zBi), out: (g.outWq, g.outSc, g.outBi))
             }
             fwd.hybridGdnW = hw
+            var aw: [Int: (q: (MLXArray, MLXArray, MLXArray), k: (MLXArray, MLXArray, MLXArray), v: (MLXArray, MLXArray, MLXArray), o: (MLXArray, MLXArray, MLXArray))] = [:]
+            for (i, spec) in engine.layers.enumerated() {
+                guard let a = spec.attn else { continue }
+                aw[i] = (q: (a.qWq, a.qSc, a.qBi), k: (a.kWq, a.kSc, a.kBi), v: (a.vWq, a.vSc, a.vBi), o: (a.oWq, a.oSc, a.oBi))
+            }
+            fwd.hybridAttnW = aw
             if Tell.envInt("QWISP_HYBRID_MOE", 1) == 1 {
                 var mwAll: [Int: (g: (MLXArray, MLXArray, MLXArray), u: (MLXArray, MLXArray, MLXArray), d: (MLXArray, MLXArray, MLXArray))] = [:]
                 for (i, spec) in engine.layers.enumerated() {
@@ -252,6 +258,12 @@ extension Tell {
                 hw[i] = (qkv: (g.qkvWq, g.qkvSc, g.qkvBi), z: (g.zWq, g.zSc, g.zBi), out: (g.outWq, g.outSc, g.outBi))
             }
             fwd.hybridGdnW = hw
+            var aw: [Int: (q: (MLXArray, MLXArray, MLXArray), k: (MLXArray, MLXArray, MLXArray), v: (MLXArray, MLXArray, MLXArray), o: (MLXArray, MLXArray, MLXArray))] = [:]
+            for (i, spec) in engine.layers.enumerated() {
+                guard let a = spec.attn else { continue }
+                aw[i] = (q: (a.qWq, a.qSc, a.qBi), k: (a.kWq, a.kSc, a.kBi), v: (a.vWq, a.vSc, a.vBi), o: (a.oWq, a.oSc, a.oBi))
+            }
+            fwd.hybridAttnW = aw
             if Tell.envInt("QWISP_HYBRID_MOE", 1) == 1 {
                 var mwAll: [Int: (g: (MLXArray, MLXArray, MLXArray), u: (MLXArray, MLXArray, MLXArray), d: (MLXArray, MLXArray, MLXArray))] = [:]
                 for (i, spec) in engine.layers.enumerated() {

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -89,6 +89,10 @@ extension Tell {
         // Distinct from snapshot/rollback (1-step spec). nil if the backend doesn't support it.
         var fullSnapshot: (() -> Any)? = nil
         var fullRestore: ((Any) -> Void)? = nil
+        // Steel-prefill hybrid (QWISP_HYBRID_PREFILL=1): prefill-scoped forward with GDN dense
+        // matmuls via MLX steel. nil → prefill uses `forward`. Decode/verify NEVER use this.
+        var forwardHybrid: (([Int32]) -> MLXArray?)? = nil
+        var hybridChunk: Int = 64
         var chainedStepArgmax: ((Int32, Int) -> [Int]?)? = nil   // Phase II-a
         // Option B (sampling): full logits per input row (readback), for speculative sampling.
         // Additive — greedy stepArgmax path is untouched.
@@ -171,6 +175,29 @@ extension Tell {
         backend.fullRestore = { snap in
             if let s = snap as? SeedlessFusedVerify.SeedlessFusedForward.FullSnapshot { fwd.fullRestore(s) }
         }
+        // Steel-prefill hybrid (opt-in): wire per-layer GDN MLX weights + the hybrid forward.
+        // Chunk = min(1024, maxM): steel wins grow with chunk; callers wanting 1024 pass maxM>=1024.
+        if Tell.envFlag("QWISP_HYBRID_PREFILL") {
+            var hw: [Int: (qkv: (MLXArray, MLXArray, MLXArray), z: (MLXArray, MLXArray, MLXArray), out: (MLXArray, MLXArray, MLXArray))] = [:]
+            for (i, spec) in engine.layers.enumerated() {
+                guard let g = spec.gdn else { continue }
+                hw[i] = (qkv: (g.qkvWq, g.qkvSc, g.qkvBi), z: (g.zWq, g.zSc, g.zBi), out: (g.outWq, g.outSc, g.outBi))
+            }
+            fwd.hybridGdnW = hw
+            if Tell.envInt("QWISP_HYBRID_MOE", 1) == 1 {
+                var mwAll: [Int: (g: (MLXArray, MLXArray, MLXArray), u: (MLXArray, MLXArray, MLXArray), d: (MLXArray, MLXArray, MLXArray))] = [:]
+                for (i, spec) in engine.layers.enumerated() {
+                    let m = spec.moe
+                    mwAll[i] = (g: (m.swGWq, m.swGSc, m.swGBi), u: (m.swUWq, m.swUSc, m.swUBi), d: (m.swDWq, m.swDSc, m.swDBi))
+                }
+                fwd.hybridMoEW = mwAll
+            }
+            backend.forwardHybrid = { tokens in
+                let x = engine.embed(tokens: tokens)
+                return fwd.forwardRowsHybrid(x, M: tokens.count, finalNormW: fnBuf)
+            }
+            backend.hybridChunk = Swift.min(1024, maxM)
+        }
         // Phase II-a: wire chained greedy decode when the 1-CB head path is active.
         // Only resident/bolt return non-nil (strict returns nil → per-step fallback).
         if fwd.head != nil {
@@ -215,6 +242,29 @@ extension Tell {
         backend.fullSnapshot = { fwd.fullSnapshot() }
         backend.fullRestore = { snap in
             if let s = snap as? SeedlessFusedVerify.SeedlessFusedForward.FullSnapshot { fwd.fullRestore(s) }
+        }
+        // Steel-prefill hybrid (opt-in): wire per-layer GDN MLX weights + the hybrid forward.
+        // Chunk = min(1024, maxM): steel wins grow with chunk; callers wanting 1024 pass maxM>=1024.
+        if Tell.envFlag("QWISP_HYBRID_PREFILL") {
+            var hw: [Int: (qkv: (MLXArray, MLXArray, MLXArray), z: (MLXArray, MLXArray, MLXArray), out: (MLXArray, MLXArray, MLXArray))] = [:]
+            for (i, spec) in engine.layers.enumerated() {
+                guard let g = spec.gdn else { continue }
+                hw[i] = (qkv: (g.qkvWq, g.qkvSc, g.qkvBi), z: (g.zWq, g.zSc, g.zBi), out: (g.outWq, g.outSc, g.outBi))
+            }
+            fwd.hybridGdnW = hw
+            if Tell.envInt("QWISP_HYBRID_MOE", 1) == 1 {
+                var mwAll: [Int: (g: (MLXArray, MLXArray, MLXArray), u: (MLXArray, MLXArray, MLXArray), d: (MLXArray, MLXArray, MLXArray))] = [:]
+                for (i, spec) in engine.layers.enumerated() {
+                    let m = spec.moe
+                    mwAll[i] = (g: (m.swGWq, m.swGSc, m.swGBi), u: (m.swUWq, m.swUSc, m.swUBi), d: (m.swDWq, m.swDSc, m.swDBi))
+                }
+                fwd.hybridMoEW = mwAll
+            }
+            backend.forwardHybrid = { tokens in
+                let x = engine.embed(tokens: tokens)
+                return fwd.forwardRowsHybrid(x, M: tokens.count, finalNormW: fnBuf)
+            }
+            backend.hybridChunk = Swift.min(1024, maxM)
         }
         // Phase II-a: wire chained greedy decode when the 1-CB head path is active.
         if fwd.head != nil {
@@ -297,13 +347,15 @@ extension Tell {
                         mtpFwd: SeedlessFusedVerify.SeedlessFusedForward? = nil) -> MLXArray? {
         let pLen = promptIds.count
         guard pLen > 0 else { return nil }
-        let chunkSize = 64
+        // Steel-prefill hybrid: larger chunks (steel wins grow with M); decode/verify unaffected.
+        let fwdFn = backend.forwardHybrid ?? backend.forward
+        let chunkSize = backend.forwardHybrid != nil ? backend.hybridChunk : 64
         var lastNormed: MLXArray? = nil
         var pos = 0
         while pos < pLen {
             let end = Swift.min(pos + chunkSize, pLen)
             let chunk = Array(promptIds[pos ..< end])
-            guard let normed = backend.forward(chunk) else { return nil }
+            guard let normed = fwdFn(chunk) else { return nil }
             if let head = mtpHead, let fwd = mtpFwd {
                 // Non-final chunk: k pairs (last row pairs with the next chunk's head
                 // token). Final chunk: k-1 pairs (h_last has no committed successor yet).

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -30,6 +30,7 @@ if CommandLine.arguments.contains("stream") {
         ("mlx-qmm-minv", { md, _ in Tell.mlxQmmInvariance(modelDir: md) }),
         ("steel-route-bench", { _, _ in GroupedMoEPoC.steelRouteBench() }),
         ("hybrid-estimate", { md, _ in Tell.hybridEstimate(modelDir: md) }),
+        ("hybrid-prefill-bench", { md, _ in Tell.hybridPrefillBench(modelDir: md) }),
         ("prefix-cache-e2e", { md, _ in Tell.prefixCacheE2E(modelDir: md) }),
         ("prefix-cache-speed", { md, _ in Tell.prefixCacheSpeedProbe(modelDir: md) }),
         ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -24,6 +24,7 @@ if CommandLine.arguments.contains("stream") {
         ("raw-spec",  { try Tell.run(modelDir: $0, refPath: $1) }),
         ("prefix-cache-poc", { md, _ in Tell.prefixCachePoC(modelDir: md) }),
         ("prefill-breakdown", { md, _ in Tell.prefillBreakdownProbe(modelDir: md) }),
+        ("prefill-stage-profile", { md, _ in Tell.prefillStageProfile(modelDir: md) }),
         ("prefix-cache-e2e", { md, _ in Tell.prefixCacheE2E(modelDir: md) }),
         ("prefix-cache-speed", { md, _ in Tell.prefixCacheSpeedProbe(modelDir: md) }),
         ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -25,6 +25,7 @@ if CommandLine.arguments.contains("stream") {
         ("prefix-cache-poc", { md, _ in Tell.prefixCachePoC(modelDir: md) }),
         ("prefill-breakdown", { md, _ in Tell.prefillBreakdownProbe(modelDir: md) }),
         ("prefill-stage-profile", { md, _ in Tell.prefillStageProfile(modelDir: md) }),
+        ("grouped-moe-bench", { _, _ in GroupedMoEPoC.bench() }),
         ("prefix-cache-e2e", { md, _ in Tell.prefixCacheE2E(modelDir: md) }),
         ("prefix-cache-speed", { md, _ in Tell.prefixCacheSpeedProbe(modelDir: md) }),
         ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -26,6 +26,8 @@ if CommandLine.arguments.contains("stream") {
         ("prefill-breakdown", { md, _ in Tell.prefillBreakdownProbe(modelDir: md) }),
         ("prefill-stage-profile", { md, _ in Tell.prefillStageProfile(modelDir: md) }),
         ("grouped-moe-bench", { _, _ in GroupedMoEPoC.bench() }),
+        ("dense-tiled-bench", { _, _ in GroupedMoEPoC.denseBench() }),
+        ("mlx-qmm-minv", { md, _ in Tell.mlxQmmInvariance(modelDir: md) }),
         ("prefix-cache-e2e", { md, _ in Tell.prefixCacheE2E(modelDir: md) }),
         ("prefix-cache-speed", { md, _ in Tell.prefixCacheSpeedProbe(modelDir: md) }),
         ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -28,6 +28,7 @@ if CommandLine.arguments.contains("stream") {
         ("grouped-moe-bench", { _, _ in GroupedMoEPoC.bench() }),
         ("dense-tiled-bench", { _, _ in GroupedMoEPoC.denseBench() }),
         ("mlx-qmm-minv", { md, _ in Tell.mlxQmmInvariance(modelDir: md) }),
+        ("steel-route-bench", { _, _ in GroupedMoEPoC.steelRouteBench() }),
         ("prefix-cache-e2e", { md, _ in Tell.prefixCacheE2E(modelDir: md) }),
         ("prefix-cache-speed", { md, _ in Tell.prefixCacheSpeedProbe(modelDir: md) }),
         ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -29,6 +29,7 @@ if CommandLine.arguments.contains("stream") {
         ("dense-tiled-bench", { _, _ in GroupedMoEPoC.denseBench() }),
         ("mlx-qmm-minv", { md, _ in Tell.mlxQmmInvariance(modelDir: md) }),
         ("steel-route-bench", { _, _ in GroupedMoEPoC.steelRouteBench() }),
+        ("hybrid-estimate", { md, _ in Tell.hybridEstimate(modelDir: md) }),
         ("prefix-cache-e2e", { md, _ in Tell.prefixCacheE2E(modelDir: md) }),
         ("prefix-cache-speed", { md, _ in Tell.prefixCacheSpeedProbe(modelDir: md) }),
         ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),


### PR DESCRIPTION
## Summary

**Steel-prefill hybrid, default ON: cold prefill 201 → 451 tok/s (2.24x); real agentic task 110s → 59s (1.86x).**

After the prefix cache (#29) removed *repeated* prefills, the remaining wall was the one cold prefill per conversation (~59s TTFT for an 8.3K opencode prompt). This PR attacks the prefill kernels themselves: the raw engine's matmuls are M=1-optimal scalar qmv kernels, while at prefill M (64–1024 rows) matrix-unit (simdgroup_matrix) GEMM tiles are 2–4.3x faster. Every bit-exact scalar restructure was measured dead first (grouping 1.0–1.1x, TG-shared dequant 0.3–0.5x, dequant-free ceiling ~1.1x — the scalar kernel is load/FMA-bound), so the hybrid swaps the heavy prefill matmuls to MLX steel kernels while keeping the raw skeleton:

- **GDN in_proj qkv/z + out_proj** and **attn q/k/v/o** via `MLX.quantizedMatmul`, zero-padded to M≥14 so every prefill (any delta length) stays in the steel kernel class → **split-invariant** (proven: MLX steel qmm is per-element M-invariant, and zero-padding is bit-neutral for real rows).
- **MoE routed gather** via CSR: rows sorted by expert into fixed R=16 tiles → `gatherQuantizedMatmul(sortedIndices:true)` (steel gather, 2.24x @T=1024); swiglu + down-proj in tile space; scatter back in mk order. Tile composition proven bit-neutral per row.
- Norms / conv / GDN recurrence / RoPE / SDPA / route / shared / combine stay raw (all split-invariance-proven by the prefix-cache byte-identity gate).
- **Decode and spec-verify never touch the hybrid** — verify ≡ step self-consistency (both scalar qmv) is preserved, so SuffixSpec losslessness is untouched.
- Prefill chunk 1024 in hybrid mode (steel wins grow with M); `QWISP_HYBRID_PREFILL=0` opts out.

**Canonical refs**: the resident-tier greedy stream changes (steel rounding — fidelity is in-family: final-hidden rel err vs old raw 5.6e-02, *smaller* than the old full-MLX-vs-raw baseline 6.7e-02). Refs are now tier-split: `refs/resident/` (new hybrid canonical, regenerated per the `--ingest-swift` procedure) for the resident config; `refs/` unchanged for streaming tiers (the hybrid is resident-only — streaming streams are byte-unchanged by construction).

## Measurements

| metric | before | after | 
|---|---|---|
| prefill (2048 tok, resident) | 201 tok/s | **451 tok/s (2.24x)** |
| opencode cold TTFT (8304-tok prompt) | 59.4s | **25.4s (2.34x)** |
| opencode task total (same task, cache ON both) | 110s | **59s (1.86x)** |
| determinism (two runs) | — | byte-identical |
| split-invariance (chunk 512 vs 1024) | — | byte-identical |
| PREFIXE2E (prefix cache, hybrid ON) | — | 4/4 byte-identical |

## Verification

- [x] RAWTESTS **79/79** (hybrid default ON; engine tests build raw paths directly — untouched)
- [x] PREFIXE2E **4/4** byte-identical with hybrid ON (cold/extend/cross-conv/reset)
- [x] E7 resident strict fidelity **100.0%** on all 4 regimes vs re-canonicalized refs
- [x] Full deterministic matrix `scripts/bench_matrix.sh`: **MATRIXGATE PASS (E1-E7, all strict cells 100.0%: streaming tiers vs refs/, resident vs refs/resident/)**
- [x] BENCHBATCH PASS · COMPTEST 13/13 · TOKTEST 3/3
- [x] Lossless-by-construction chain: per-element M-invariance (mlx-qmm-minv), zero-pad bit-neutrality, tile-composition invariance (steel-route-bench valErr ~9e-4 / chainErr ~1.8e-3)

## Notes for reviewer

- The evidence chain lives in the probe commits (764ab4c…9671d5e): every scalar bit-exact lever was measured dead before reaching for matrix units; the steel route was gated on M-invariance + padding + tile-composition proofs before wiring.
- `forwardRowsHybrid` is an additive method beside `forwardRows`; `hybridDense` is an additive default-false param on the GDN/attn row encoders. Frozen forward math untouched (RAWTESTS gate).
- Gotchas encoded in commit messages: combine (sc.d×scores→sc.y) lives inside `encodeMoEGatherRowsRange` and must be encoded explicitly when the gather is swapped; `gatherQuantizedMatmul` rhsIndices broadcast against x batch dims; profSkip differential timing is retired (twice-invalidated methodology).
- Bench probes shipped as runners: `hybrid-prefill-bench` (the 4-gate check), `steel-route-bench`, `mlx-qmm-minv`, `prefill-stage-profile`, `grouped-moe-bench`, `dense-tiled-bench`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM
