### PR TITLE
feat(server): real-traffic decode levers — chained d0 span (+20%), minMatch sweep verdict, spec telemetry

### DIFF
--- a/swift/Sources/QwispCore/Tell.swift
+++ b/swift/Sources/QwispCore/Tell.swift
@@ -24,6 +24,12 @@ public enum Tell {
     /// top1−top2 margin ≤ τ の境界 token は M=1 逐次 replay で確定（機械的 δ-calibration は将来 task）。
     static let certTau: Float = 0.1
 
+    /// SuffixSpec minimum match length (QWISP_SUFFIX_MINMATCH, default 4 = historical
+    /// constant). Lower → more drafts on real traffic (lower d0) at the cost of wasted
+    /// verify rows on rejects; lossless either way (verify gates every draft). Read once
+    /// per process (env-in-loop is 18.8µs, fusion doctrine).
+    static let suffixMinMatch = Swift.max(1, Tell.envInt("QWISP_SUFFIX_MINMATCH", 4))
+
     /// suffix lookup draft（SuffixDecoding-style, 訓練不要・cost ~0）:
     /// 1) seq 末尾の m token(minMatch..maxMatch の最長一致)が seq 内の earlier 位置に出現する
     ///    「全ての」出現位置を収集（旧: 最近 1 箇所のみ）。

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -392,6 +392,10 @@ extension Tell {
 
     /// SuffixSpec ループ本体(main run / self-check / stream-vs-resident check の 3 箇所で共用)。
     /// Returns out[0..<N] token ids.
+    /// Last greedy spec-loop stats (server throughput log): steps = verify forwards,
+    /// drafted/accepted = suffix-draft tokens offered/accepted. Measurement-only.
+    nonisolated(unsafe) public static var lastSpecStats: (steps: Int, drafted: Int, accepted: Int, d0: Int) = (0, 0, 0, 0)
+
     static func runSpecLoop(promptIds: [Int32], backend: SpecBackend, engine: SeedlessEngine,
                              N: Int, maxK: Int, useA3: Bool = false,
                              prefillTokens: [Int32]? = nil,
@@ -407,6 +411,7 @@ extension Tell {
 
         var hist = promptIds.map { Int($0) }
         var out: [Int] = []
+        var stSteps = 0, stDrafted = 0, stAccepted = 0, stD0 = 0   // accept telemetry
         var pending: [Int] = []  // A3: pending prefix tokens
         let pendingCap = 24
         // Incremental streaming seam: onToken nil → zero behavior change (out/return unchanged).
@@ -421,6 +426,7 @@ extension Tell {
             flush()
             let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: 4)
             let D      = drafts.count
+            stSteps += 1; stDrafted += D; if D == 0 { stD0 += 1 }
 
             var snap = backend.snapshot()
 
@@ -453,6 +459,7 @@ extension Tell {
                 // an off-by-one: the u-row IS the comparison origin, not a skip.
                 var p = 0
                 while p < D && drafts[p] == evals[pk + p] { p += 1 }
+                stAccepted += p
 
                 if p == D {
                     // A3 full accept: fused forward already advanced cache to B+pk+1+D
@@ -483,6 +490,7 @@ extension Tell {
 
                 var p = 0
                 while p < D && drafts[p] == evals[p] { p += 1 }
+                stAccepted += p
 
                 if p == D {
                     out.append(u); hist.append(u)
@@ -499,6 +507,7 @@ extension Tell {
             }
         }
         flush()
+        Tell.lastSpecStats = (stSteps, stDrafted, stAccepted, stD0)
         return Array(out.prefix(N))
     }
 

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -414,6 +414,13 @@ extension Tell {
         var stSteps = 0, stDrafted = 0, stAccepted = 0, stD0 = 0   // accept telemetry
         var pending: [Int] = []  // A3: pending prefix tokens
         let pendingCap = 24
+        // Phase II-a chain on the server decode path: real-traffic d0 ≈ 90% (telemetry
+        // @03c9d4c) so the draftless span dominates. chainedStepArgmax runs K greedy steps
+        // in ONE command buffer, bit-exact to K sequential stepArgmax([t]) calls → the
+        // greedy stream stays byte-identical while collapsing K CPU round-trips to 1.
+        // Strict streaming wires no chain fn (needs a CPU turn per step to ensure/pread
+        // the expert union) → nil → per-step fallback by construction. QWISP_CHAIN_K=0 opts out.
+        let chainK = Tell.envInt("QWISP_CHAIN_K", SeedlessFusedVerify.SeedlessFusedForward.chainKDefault)
         // Incremental streaming seam: onToken nil → zero behavior change (out/return unchanged).
         var streamed = 0
         func flush() { if let onToken { while streamed < out.count { onToken(out[streamed]); streamed += 1 } } }
@@ -431,6 +438,20 @@ extension Tell {
             var snap = backend.snapshot()
 
             if D == 0 {
+                // Chain path (mirrors the bench-engine block in `run`): only the non-A3 /
+                // empty-pending greedy span. Chained tokens skip drafting opportunities for
+                // those positions — at d0≈90% almost always free. nil chain fn / failed call
+                // → fall through to per-step.
+                if chainK > 0, (!useA3 || pending.isEmpty), let chainFn = backend.chainedStepArgmax,
+                   let chainResult = chainFn(Int32(u), chainK), !chainResult.isEmpty {
+                    out.append(u); hist.append(u)
+                    let addN = Swift.min(chainResult.count - 1, N - out.count)
+                    for i in 0 ..< addN {
+                        out.append(chainResult[i]); hist.append(chainResult[i])
+                    }
+                    u = chainResult[chainResult.count - 1]
+                    continue
+                }
                 if useA3 && !pending.isEmpty {
                     // A3 D==0: stepArgmax on [pending, u] (batched)—ONE forward to realize pending
                     let pk = pending.count

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -431,7 +431,7 @@ extension Tell {
         // to N and orphaning the GPU (see SeedlessBackend.generate).
         while out.count < N && !(isCancelled?() ?? false) {
             flush()
-            let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: 4)
+            let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: Tell.suffixMinMatch)
             let D      = drafts.count
             stSteps += 1; stDrafted += D; if D == 0 { stD0 += 1 }
 
@@ -571,7 +571,7 @@ extension Tell {
 
         while out.count < N && !(isCancelled?() ?? false) {
             flush()
-            let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: 4)
+            let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: Tell.suffixMinMatch)
             let D = drafts.count
             let snap = backend.snapshot()
 
@@ -659,7 +659,7 @@ extension Tell {
 
         while out.count < N && !(isCancelled?() ?? false) {
             flush()
-            let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: 4)
+            let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: Tell.suffixMinMatch)
             let D = drafts.count
             let snap = backend.snapshot()
             let basePos = out.count   // monotonic absolute position → reproducible per-position RNG
@@ -904,7 +904,7 @@ extension Tell {
                 let resPerLayer = _reuseStreamProviders?.map { Set($0.cache.slotOf.keys) } ?? []
                 return (ctx: _reuseCtx, residentPerLayer: resPerLayer, alpha: _reuseAlpha)
             }() : nil
-            var drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: 4,
+            var drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: Tell.suffixMinMatch,
                                           reuseCtx: _reuseArg)
             var D      = drafts.count
 
@@ -1544,7 +1544,7 @@ extension Tell {
             if boltBiasEps > 0 && boltBiasDecayH > 0 {
                 fwd2.setRouteBiasEps(boltBiasEps * Swift.max(0, 1 - Float(out.count) / Float(boltBiasDecayH)))
             }
-            let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: 4)
+            let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: Tell.suffixMinMatch)
             let D      = drafts.count
             let snap   = backend2.snapshot()
 

--- a/swift/Sources/qwisp/Server.swift
+++ b/swift/Sources/qwisp/Server.swift
@@ -85,8 +85,12 @@ final class QwispEngine: @unchecked Sendable {
         let ttft = tFirst.map { String(format: "%.0fms", $0.timeIntervalSince(t0) * 1000) } ?? "-"
         let dt = now.timeIntervalSince(tFirst ?? t0)
         let rate = dt > 0 ? Double(max(0, gen - 1)) / dt : 0
-        fputs(String(format: "[qwisp] %@ prompt=%d gen=%d ttft=%@ decode=%.1f tok/s (%.2fs)\n",
-                     tag, prompt, gen, ttft, rate, now.timeIntervalSince(t0)), stderr)
+        // spec accept telemetry (greedy loop): tokens/step incl. the free u-token, draft accept %.
+        let st = Tell.lastSpecStats
+        let tokPerStep = st.steps > 0 ? Double(st.accepted + st.steps) / Double(st.steps) : 0
+        let acc = st.drafted > 0 ? 100.0 * Double(st.accepted) / Double(st.drafted) : 0
+        fputs(String(format: "[qwisp] %@ prompt=%d gen=%d ttft=%@ decode=%.1f tok/s (%.2fs) spec[steps=%d tok/step=%.2f accept=%.0f%% d0=%d]\n",
+                     tag, prompt, gen, ttft, rate, now.timeIntervalSince(t0), st.steps, tokPerStep, acc, st.d0), stderr)
     }
 
     /// Non-streaming completion.


### PR DESCRIPTION
## Summary

Real opencode traffic is spec-starved (d0=90% of decode steps have no suffix draft — telemetry added in 03c9d4c), so the server decode loop paid one CPU↔GPU command-buffer round-trip per token. This PR chains the draftless span: when D==0, `runSpecLoop` delegates K=8 greedy steps to `chainedStepArgmax` (Phase II-a, one command buffer, bit-exact to K sequential steps by locked tests 47/48), keeping the greedy stream byte-identical by construction. Strict streaming wires no chain fn → per-step fallback unchanged.

Measured: fixed greedy 300-tok request decode 74.1 → 87.7 tok/s (steps 295 → 40, output byte-identical vs QWISP_CHAIN_K=0). opencode stats.py task: greedy requests mean 58.2 tok/s vs 45-48 baseline (+20-25%).

Also ships the lever-2 sweep: `QWISP_SUFFIX_MINMATCH` knob (default 4). A/B 2/3/4 on E7 bench (83.0 / 80.7 / 77.9 tok/s mean — 4 wins) and opencode (58.2 / 59.1 / 56.0 — parity-to-worse) → **default 4 stays**; the chain already made d0 steps cheap, so buying more drafts with wasted verify rows loses.

Lever 3 (frequency drafting on d0 steps) closed NO-GO without implementation: a D=1 fallback draft yields ≤2 tok/CB vs the chain's guaranteed 9 tok/CB on the same steps, and the strictly stronger MTP-D1 draft (accept 0.69) already measured 0.56-0.87x vs chain — frequency drafts are bounded above by a measured loser.

## Related issue

None (HANDOFF.md workstream).

## Verification

- [x] RAWTESTS 79/79, BENCHBATCHTEST PASS, TOKTEST 3/3, COMPTEST 13/13, PREFIXE2E PASS (all local, post-change)
- [x] Byte-identity: chain ON vs QWISP_CHAIN_K=0 server responses identical (300-tok greedy)
- [x] E7 bench fidelity 100.0% all 4 regimes at minMatch 2/3/4
- [x] Zero new warnings
- [ ] Related docs updated (none needed — env knobs documented in code)

## Notes for reviewer

- The chain block in `runSpecLoop` mirrors the existing bench-engine block in `run` (TellRuntime.swift ~line 919); guards: `chainK > 0`, non-A3/empty-pending, non-nil chain fn.
- Chained tokens skip drafting opportunities for those positions — at d0≈90% almost always free (mm sweep confirms drafts there don't pay).
- `QWISP_SUFFIX_MINMATCH` is read once per process (env-in-loop doctrine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM