### PR TITLE
feat(server): bolt followups — GPU sampler on streaming; async refresh free-run-safe + default ON (slot-0 fallback lottery fixed)

### DIFF
--- a/swift/Sources/QwispCore/BoltServe.swift
+++ b/swift/Sources/QwispCore/BoltServe.swift
@@ -20,17 +20,22 @@ import MLX
 // AFTER, mirroring runBoltMode's phase 4 → phase 5 order.
 //
 // Scope: greedy only (the server falls back to strict streaming for sampling
-// requests). Rolling recalib (notes/13, R=128) refreshes residency SYNCHRONOUSLY
-// by default. The async staged-swap pipeline (notes/14) is ported but OPT-IN
-// (QWISP_BOLT_REFRESH_ASYNC=1): free-run A/B on nl text (600 tok, C=64) showed
-// the staggered per-layer table swaps open a mixed-vintage window that dips
-// quality mid-transition, and greedy decode then locks into a repetition
-// attractor it never exits — even when the endpoint tables are byte-verified
-// correct and a full convergence freeze runs after the last chunk. The bench
-// validation (notes/14, +41-48% slow-NAND) measured teacher-forced fidelity,
-// which cannot exhibit free-run attractors, so this regression was invisible
-// there. Making async free-run-safe (atomic table flip / double-buffered slots)
-// is a separate campaign.
+// requests). Rolling recalib (notes/13, R=128) refreshes residency; the async
+// staged-swap pipeline (notes/14) is default ON (QWISP_BOLT_REFRESH_ASYNC=0 →
+// sync). Async is free-run-safe only since the FALLBACK-SLOT fix: free-run A/B
+// on nl text (600 tok, C=64, deterministic) initially showed async decode
+// locking into a repetition attractor while sync stayed coherent. The evidence
+// chain (swap bytes memcmp-MATCH on all 9 planes × all jobs; S=1 immediate
+// swaps; atomic single-turn application; convergence freeze ⇒ endpoint ≡ sync)
+// eliminated every timing/data suspect — the one semantic difference left was
+// buildBuddyTable's slot-0 fallback: cold experts with no in-window
+// co-activation (~100+/256 on a sparse 128-token window) remap to WHATEVER
+// EXPERT OCCUPIES SLOT 0, and ensure() vs staged-swap victim assignment park
+// different experts there. That fallback-target lottery compounded per refresh
+// into the attractor. Fixed by pinning the fallback to the basis window's
+// top-count resident (buildBuddyTable(fallbackSlot:), additive, default 0 =
+// bench byte-identical). The notes/14 validation measured teacher-forced
+// fidelity on a re-canonicalized state, which structurally hides both effects.
 //
 // Lifetime: one instance per SeedlessBackend. The expert arena (providers) and the
 // freeze basis (last calib/recalib routing window) persist across requests; each
@@ -61,8 +66,8 @@ final class BoltServe {
     private let recalibR = Tell.envInt("QWISP_BOLT_RECALIB_R", 128)
     private let chainK = Tell.envInt("QWISP_CHAIN_K", SeedlessFusedVerify.SeedlessFusedForward.chainKDefault)
     private let refreshB = Tell.envInt("QWISP_BOLT_REFRESH_B", 32)
-    // Server default 0 (sync) — free-run attractor regression, see header. Bench keeps its own default.
-    private var refreshAsync: Bool { recalibR > 0 && Tell.envInt("QWISP_BOLT_REFRESH_ASYNC", 0) != 0 && stagingArenas.count == 2 }
+    // Default ON since the fallback-slot fix (see header); QWISP_BOLT_REFRESH_ASYNC=0 opts out to sync.
+    private var refreshAsync: Bool { recalibR > 0 && Tell.envInt("QWISP_BOLT_REFRESH_ASYNC", 1) != 0 && stagingArenas.count == 2 }
     // Async refresh staging: 2 ping-pong arenas (N=refreshB each), background pread pipeline
     // (bounded buffer via semaphores). Created once, after the first calib (needs providers).
     private var stagingArenas: [ExpertArena] = []
@@ -81,6 +86,20 @@ final class BoltServe {
     /// Freeze current residency to `fwd`: ensure top-C of the basis window, rebuild
     /// buddy tables against the CURRENT slot state, upload tables + residency bias.
     /// Must run AFTER any ensure-moving operation (prefill, refresh) — see header.
+    /// Slot of the basis window's top-count expert — the deterministic remap target for
+    /// coactivation-less cold experts. The historical slot-0 fallback made that target the
+    /// slot-0 occupant LOTTERY: ensure() and staged swaps assign slots differently, so sync
+    /// and async runs silently remapped the fallback mass (~100+/256 experts on a sparse
+    /// 128-token window) to DIFFERENT experts — measured as compounding free-run divergence.
+    private func fallbackSlot(_ li: Int) -> Int {
+        guard let providers else { return 0 }
+        let top1 = baseCounts[li].enumerated()
+            .sorted { $0.element != $1.element ? $0.element > $1.element : $0.offset < $1.offset }
+            .first?.offset
+        guard let t = top1, let s = providers[li].cache.slotOf[t] else { return 0 }
+        return s
+    }
+
     private func freeze(_ fwd: SeedlessFusedVerify.SeedlessFusedForward) {
         guard let providers else { return }
         for (li, provider) in providers.enumerated() {
@@ -88,7 +107,7 @@ final class BoltServe {
                 .sorted { $0.element != $1.element ? $0.element > $1.element : $0.offset < $1.offset }
                 .prefix(C).map { $0.offset }
             _ = provider.cache.ensure(Array(top))
-            provider.cache.buildBuddyTable(coact: baseCoact[li], numExperts: Self.nE)
+            provider.cache.buildBuddyTable(coact: baseCoact[li], numExperts: Self.nE, fallbackSlot: fallbackSlot(li))
         }
         fwd.setBoltTables(providers.map { $0.cache.buddyTableCPU })
         if biasEps > 0 {
@@ -144,7 +163,7 @@ final class BoltServe {
                                  count: nLayers)
             // Staging arenas for the async refresh pipeline (best-effort: on failure the
             // refreshAsync computed property stays false → sync refresh path).
-            if Tell.envInt("QWISP_BOLT_REFRESH_ASYNC", 0) != 0, let first = provs.first {
+            if Tell.envInt("QWISP_BOLT_REFRESH_ASYNC", 1) != 0, let first = provs.first {
                 for _ in 0 ..< 2 {
                     if let a = try? ExpertArena(device: first.cache.arena.device,
                                                 source: first.cache.arena.source,
@@ -277,11 +296,28 @@ final class BoltServe {
             }
             LayerExpertCache.missTotal += chunk.count
             if Tell.envFlag("QWISP_BOLT_DEBUG") {
-                FileHandle.standardError.write(Data("[boltserve] swap chunk \(j): \(chunk.count) jobs, layers=\(Set(chunk.map { $0.li }).count)\n".utf8))
+                // Full bytecheck: every job × every plane, arena victim vs fresh pread.
+                var bad: [String: Int] = [:], checked = 0
+                for cj in chunk {
+                    let arena = providers[cj.li].cache.arena
+                    for proj in ExpertSource.projs {
+                        for part in ExpertSource.parts {
+                            guard let s = arena.slots["\(proj).\(part)"] else { continue }
+                            let tmp = UnsafeMutableRawPointer.allocate(byteCount: s.sliceBytes, alignment: 16)
+                            defer { tmp.deallocate() }
+                            try? arena.source.preadInto(tmp, cj.li, proj, part, cj.expert)
+                            checked += 1
+                            if memcmp(tmp, s.ptr + cj.victimSlot * s.sliceBytes, s.sliceBytes) != 0 {
+                                bad["\(proj).\(part)", default: 0] += 1
+                            }
+                        }
+                    }
+                }
+                FileHandle.standardError.write(Data("[boltserve] swap chunk \(j): \(chunk.count) jobs, planes checked=\(checked) mismatch=\(bad.isEmpty ? "NONE" : String(describing: bad))\n".utf8))
             }
             for li in Set(chunk.map { $0.li }).sorted() {
                 let cache = providers[li].cache
-                cache.buildBuddyTable(coact: baseCoact[li], numExperts: nE)
+                cache.buildBuddyTable(coact: baseCoact[li], numExperts: nE, fallbackSlot: fallbackSlot(li))
                 fwd.setBoltTable(li, cache.buddyTableCPU)
                 if biasEps > 0 {
                     fwd.updateRouteBiasMask(li, (0 ..< nE).map { Int32(cache.buddyExpertCPU[$0] == $0 ? 1 : 0) })
@@ -305,17 +341,29 @@ final class BoltServe {
             drainAsync()                       // leftover chunks from the previous plan
             swap(&baseCounts, &winCounts)
             swap(&baseCoact, &winCoact)
-            var allJobs = [CrossJob]()
+            var perLayer = [[CrossJob]]()
             for (li, provider) in providers.enumerated() {
+                var jobs = [CrossJob]()
                 if let plan = BoltAsyncRefresh.makePlan(
                     counts: baseCounts[li], coact: baseCoact[li],
                     slotOf: provider.cache.slotOf, expertAt: provider.cache.expertAt,
                     tick: provider.cache.tick, pinnedSlots: provider.cache.pinnedSlots,
                     C: C, nE: nE, B: refreshB) {
                     for job in plan.jobs {
-                        allJobs.append(CrossJob(li: li, expert: job.expert, victimSlot: job.victimSlot))
+                        jobs.append(CrossJob(li: li, expert: job.expert, victimSlot: job.victimSlot))
                     }
                 }
+                perLayer.append(jobs)
+            }
+            // Round-robin interleave across layers: each chunk advances EVERY layer by
+            // ~1 expert, so intermediate states are uniform-vintage snapshots (a series
+            // of small sync-like refreshes). Layer-contiguous chunking staggered layer
+            // vintages across the transition window — the measured free-run attractor
+            // seed (see header). Uniformity is what makes async free-run-safe.
+            var allJobs = [CrossJob]()
+            let maxLen = perLayer.map(\.count).max() ?? 0
+            for r in 0 ..< maxLen {
+                for lj in perLayer where r < lj.count { allJobs.append(lj[r]) }
             }
             asyncBoundary = out.count
             asyncChunks = stride(from: 0, to: allJobs.count, by: refreshB).map {
@@ -340,6 +388,10 @@ final class BoltServe {
             semFree = DispatchSemaphore(value: 2)
             semReady = DispatchSemaphore(value: 0)
             startBgPlan()
+            // Atomic-apply diag (QWISP_BOLT_ATOMIC=1): drain every chunk right here —
+            // staged IO, but application collapses to ONE CPU turn like a sync refresh.
+            // Discriminates "spread-out application is the poison" from "swap mechanics".
+            if Tell.envFlag("QWISP_BOLT_ATOMIC") { drainAsync() }
         }
 
         // ── Bolt spec decode loop (mirror of runBoltMode phase 6, server contract) ──

--- a/swift/Sources/QwispCore/BoltServe.swift
+++ b/swift/Sources/QwispCore/BoltServe.swift
@@ -19,9 +19,18 @@ import MLX
 // its strict prefill FIRST and freezes (ensure top-C + rebuild tables + setBoltTables)
 // AFTER, mirroring runBoltMode's phase 4 → phase 5 order.
 //
-// v1 scope (ponytail): greedy only (the server falls back to strict streaming for
-// sampling requests), sync rolling recalib (notes/13, R=128); async refresh
-// (notes/14 staging pipeline, slow-NAND +41-48%) is a follow-up.
+// Scope: greedy only (the server falls back to strict streaming for sampling
+// requests). Rolling recalib (notes/13, R=128) refreshes residency SYNCHRONOUSLY
+// by default. The async staged-swap pipeline (notes/14) is ported but OPT-IN
+// (QWISP_BOLT_REFRESH_ASYNC=1): free-run A/B on nl text (600 tok, C=64) showed
+// the staggered per-layer table swaps open a mixed-vintage window that dips
+// quality mid-transition, and greedy decode then locks into a repetition
+// attractor it never exits — even when the endpoint tables are byte-verified
+// correct and a full convergence freeze runs after the last chunk. The bench
+// validation (notes/14, +41-48% slow-NAND) measured teacher-forced fidelity,
+// which cannot exhibit free-run attractors, so this regression was invisible
+// there. Making async free-run-safe (atomic table flip / double-buffered slots)
+// is a separate campaign.
 //
 // Lifetime: one instance per SeedlessBackend. The expert arena (providers) and the
 // freeze basis (last calib/recalib routing window) persist across requests; each
@@ -51,6 +60,13 @@ final class BoltServe {
     private let biasEps = Tell.envFloat("QWISP_ROUTE_BIAS_EPS", 0.25)
     private let recalibR = Tell.envInt("QWISP_BOLT_RECALIB_R", 128)
     private let chainK = Tell.envInt("QWISP_CHAIN_K", SeedlessFusedVerify.SeedlessFusedForward.chainKDefault)
+    private let refreshB = Tell.envInt("QWISP_BOLT_REFRESH_B", 32)
+    // Server default 0 (sync) — free-run attractor regression, see header. Bench keeps its own default.
+    private var refreshAsync: Bool { recalibR > 0 && Tell.envInt("QWISP_BOLT_REFRESH_ASYNC", 0) != 0 && stagingArenas.count == 2 }
+    // Async refresh staging: 2 ping-pong arenas (N=refreshB each), background pread pipeline
+    // (bounded buffer via semaphores). Created once, after the first calib (needs providers).
+    private var stagingArenas: [ExpertArena] = []
+    private let bgQueue = DispatchQueue(label: "qwisp.boltserve.async_refresh", qos: .userInitiated)
     private static let nE = 256
     private static let Ktop = 8
 
@@ -126,6 +142,16 @@ final class BoltServe {
             winCounts = [[Int]](repeating: [Int](repeating: 0, count: nE), count: nLayers)
             winCoact = [[[Int]]](repeating: [[Int]](repeating: [Int](repeating: 0, count: nE), count: nE),
                                  count: nLayers)
+            // Staging arenas for the async refresh pipeline (best-effort: on failure the
+            // refreshAsync computed property stays false → sync refresh path).
+            if Tell.envInt("QWISP_BOLT_REFRESH_ASYNC", 0) != 0, let first = provs.first {
+                for _ in 0 ..< 2 {
+                    if let a = try? ExpertArena(device: first.cache.arena.device,
+                                                source: first.cache.arena.source,
+                                                N: refreshB, refLayer: 0) { stagingArenas.append(a) }
+                }
+                if stagingArenas.count < 2 { stagingArenas = [] }
+            }
             calibrated = true
         }
         guard let providers else { return nil }
@@ -169,10 +195,15 @@ final class BoltServe {
                     counts: &winCounts[li], coact: &winCoact[li])
             }
         }
-        /// Recalib refresh: the observation window becomes the new freeze basis.
+        /// Recalib refresh (sync): the observation window becomes the new freeze basis.
         func refresh() {
             swap(&baseCounts, &winCounts)
             swap(&baseCoact, &winCoact)
+            if Tell.envFlag("QWISP_BOLT_DEBUG") {
+                let obs = baseCounts.reduce(0) { $0 + $1.reduce(0, +) }
+                let top8 = baseCounts[0].enumerated().sorted { $0.element > $1.element }.prefix(8).map { "\($0.offset):\($0.element)" }
+                FileHandle.standardError.write(Data("[boltserve] sync refresh: windowObs=\(obs) L0top8=\(top8.joined(separator: ","))\n".utf8))
+            }
             freeze(fwd)
             for li in 0 ..< nLayers {
                 for e in 0 ..< nE { winCounts[li][e] = 0; winCoact[li][e] = [Int](repeating: 0, count: nE) }
@@ -180,16 +211,149 @@ final class BoltServe {
             tokensSinceRefresh = 0
         }
 
-        // ── Bolt spec decode loop (mirror of runBoltMode phase 6, server contract) ──
+        // Decode-loop state (declared before the async machinery below captures it).
         var hist = promptIds.map { Int($0) }
         var out: [Int] = []
         var stSteps = 0, stDrafted = 0, stAccepted = 0, stD0 = 0
         var streamed = 0
         func flush() { if let onToken { while streamed < out.count { onToken(out[streamed]); streamed += 1 } } }
 
+        // ── Async refresh plan state (notes/14; mirror of runBoltMode's machinery) ──
+        struct CrossJob { let li: Int; let expert: Int; let victimSlot: Int }
+        var asyncBoundary = 0
+        var asyncChunks = [[CrossJob]]()
+        var asyncNextSwap = 0
+        var asyncStride = 1
+        var semFree = DispatchSemaphore(value: 2)
+        var semReady = DispatchSemaphore(value: 0)
+        /// Background pipeline: pread every chunk into the 2 staging arenas (bounded buffer).
+        /// Writes ONLY to stagingArenas — providers are touched by swapChunk on this thread.
+        func startBgPlan() {
+            guard refreshAsync, !asyncChunks.isEmpty else { return }
+            let chunks = asyncChunks, stages = stagingArenas
+            let sf = semFree, sr = semReady
+            bgQueue.async {
+                for (j, chunk) in chunks.enumerated() {
+                    sf.wait()
+                    let stage = stages[j % 2]
+                    var byLayer = [Int: [(e: Int, slot: Int)]]()
+                    for (k, cj) in chunk.enumerated() {
+                        byLayer[cj.li, default: []].append((e: cj.expert, slot: k))
+                    }
+                    for (layer, jobs) in byLayer { stage.loadMany(layer, jobs) }
+                    sr.signal()
+                }
+            }
+        }
+        /// Atomic CPU-turn swap of chunk j: staging → arena victim slots + bookkeeping +
+        /// per-touched-layer buddy/table/bias rebuild (baseCoact = the plan's window snapshot).
+        func swapChunk(_ j: Int) {
+            guard refreshAsync, j < asyncChunks.count else { return }
+            semReady.wait()
+            let chunk = asyncChunks[j]
+            let stage = stagingArenas[j % 2]
+            for (k, cj) in chunk.enumerated() {
+                let cache = providers[cj.li].cache
+                let arena = cache.arena
+                for key in stage.slots.keys {
+                    guard let srcS = stage.slots[key], let dstS = arena.slots[key] else { continue }
+                    memcpy(dstS.ptr + cj.victimSlot * dstS.sliceBytes,
+                           srcS.ptr + k             * srcS.sliceBytes,
+                           srcS.sliceBytes)
+                }
+                let cur = cache.expertAt[cj.victimSlot]
+                if cur >= 0 && cur != cj.expert { cache.slotOf.removeValue(forKey: cur) }
+                cache.slotOf[cj.expert]       = cj.victimSlot
+                cache.expertAt[cj.victimSlot] = cj.expert
+                cache.clock                  += 1
+                cache.tick[cj.victimSlot]     = cache.clock
+                // ensure() parity: slotOf changed → the STRICT-path derived GPU arrays
+                // (slotTableGPU / hotMask) must rebuild, or the next segment's strict
+                // prefill remaps routed experts to pre-swap slots = silent garbage.
+                // (runBoltMode never runs strict again after its swaps, so the bench
+                // template omits this; the server does — every segment prefills strict.)
+                cache.slotTableDirty = true
+                cache.slotVersion   += 1
+            }
+            LayerExpertCache.missTotal += chunk.count
+            if Tell.envFlag("QWISP_BOLT_DEBUG") {
+                FileHandle.standardError.write(Data("[boltserve] swap chunk \(j): \(chunk.count) jobs, layers=\(Set(chunk.map { $0.li }).count)\n".utf8))
+            }
+            for li in Set(chunk.map { $0.li }).sorted() {
+                let cache = providers[li].cache
+                cache.buildBuddyTable(coact: baseCoact[li], numExperts: nE)
+                fwd.setBoltTable(li, cache.buddyTableCPU)
+                if biasEps > 0 {
+                    fwd.updateRouteBiasMask(li, (0 ..< nE).map { Int32(cache.buddyExpertCPU[$0] == $0 ? 1 : 0) })
+                }
+            }
+            // Convergence freeze: after the last chunk, rebuild ALL layers against the
+            // plan window — endpoint identical to a sync refresh (cheap; ensure all-hit).
+            if j == asyncChunks.count - 1 { freeze(fwd) }
+            semFree.signal()
+        }
+        /// Drain all pending chunks (blocking). MUST run before replacing the plan/semaphores
+        /// and before every return — an undrained semaphore pair traps in dispose (SIGTRAP),
+        /// and undrained victim bookkeeping would go stale across the next segment's prefill.
+        func drainAsync() {
+            while asyncNextSwap < asyncChunks.count { swapChunk(asyncNextSwap); asyncNextSwap += 1 }
+        }
+        defer { drainAsync() }
+        /// Recalib refresh (async): window → freeze basis, plan diffs, kick the bg pipeline.
+        /// Swaps land at fixed token positions (asyncStride) at the decode loop head.
+        func refreshAsyncPlan() {
+            drainAsync()                       // leftover chunks from the previous plan
+            swap(&baseCounts, &winCounts)
+            swap(&baseCoact, &winCoact)
+            var allJobs = [CrossJob]()
+            for (li, provider) in providers.enumerated() {
+                if let plan = BoltAsyncRefresh.makePlan(
+                    counts: baseCounts[li], coact: baseCoact[li],
+                    slotOf: provider.cache.slotOf, expertAt: provider.cache.expertAt,
+                    tick: provider.cache.tick, pinnedSlots: provider.cache.pinnedSlots,
+                    C: C, nE: nE, B: refreshB) {
+                    for job in plan.jobs {
+                        allJobs.append(CrossJob(li: li, expert: job.expert, victimSlot: job.victimSlot))
+                    }
+                }
+            }
+            asyncBoundary = out.count
+            asyncChunks = stride(from: 0, to: allJobs.count, by: refreshB).map {
+                Array(allJobs[$0 ..< Swift.min($0 + refreshB, allJobs.count)])
+            }
+            if Tell.envFlag("QWISP_BOLT_DEBUG") {
+                let obs = baseCounts.reduce(0) { $0 + $1.reduce(0, +) }
+                let top8 = baseCounts[0].enumerated().sorted { $0.element > $1.element }.prefix(8).map { "\($0.offset):\($0.element)" }
+                FileHandle.standardError.write(Data("[boltserve] async plan: jobs=\(allJobs.count) chunks=\(asyncChunks.count) boundary=\(asyncBoundary) windowObs=\(obs) L0top8=\(top8.joined(separator: ","))\n".utf8))
+            }
+            asyncNextSwap = 0
+            // Spread swaps over the half-window (OAT 2026-07-07: full-width lags table
+            // freshness, tighter blocks on GPU-idle swaps). QWISP_BOLT_REFRESH_S overrides
+            // (bench parity knob).
+            let sOverride = Tell.envInt("QWISP_BOLT_REFRESH_S", 0)
+            asyncStride = sOverride > 0 ? sOverride
+                        : Swift.max(1, (recalibR / 2) / Swift.max(1, asyncChunks.count))
+            for li in 0 ..< nLayers {
+                for e in 0 ..< nE { winCounts[li][e] = 0; winCoact[li][e] = [Int](repeating: 0, count: nE) }
+            }
+            tokensSinceRefresh = 0
+            semFree = DispatchSemaphore(value: 2)
+            semReady = DispatchSemaphore(value: 0)
+            startBgPlan()
+        }
+
+        // ── Bolt spec decode loop (mirror of runBoltMode phase 6, server contract) ──
         while out.count < N && !(isCancelled?() ?? false) {
             flush()
-            if recalibR > 0 && tokensSinceRefresh >= recalibR { refresh() }
+            if recalibR > 0 && tokensSinceRefresh >= recalibR {
+                if refreshAsync { refreshAsyncPlan() } else { refresh() }
+            }
+            // Async: swap due chunks at fixed token positions (chain/verify spans jump
+            // out.count, so consume ALL due chunks here — bg pipeline has them preread).
+            while refreshAsync, asyncNextSwap < asyncChunks.count,
+                  out.count >= asyncBoundary + (asyncNextSwap + 1) * asyncStride {
+                swapChunk(asyncNextSwap); asyncNextSwap += 1
+            }
             let before = out.count
             let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: Tell.suffixMinMatch)
             let D = drafts.count

--- a/swift/Sources/QwispCore/ExpertArena.swift
+++ b/swift/Sources/QwispCore/ExpertArena.swift
@@ -184,7 +184,12 @@ nonisolated(unsafe) public static var chunkTotal: Int = 0       // 累積 chunk 
     /// BuddyMoE: cold expert を「最も共活性化する hot expert」の slot に remap する table を構築。
     /// hot は現在 slotOf にいる expert。coact[e][h] = calib で e と h が同 token で共 routed した回数。
     /// 各 cold e → argmax_h(coact[e][h]) の slot（co-activation 無ければ slot-0 fallback）。
-    public func buildBuddyTable(coact: [[Int]], numExperts: Int) {
+    /// fallbackSlot: remap target for coactivation-less cold experts. Default 0 preserves the
+    /// historical behavior (slot-0 fallback), whose TARGET EXPERT silently depends on how slots
+    /// were assigned — ensure() and async staged swaps assign differently, which BoltServe
+    /// measured as a free-run quality divergence (the slot-0 occupant lottery). Callers that
+    /// know the basis window should pass the top-count resident's slot instead.
+    public func buildBuddyTable(coact: [[Int]], numExperts: Int, fallbackSlot: Int = 0) {
         // 決定化: Dictionary iteration はプロセス毎に乱択（hash seed）で、coact の同点 buddy が
         // 走査順で決まると run 毎に table が変わる（C=64 fidelity ±2-5pt の非決定性の原因）。
         // 同点 tie-break は「最小 expert id 固定」だと全 cold の同点が同一低 id hot に集中し
@@ -199,7 +204,7 @@ nonisolated(unsafe) public static var chunkTotal: Int = 0       // 累積 chunk 
             let n = hot.count
             for i in 0 ..< n { let h = hot[(i + e) % n]; let cc = coact[e][h]; if cc > bestC { bestC = cc; bestH = h } }
             if bestH >= 0 && bestC > 0 { bmap[e] = Int32(slotOf[bestH]!); bexp[e] = Int32(bestH) }
-            else { bmap[e] = 0 }   // co-activation 無し: slot-0 fallback（buddy expert 無し）
+            else { bmap[e] = Int32(fallbackSlot) }   // co-activation 無し: fallback（buddy expert 無し）
         }
         let arr = MLXArray(bmap, [numExperts]); arr.eval()
         buddyTable = arr

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -289,8 +289,15 @@ extension Tell {
         // Option B sampling (CPU logits readback). Pre-v0.3.0 the streaming tier wired
         // NO sampling rows at all, so any temperature>0 request on <32GB returned an
         // EMPTY completion (runSpecSampleLoop guards on stepLogitsRows → nil → 0 tokens).
-        // The GPU sampler (stepSampleRows) stays resident/bolt-only (1-CB head path).
         backend.stepLogitsRows = makeStepLogits(engine: engine, forward: forward)
+        // GPU sampler (v0.3.1): stepSampleRows implements all three streamModes (strict
+        // runs the per-layer runStrictLayers path) — it was simply never wired here.
+        // Same head guard as the fused backend.
+        if fwd.head != nil {
+            backend.stepSampleRows = { toks, drafts, invT, seed, base, adj, topP in
+                fwd.stepSampleRows(toks, drafts: drafts, invT: invT, seed: seed, basePos: base, logitAdj: adj, topP: topP)
+            }
+        }
         return (backend, fwd, providers)
     }
 


### PR DESCRIPTION
## Summary

The two follow-ups scoped in PR #33, for v0.3.1 — with a root-caused fix that makes async refresh safe to default.

**1. GPU sampler on streaming tiers.** `stepSampleRows` already implements all three streamModes — it was never wired into `streamingBackend`. `temperature>0` on <32GB now uses the 1-CB GPU sampler instead of the CPU logits-readback fallback (maxK≤8 cap lifted).

**2. Async recalib refresh ported into BoltServe — now DEFAULT ON, free-run-safe.** The port initially reproduced a catastrophic free-run regression (greedy locks into a repetition attractor on nl text while sync stays coherent). The elimination chain — all-plane swap bytes memcmp-MATCH, S=1 immediate swaps, atomic single-turn application, convergence freeze (endpoint ≡ sync), all STILL degenerate — left exactly one semantic difference between ensure()-built and swap-built state: **`buildBuddyTable`'s slot-0 fallback.** Cold experts with no in-window co-activation (~100+/256 on a sparse 128-token window) remap to *whatever expert occupies slot 0*, and ensure() vs staged-swap victim assignment park different experts there. The fallback-target lottery compounds per refresh into the attractor.

Fix: `buildBuddyTable(fallbackSlot:)` — additive param, default 0 = bench byte-identical (RAWTESTS 79/79); BoltServe pins the fallback to the basis window's top-count resident, deterministic in both refresh modes. With the fix the original failing config runs the 600-token reproducer coherent end-to-end (80.3 tok/s; sync 82.8 — fast-SSD wash, the async prize is slow-NAND where sync refresh stalls seconds per window). Chunk ordering is also round-robin interleaved across layers (uniform-vintage transitions).

Also fixes two latent bugs the port surfaced: (a) manual swap bookkeeping must bump `slotTableDirty`/`slotVersion` (ensure() parity) or the next segment's strict prefill remaps against pre-swap slot state; (b) the slot-0 lottery itself, which was latent in the bench async path too — invisible there because notes/14 validated teacher-forced fidelity on a re-canonicalized state, which structurally hides both effects.

## Related issue

None (v0.3.0 follow-up workstream).

## Verification

- [x] RAWTESTS 79/79 (bench byte-identity of the default fallback param) · BENCHBATCH · TOKTEST 3/3 · COMPTEST 13/13 · CONFIGTEST 24/24 · PREFIXE2E PASS
- [x] Reproducer (600-tok nl, C=64, deterministic): async-default coherent end-to-end; sync coherent; cross-request coherent; sampling 80/80 tokens (GPU sampler)
- [x] Attractor evidence chain documented in BoltServe header + memory
- [x] runBoltMode / bench path untouched (fallbackSlot default 0)

## Notes for reviewer

- Release intent: **v0.3.1**.
- `QWISP_BOLT_DEBUG=1` leaves gated plan/swap/bytecheck telemetry; `QWISP_BOLT_ATOMIC=1` keeps the atomic-apply diag.
- Follow-up candidate (not this PR): apply the fallback fix to the bench bolt path as an opt-in for free-run comparability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM