### PR TITLE
feat(server): width-2 draft-tree prize probe — verdict NO-GO (+0.7%), lead ① closed

### DIFF
--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -394,7 +394,11 @@ extension Tell {
     /// Returns out[0..<N] token ids.
     /// Last greedy spec-loop stats (server throughput log): steps = verify forwards,
     /// drafted/accepted = suffix-draft tokens offered/accepted. Measurement-only.
-    nonisolated(unsafe) public static var lastSpecStats: (steps: Int, drafted: Int, accepted: Int, d0: Int) = (0, 0, 0, 0)
+    /// rejects = draft steps that mismatched; altHits = of those, how many the draft vote's
+    /// runner-up token WOULD have matched the model (QWISP_ACCEPT_TRACE=1 to fill) — the
+    /// measured prize of a width-2 depth-1 draft tree (m-gt-1-decode-leads ①). Diag only.
+    nonisolated(unsafe) public static var lastSpecStats: (steps: Int, drafted: Int, accepted: Int, d0: Int, rejects: Int, altHits: Int) = (0, 0, 0, 0, 0, 0)
+    static let traceAltsEnabled = Tell.envFlag("QWISP_ACCEPT_TRACE")
 
     static func runSpecLoop(promptIds: [Int32], backend: SpecBackend, engine: SeedlessEngine,
                              N: Int, maxK: Int, useA3: Bool = false,
@@ -412,6 +416,7 @@ extension Tell {
         var hist = promptIds.map { Int($0) }
         var out: [Int] = []
         var stSteps = 0, stDrafted = 0, stAccepted = 0, stD0 = 0   // accept telemetry
+        var stRejects = 0, stAltHits = 0                           // width-2 tree prize probe
         var pending: [Int] = []  // A3: pending prefix tokens
         let pendingCap = 24
         // Phase II-a chain on the server decode path: real-traffic d0 ≈ 90% (telemetry
@@ -431,7 +436,8 @@ extension Tell {
         // to N and orphaning the GPU (see SeedlessBackend.generate).
         while out.count < N && !(isCancelled?() ?? false) {
             flush()
-            let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: Tell.suffixMinMatch)
+            let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: Tell.suffixMinMatch,
+                                          traceAlts: Tell.traceAltsEnabled)
             let D      = drafts.count
             stSteps += 1; stDrafted += D; if D == 0 { stD0 += 1 }
 
@@ -518,6 +524,12 @@ extension Tell {
                     for d in drafts { out.append(d); hist.append(d) }
                     u = evals[D]
                 } else {
+                    // Width-2 tree prize probe: would the draft vote's runner-up at the reject
+                    // position have matched the model's true token? (evals[p] = argmax after
+                    // the accepted prefix = the token a width-2 branch would need to hit.)
+                    stRejects += 1
+                    if Tell.traceAltsEnabled, p < Tell.lastDraftAlts.count,
+                       Tell.lastDraftAlts[p] == evals[p] { stAltHits += 1 }
                     backend.rollback(snap)
                     out.append(u); hist.append(u)
                     for d in drafts.prefix(p) { out.append(d); hist.append(d) }
@@ -528,7 +540,7 @@ extension Tell {
             }
         }
         flush()
-        Tell.lastSpecStats = (stSteps, stDrafted, stAccepted, stD0)
+        Tell.lastSpecStats = (stSteps, stDrafted, stAccepted, stD0, stRejects, stAltHits)
         return Array(out.prefix(N))
     }
 

--- a/swift/Sources/qwisp/Server.swift
+++ b/swift/Sources/qwisp/Server.swift
@@ -89,8 +89,8 @@ final class QwispEngine: @unchecked Sendable {
         let st = Tell.lastSpecStats
         let tokPerStep = st.steps > 0 ? Double(st.accepted + st.steps) / Double(st.steps) : 0
         let acc = st.drafted > 0 ? 100.0 * Double(st.accepted) / Double(st.drafted) : 0
-        fputs(String(format: "[qwisp] %@ prompt=%d gen=%d ttft=%@ decode=%.1f tok/s (%.2fs) spec[steps=%d tok/step=%.2f accept=%.0f%% d0=%d]\n",
-                     tag, prompt, gen, ttft, rate, now.timeIntervalSince(t0), st.steps, tokPerStep, acc, st.d0), stderr)
+        fputs(String(format: "[qwisp] %@ prompt=%d gen=%d ttft=%@ decode=%.1f tok/s (%.2fs) spec[steps=%d tok/step=%.2f accept=%.0f%% d0=%d rej=%d alt=%d]\n",
+                     tag, prompt, gen, ttft, rate, now.timeIntervalSince(t0), st.steps, tokPerStep, acc, st.d0, st.rejects, st.altHits), stderr)
     }
 
     /// Non-streaming completion.


### PR DESCRIPTION
## Summary

Measurement gate for the shallow-draft-tree lead (m-gt-1 ①): at each spec reject, count whether the suffix vote's runner-up token would have matched the model's true token — i.e. the exact prize a depth-1 width-2 draft tree would collect. `rej=`/`alt=` appended to the per-request `spec[]` telemetry (diag counters only; the token stream is untouched; `alt` fills only under `QWISP_ACCEPT_TRACE=1`).

**Verdict: NO-GO.** Real opencode traffic (2 runs, 9 greedy requests, 350 steps): rejects=91, altHits=5 → 5.5% of rejects caught = **+0.7% throughput** (≤~2% even crediting branch continuation), far below the pre-registered +5% bar. Root cause is structural: the suffix vote rarely forks at the reject position — there is usually no second opinion to branch on. Tree-attention verify surgery (frozen-kernel work + verify≡step invariant extension) would buy sub-noise gains, so the lead is closed with direct measurement.

## Related issue

None (m-gt-1-decode-leads workstream).

## Verification

- [x] RAWTESTS 79/79, BENCHBATCHTEST PASS, COMPTEST 13/13
- [x] Stream unchanged by construction (counters only; probe compare happens after the accept decision)
- [ ] Related docs updated (none needed)

## Notes for reviewer

The probe stays in the tree: `rej=` is free and useful context for accept telemetry; `alt=` costs one array append per draft token and only under the env flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM