### PR TITLE
feat(server): streaming tiers default to bolt, --lossless forces strict (productization tier→mode)

### DIFF
--- a/swift/Sources/QwispCore/BoltServe.swift
+++ b/swift/Sources/QwispCore/BoltServe.swift
@@ -1,0 +1,241 @@
+import Foundation
+import Metal
+import MLX
+
+// Server-side bolt runtime (near-lossless L3, streaming tiers only).
+//
+// Productization decision (2026-07-09): <32GB (streaming, C<256) defaults to bolt;
+// ≥32GB (resident) stays strict; --lossless forces strict on every tier.
+//
+// This is the SERVER counterpart of the bench-only Tell.runBoltMode (phases 1-6):
+// the same primitives (streamingBackend / indsCaptureHook calib / buildBuddyTable /
+// setBoltTables / setRouteBias / recalibAccumulate) recomposed for a persistent,
+// multi-request process. runBoltMode itself is untouched — it stays the measurement
+// harness; byte-level parity of the bench path is preserved by construction.
+//
+// ORDER INVARIANT (notes/13 "TF 開始状態の正準化"): buddy tables map experts to arena
+// SLOTS, so any ensure() after freezing (e.g. a strict prefill pulling prompt experts)
+// silently invalidates the tables → garbage activations. Therefore every segment runs
+// its strict prefill FIRST and freezes (ensure top-C + rebuild tables + setBoltTables)
+// AFTER, mirroring runBoltMode's phase 4 → phase 5 order.
+//
+// v1 scope (ponytail): greedy only (the server falls back to strict streaming for
+// sampling requests), sync rolling recalib (notes/13, R=128); async refresh
+// (notes/14 staging pipeline, slow-NAND +41-48%) is a follow-up.
+//
+// Lifetime: one instance per SeedlessBackend. The expert arena (providers) and the
+// freeze basis (last calib/recalib routing window) persist across requests; each
+// request builds a fresh forward sized to the request (KV/GDN state is per-request),
+// prefills, then freezes. Calibration (strict prefill + calibN greedy steps with
+// routing capture) runs once, on the first request; rolling recalib adapts from there.
+// The server serializes generation (AsyncLock), so no internal locking.
+final class BoltServe {
+    private let engine: SeedlessEngine
+    private let modelDir: String
+    private let C: Int
+    private let maxK: Int
+    private let maxM: Int
+
+    private var providers: [ArenaExpertProvider]? = nil
+    private var calibrated = false
+    // Freeze basis: the routing window (counts/coact) the current residency was built
+    // from — calib initially, then the latest recalib window.
+    private var baseCounts: [[Int]] = []
+    private var baseCoact: [[[Int]]] = []
+    // Rolling recalib window (persists across requests — R boundaries span requests).
+    private var winCounts: [[Int]] = []
+    private var winCoact: [[[Int]]] = []
+    private var tokensSinceRefresh = 0
+
+    private let calibN = Tell.envInt("QWISP_CALIB", 48)
+    private let biasEps = Tell.envFloat("QWISP_ROUTE_BIAS_EPS", 0.25)
+    private let recalibR = Tell.envInt("QWISP_BOLT_RECALIB_R", 128)
+    private let chainK = Tell.envInt("QWISP_CHAIN_K", SeedlessFusedVerify.SeedlessFusedForward.chainKDefault)
+    private static let nE = 256
+    private static let Ktop = 8
+
+    init(engine: SeedlessEngine, modelDir: String, C: Int, maxK: Int, maxM: Int) {
+        self.engine = engine
+        self.modelDir = modelDir
+        self.C = C
+        self.maxK = maxK
+        self.maxM = maxM
+    }
+
+    /// Freeze current residency to `fwd`: ensure top-C of the basis window, rebuild
+    /// buddy tables against the CURRENT slot state, upload tables + residency bias.
+    /// Must run AFTER any ensure-moving operation (prefill, refresh) — see header.
+    private func freeze(_ fwd: SeedlessFusedVerify.SeedlessFusedForward) {
+        guard let providers else { return }
+        for (li, provider) in providers.enumerated() {
+            let top = baseCounts[li].enumerated()
+                .sorted { $0.element != $1.element ? $0.element > $1.element : $0.offset < $1.offset }
+                .prefix(C).map { $0.offset }
+            _ = provider.cache.ensure(Array(top))
+            provider.cache.buildBuddyTable(coact: baseCoact[li], numExperts: Self.nE)
+        }
+        fwd.setBoltTables(providers.map { $0.cache.buddyTableCPU })
+        if biasEps > 0 {
+            let masks: [[Int32]] = providers.map { p in
+                (0 ..< Self.nE).map { Int32(p.cache.buddyExpertCPU[$0] == $0 ? 1 : 0) }
+            }
+            fwd.setRouteBias(masks: masks, eps: biasEps)
+        }
+    }
+
+    /// One generation segment (mirror of Tell.runSpecLoop's contract: returns out[0..<N],
+    /// streams via onToken, stops early on isCancelled). nil on backend error.
+    func runSegment(promptIds: [Int32], N: Int, maxSeqLen: Int,
+                    isCancelled: (() -> Bool)? = nil,
+                    onToken: ((Int) -> Void)? = nil) -> [Int]? {
+        let nLayers = SeedlessEngine.numLayers
+        let nE = Self.nE, Ktop = Self.Ktop
+
+        // ── First request: strict calib pass (routing frequency + co-activation) ──
+        if !calibrated {
+            print("[qwisp] bolt tier active (near-lossless, streaming default): C=\(C) — pass --lossless for bit-exact strict")
+            guard let (backend1, fwd1, provs) = Tell.streamingBackend(
+                engine: engine, modelDir: modelDir, maxM: maxM, maxSeqLen: maxSeqLen, C: C)
+            else { return nil }
+            var counts = [[Int]](repeating: [Int](repeating: 0, count: nE), count: nLayers)
+            var coact = [[[Int]]](repeating: [[Int]](repeating: [Int](repeating: 0, count: nE), count: nE),
+                                  count: nLayers)
+            fwd1.indsCaptureHook = { li, inds in
+                let distinct = Array(Set(inds.map { Int($0) }))
+                for e in distinct { counts[li][e] += 1 }
+                let n = distinct.count
+                for ai in 0 ..< n {
+                    for bi in (ai + 1) ..< n {
+                        let a = distinct[ai], b = distinct[bi]
+                        coact[li][a][b] += 1; coact[li][b][a] += 1
+                    }
+                }
+            }
+            guard let lastNormed = Tell.prefill(promptIds: promptIds, backend: backend1),
+                  let lg0 = engine.logits(lastNormed, M: 1) else { return nil }
+            MLX.eval([lg0])
+            var u = MLX.argMax(lg0[0], axis: -1).item(Int.self)
+            for _ in 0 ..< calibN {
+                guard let evals = backend1.stepArgmax([Int32(u)]) else { return nil }
+                u = evals[0]
+            }
+            fwd1.indsCaptureHook = nil
+            providers = provs
+            baseCounts = counts
+            baseCoact = coact
+            winCounts = [[Int]](repeating: [Int](repeating: 0, count: nE), count: nLayers)
+            winCoact = [[[Int]]](repeating: [[Int]](repeating: [Int](repeating: 0, count: nE), count: nE),
+                                 count: nLayers)
+            calibrated = true
+        }
+        guard let providers else { return nil }
+
+        // ── Fresh forward for this segment (arena persists via providers) ──
+        guard let (backend, fwd, _) = Tell.streamingBackend(
+            engine: engine, modelDir: modelDir, maxM: maxM, maxSeqLen: maxSeqLen, C: C,
+            existingProviders: providers)
+        else { return nil }
+        // Exact (strict) prefill FIRST — its ensures may move arena slots — then freeze.
+        guard let lastNormed = Tell.prefill(promptIds: promptIds, backend: backend),
+              let lg0 = engine.logits(lastNormed, M: 1) else { return nil }
+        MLX.eval([lg0])
+        var u = MLX.argMax(lg0[0], axis: -1).item(Int.self)
+        freeze(fwd)
+
+        // Recalib observation buffers (side-buffer copy of route inds, notes/13 layout).
+        let obsMaxM = recalibR > 0 ? maxM : 1
+        let obsSlots = recalibR > 0 ? Swift.max(1, chainK) : 1
+        var obsBuf: MTLBuffer? = nil
+        if recalibR > 0 {
+            guard SeedlessMetalForward.compileDiagCopyRoute(),
+                  let (device, _) = SeedlessMetalForward.ensure(),
+                  let ib = device.makeBuffer(length: obsSlots * nLayers * obsMaxM * Ktop * 4,
+                                             options: .storageModeShared),
+                  let gb = device.makeBuffer(length: nLayers * nE * 2, options: .storageModeShared)
+            else { return nil }
+            obsBuf = ib
+            fwd.diagObsMaxM = obsMaxM
+            fwd.diagRouteBufs = (ib, gb)
+        }
+        func accumulate(slot: Int, M: Int) {
+            guard recalibR > 0, let ib = obsBuf else { return }
+            for li in 0 ..< nLayers {
+                let off = ((slot * nLayers + li) * obsMaxM) * Ktop * 4
+                let inds = Array(UnsafeBufferPointer(
+                    start: ib.contents().advanced(by: off).assumingMemoryBound(to: Int32.self),
+                    count: M * Ktop))
+                _ = SeedlessFusedVerify.SeedlessFusedForward.recalibAccumulate(
+                    inds: inds, M: M, Ktop: Ktop, nE: nE,
+                    counts: &winCounts[li], coact: &winCoact[li])
+            }
+        }
+        /// Recalib refresh: the observation window becomes the new freeze basis.
+        func refresh() {
+            swap(&baseCounts, &winCounts)
+            swap(&baseCoact, &winCoact)
+            freeze(fwd)
+            for li in 0 ..< nLayers {
+                for e in 0 ..< nE { winCounts[li][e] = 0; winCoact[li][e] = [Int](repeating: 0, count: nE) }
+            }
+            tokensSinceRefresh = 0
+        }
+
+        // ── Bolt spec decode loop (mirror of runBoltMode phase 6, server contract) ──
+        var hist = promptIds.map { Int($0) }
+        var out: [Int] = []
+        var stSteps = 0, stDrafted = 0, stAccepted = 0, stD0 = 0
+        var streamed = 0
+        func flush() { if let onToken { while streamed < out.count { onToken(out[streamed]); streamed += 1 } } }
+
+        while out.count < N && !(isCancelled?() ?? false) {
+            flush()
+            if recalibR > 0 && tokensSinceRefresh >= recalibR { refresh() }
+            let before = out.count
+            let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: Tell.suffixMinMatch)
+            let D = drafts.count
+            stSteps += 1; stDrafted += D; if D == 0 { stD0 += 1 }
+            let snap = backend.snapshot()
+
+            if D == 0 {
+                if let (emitted, nextU) = Tell.boltGreedyChainSpan(
+                    backend: backend, u: u, chainK: chainK, budget: N - out.count) {
+                    if recalibR > 0 { for k in 0 ..< chainK { accumulate(slot: k, M: 1) } }
+                    for t in emitted { out.append(t); hist.append(t) }
+                    u = nextU
+                } else {
+                    guard let evals = backend.stepArgmax([Int32(u)]) else { return nil }
+                    if recalibR > 0 { accumulate(slot: 0, M: 1) }
+                    out.append(u); hist.append(u)
+                    u = evals[0]
+                }
+                tokensSinceRefresh += out.count - before
+                continue
+            }
+
+            let verifyTokens: [Int32] = [Int32(u)] + drafts.map { Int32($0) }
+            guard let evals = backend.stepArgmax(verifyTokens) else { return nil }
+            if recalibR > 0 { accumulate(slot: 0, M: D + 1) }
+
+            var p = 0
+            while p < D && drafts[p] == evals[p] { p += 1 }
+            stAccepted += p
+
+            if p == D {
+                out.append(u); hist.append(u)
+                for d in drafts { out.append(d); hist.append(d) }
+                u = evals[D]
+            } else {
+                backend.rollback(snap)
+                out.append(u); hist.append(u)
+                for d in drafts.prefix(p) { out.append(d); hist.append(d) }
+                let rebuildTokens: [Int32] = [Int32(u)] + drafts.prefix(p).map { Int32($0) }
+                guard let _ = backend.forward(rebuildTokens) else { return nil }
+                u = evals[p]
+            }
+            tokensSinceRefresh += out.count - before
+        }
+        flush()
+        Tell.lastSpecStats = (stSteps, stDrafted, stAccepted, stD0, 0, 0)
+        return Array(out.prefix(N))
+    }
+}

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -97,6 +97,12 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
 
     let store: WeightStore
     let engine: SeedlessEngine
+    /// --lossless / QWISP_LOSSLESS: force strict (bit-exact) on every tier. Streaming
+    /// tiers (<32GB) otherwise default to bolt (near-lossless L3) — productization
+    /// tier→mode decision. Set by the CLI after init (resolved flag > env > config).
+    public var losslessForced: Bool? = nil
+    var lossless: Bool { losslessForced ?? (ProcessInfo.processInfo.environment["QWISP_LOSSLESS"] == "1") }
+    private var boltServe: BoltServe? = nil
     let modelDir: String
     let tier: SeedlessTier
     let contextLen: Int      // model context window (max_position_embeddings); caps unbounded generation.
@@ -182,6 +188,10 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
             // QWISP_FORCE_SAMPLE=1 forces the sampling loop even at temperature 0 (T=0-equivalence gate).
             let forceSample = Tell.envFlag("QWISP_FORCE_SAMPLE")
             let wantSample = options.sampling || forceSample
+            // Productization tier→mode: streaming tiers (<32GB) decode with bolt (near-lossless
+            // L3, buddy remap) by default; --lossless / QWISP_LOSSLESS forces strict. Sampling
+            // requests fall back to strict streaming (the bolt loop is greedy-deterministic; v1).
+            let useBolt = cfg.isStreaming && !wantSample && !self.lossless
             Thread.detachNewThread {
                 var seq = promptIds0          // prompt + all accepted tokens so far
                 var produced = 0
@@ -189,6 +199,22 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                 while produced < ceiling && !cancel.isCancelled {
                     let segN = Swift.min(budget, ceiling - produced)
                     let maxSeqLen = seq.count + segN + cfg.maxK + 64
+                    let onTok: (Int) -> Void = { continuation.yield($0) }
+                    if useBolt {
+                        if self.boltServe == nil {
+                            self.boltServe = BoltServe(engine: self.engine, modelDir: self.modelDir,
+                                                       C: cfg.c, maxK: cfg.maxK, maxM: cfg.maxM)
+                        }
+                        guard let seg = self.boltServe?.runSegment(
+                            promptIds: seq, N: segN, maxSeqLen: maxSeqLen,
+                            isCancelled: { cancel.isCancelled }, onToken: onTok),
+                            !seg.isEmpty else { break }
+                        seq += seg.map { Int32($0) }
+                        produced += seg.count
+                        if seg.count < segN { break }
+                        budget = Swift.min(budget * 2, 65536)
+                        continue
+                    }
                     let sb: Tell.SpecBackend? = cfg.isStreaming
                         ? Tell.streamingBackend(engine: self.engine, modelDir: self.modelDir,
                                                 maxM: cfg.maxM, maxSeqLen: maxSeqLen, C: cfg.c).map { $0.0 }
@@ -196,7 +222,6 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                                             maxM: ProcessInfo.processInfo.environment["QWISP_HYBRID_PREFILL"] != "0" ? Swift.max(cfg.maxM, 1032) : cfg.maxM,
                                             maxSeqLen: maxSeqLen)
                     guard let backend = sb else { break }
-                    let onTok: (Int) -> Void = { continuation.yield($0) }
                     // Each segment dispatches to greedy or sampling. Sampling keeps its own state
                     // per segment (RNG restarts, so vary the seed by `produced` to avoid reusing the
                     // same stream across segment boundaries). ponytail: penalty counts reset per

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -286,6 +286,11 @@ extension Tell {
         if fwd.head != nil {
             backend.chainedStepArgmax = { token, k in fwd.chainedStepArgmax(token, K: k) }
         }
+        // Option B sampling (CPU logits readback). Pre-v0.3.0 the streaming tier wired
+        // NO sampling rows at all, so any temperature>0 request on <32GB returned an
+        // EMPTY completion (runSpecSampleLoop guards on stepLogitsRows → nil → 0 tokens).
+        // The GPU sampler (stepSampleRows) stays resident/bolt-only (1-CB head path).
+        backend.stepLogitsRows = makeStepLogits(engine: engine, forward: forward)
         return (backend, fwd, providers)
     }
 

--- a/swift/Sources/qwisp/Config.swift
+++ b/swift/Sources/qwisp/Config.swift
@@ -14,6 +14,7 @@ import Foundation
 struct QwispConfig: Codable {
     var model: String?
     var port: Int?
+    var lossless: Bool?
 }
 
 enum Config {
@@ -30,7 +31,7 @@ enum Config {
     static func load(path: String) -> QwispConfig {
         guard let data = FileManager.default.contents(atPath: path),
               let cfg = try? JSONDecoder().decode(QwispConfig.self, from: data)
-        else { return QwispConfig(model: nil, port: nil) }
+        else { return QwispConfig(model: nil, port: nil, lossless: nil) }
         return cfg
     }
 
@@ -41,6 +42,16 @@ enum Config {
     static func resolvePort(env: [String: String], config: QwispConfig, default def: Int) -> Int {
         if let e = env["QWISP_PORT"], let v = Int(e) { return v }
         return config.port ?? def
+    }
+
+    /// --lossless: force strict (bit-exact) on every tier. Streaming tiers (<32GB)
+    /// otherwise default to bolt (near-lossless). env QWISP_LOSSLESS=1 > config > false.
+    static func resolveLossless(env: [String: String], config: QwispConfig) -> Bool {
+        if let e = env["QWISP_LOSSLESS"] { return e == "1" }
+        return config.lossless ?? false
+    }
+    static func sourceOfLossless(env: [String: String], config: QwispConfig) -> String {
+        env["QWISP_LOSSLESS"] != nil ? "env" : (config.lossless != nil ? "config" : "default")
     }
 
     // Where each effective value came from — for `qwisp config` transparency.
@@ -66,7 +77,7 @@ enum Config {
     // relative to this binary. `qwisp config --defaults`.
     static func defaultsJSON() -> String {
         let enc = JSONEncoder(); enc.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
-        let full = QwispConfig(model: defaultModel, port: defaultPort)
+        let full = QwispConfig(model: defaultModel, port: defaultPort, lossless: false)
         return (try? enc.encode(full)).flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
     }
 
@@ -74,10 +85,12 @@ enum Config {
     static func effectiveReport(env: [String: String], config: QwispConfig, path: String) -> String {
         let m = resolveModel(env: env, config: config, default: defaultModel)
         let p = resolvePort(env: env, config: config, default: defaultPort)
+        let l = resolveLossless(env: env, config: config)
         return """
         config file: \(path)\(FileManager.default.fileExists(atPath: path) ? "" : "  (not present)")
-          model = \(m)  [\(sourceOfModel(env: env, config: config))]
-          port  = \(p)  [\(sourceOfPort(env: env, config: config))]
+          model    = \(m)  [\(sourceOfModel(env: env, config: config))]
+          port     = \(p)  [\(sourceOfPort(env: env, config: config))]
+          lossless = \(l)  [\(sourceOfLossless(env: env, config: config))]
         """
     }
 
@@ -87,8 +100,8 @@ enum Config {
         func check(_ name: String, _ ok: Bool) {
             total += 1; if ok { passed += 1 } else { log.append("FAIL: \(name)") }
         }
-        let cfg = QwispConfig(model: "/cfg/model", port: 9)
-        let empty = QwispConfig(model: nil, port: nil)
+        let cfg = QwispConfig(model: "/cfg/model", port: 9, lossless: true)
+        let empty = QwispConfig(model: nil, port: nil, lossless: nil)
 
         check("env wins model",   resolveModel(env: ["QWISP_MODEL": "/env/m"], config: cfg, default: "/def") == "/env/m")
         check("config wins model", resolveModel(env: [:], config: cfg, default: "/def") == "/cfg/model")
@@ -105,9 +118,18 @@ enum Config {
         check("source port default",  sourceOfPort(env: [:], config: empty) == "default")
         check("source port env",      sourceOfPort(env: ["QWISP_PORT": "1"], config: empty) == "env")
 
-        // defaultsJSON carries both keys
+        // lossless resolution (productization: <32GB defaults bolt; this forces strict)
+        check("env wins lossless",     resolveLossless(env: ["QWISP_LOSSLESS": "1"], config: empty) == true)
+        check("env 0 beats config",    resolveLossless(env: ["QWISP_LOSSLESS": "0"], config: cfg) == false)
+        check("config lossless",       resolveLossless(env: [:], config: cfg) == true)
+        check("default lossless off",  resolveLossless(env: [:], config: empty) == false)
+        check("source lossless env",   sourceOfLossless(env: ["QWISP_LOSSLESS": "1"], config: empty) == "env")
+        check("source lossless config", sourceOfLossless(env: [:], config: cfg) == "config")
+
+        // defaultsJSON carries the keys
         let dj = defaultsJSON()
-        check("defaults json has model+port", dj.contains("\"model\"") && dj.contains("\"port\"") && dj.contains("8080"))
+        check("defaults json has model+port+lossless",
+              dj.contains("\"model\"") && dj.contains("\"port\"") && dj.contains("8080") && dj.contains("\"lossless\""))
 
         // load(): missing file and malformed JSON both yield empty config, no throw.
         let tmp = NSTemporaryDirectory() + "qwisp-configtest-\(getpid())"

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -27,7 +27,12 @@ case "serve":
         backend = FakeBackend(script: tok.encode("Hello! This is qwisp with a fake backend for wire-format testing."))
     } else {
         print("[qwisp serve] loading Seedless engine (loads the model) …")
-        backend = try SeedlessBackend(modelDir: model)
+        let sb = try SeedlessBackend(modelDir: model)
+        // --lossless > env QWISP_LOSSLESS > config "lossless" > false. Streaming tiers
+        // (<32GB) otherwise default to bolt (near-lossless).
+        sb.losslessForced = args.contains("--lossless")
+            || Config.resolveLossless(env: ProcessInfo.processInfo.environment, config: qwispConfig)
+        backend = sb
     }
     let engine = QwispEngine(tokenizer: tok, backend: backend, modelID: modelID)
     try await runServe(engine: engine, modelID: modelID, port: port)
@@ -36,6 +41,8 @@ case "chat":
     // Default -1 = generate until EOS / context (mlx-lm / llama.cpp semantics); N caps it.
     var rest = Array(args.dropFirst())
     var maxTokens = -1
+    var chatLossless = Config.resolveLossless(env: ProcessInfo.processInfo.environment, config: qwispConfig)
+    if let i = rest.firstIndex(of: "--lossless") { chatLossless = true; rest.remove(at: i) }
     if let i = rest.firstIndex(where: { $0 == "--max-tokens" || $0.hasPrefix("--max-tokens=") }) {
         let flag = rest[i]
         if let eq = flag.firstIndex(of: "=") {
@@ -51,7 +58,7 @@ case "chat":
     let promptText = rest.joined(separator: " ")
     let prompt = promptText.isEmpty ? (readLine(strippingNewline: true) ?? "") : promptText
     if prompt.isEmpty {
-        print("usage: qwisp chat [--max-tokens N] <prompt>   (or pipe text via stdin)")
+        print("usage: qwisp chat [--max-tokens N] [--lossless] <prompt>   (or pipe text via stdin)")
     } else {
         let env = ProcessInfo.processInfo.environment
         // Ensure a model is present; interactively offer to pull one if not (TTY only).
@@ -68,7 +75,9 @@ case "chat":
         if env["QWISP_FAKE"] == "1" {
             backend = FakeBackend(script: tok.encode("(fake backend) hello from qwisp chat."))
         } else {
-            backend = try SeedlessBackend(modelDir: effModel)
+            let sb = try SeedlessBackend(modelDir: effModel)
+            sb.losslessForced = chatLossless
+            backend = sb
         }
         // Option B sampling knobs (the server uses the OpenAI API params instead).
         // maxTokens comes from the --max-tokens flag above (default -1 = until EOS/context).


### PR DESCRIPTION
## Summary

Aligns the shipped server/chat with the productization tier→mode decision (2026-07-09) that was recorded but never wired: **<32GB (streaming, C<256) now decodes with bolt (near-lossless L3) by default; ≥32GB (resident) stays strict; `--lossless` / `QWISP_LOSSLESS` / config `"lossless"` forces bit-exact strict on every tier.**

New `BoltServe.swift` (additive) recomposes `runBoltMode`'s primitives for a persistent multi-request server: strict calib on the first request → freeze (top-C ensure + buddy tables + route bias ε=0.25) → chained-d0 bolt decode with sync rolling recalib (R=128). The arena and freeze basis persist across requests. Key invariant learned in testing: each segment must prefill strict FIRST and freeze AFTER — buddy tables map experts to arena slots, and a post-freeze ensure silently invalidates them (degenerate output until fixed; same class as the notes/13 TF re-canonicalization). `runBoltMode` (bench) is untouched.

**Also fixes a pre-existing v0.2.0 bug**: the streaming tier wired no sampling rows, so any `temperature>0` request on a <32GB machine returned an **empty completion** (confirmed `completion_tokens=0` on the v0.2.0 binary). `streamingBackend` now wires `stepLogitsRows` (CPU sampling). Sampling requests on bolt tiers fall back to this strict path (bolt loop is greedy-deterministic; v1 scope).

## Related issue

None (productization alignment; HANDOFF workstream).

## Verification

- [x] RAWTESTS 79/79 · BENCHBATCHTEST PASS · TOKTEST 3/3 · COMPTEST 13/13 · CONFIGTEST 24/24 (18→24, lossless resolution) · PREFIXE2E PASS
- [x] `QWISP_DEVICE_RAM=8` smoke: bolt 84-88 tok/s vs strict 21.3 (~4x); calib first-request only (TTFT 3.1s → 0.65s)
- [x] `--lossless` on 8GB tier → strict streaming, no bolt notice
- [x] Sampling on 8GB tier → strict fallback, 60/60 tokens (was 0 on v0.2.0)
- [x] Resident default → response byte-identical to v0.2.0 behavior
- [x] Zero changes to runBoltMode / bench path

## Notes for reviewer

- v1 scope: sync recalib only — async refresh (notes/14 staging pipeline, slow-NAND +41-48%) is a follow-up; GPU sampler on streaming is also a follow-up (CPU sampling maxK≤8 for now).
- Release intent: **v0.3.0** (default fidelity flips for <32GB users = observable behavior change + new flag; not a patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM