### PR TITLE
feat(cli): benchtest numeric stability ratio + release.sh version auto-sync

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -46,6 +46,18 @@ if [[ $DRY -eq 0 ]] && gh release view "$VERSION" >/dev/null 2>&1; then
   echo "ERROR: release $VERSION already exists"; exit 1
 fi
 
+# 0b. auto-sync Config.version to the tag — the bump can't be forgotten. The binary
+#     guard in 3b stays as the independent check that the build picked it up.
+CONF="swift/Sources/qwisp/Config.swift"
+if ! grep -q "static let version = \"$BARE\"" "$CONF"; then
+  if [[ $DRY -eq 1 ]]; then
+    echo "ERROR: Config.version != $BARE and --dry-run never commits — bump it first"; exit 1
+  fi
+  echo "==> bumping Config.version -> $BARE"
+  /usr/bin/sed -i '' "s|static let version = \".*\"|static let version = \"$BARE\"|" "$CONF"
+  git add "$CONF" && git commit -q -m "chore: bump version to $BARE" && git push -q origin main
+fi
+
 # 1. build Release (qwisp scheme only — qwisp-poc is not shipped)
 echo "==> building Release $VERSION (Xcode 26 required)"
 pkill -f 'Release/qwisp' 2>/dev/null || true

--- a/swift/Sources/qwisp/Benchtest.swift
+++ b/swift/Sources/qwisp/Benchtest.swift
@@ -151,7 +151,7 @@ private struct BenchRow {
     let ttftMs: Int
     let tokPerSec: Double
     let tokens: Int
-    let stable: Bool
+    let stability: Double   // distinct n-gram ratio; < 0.5 → LOOPY
     let tail: String
 }
 
@@ -183,7 +183,7 @@ private func benchRun(name: String, mode: String, prompt: String, maxTokens: Int
     return BenchRow(name: name, mode: mode,
                     ttftMs: Int(tf.timeIntervalSince(t0) * 1000),
                     tokPerSec: rate, tokens: outIds.count,
-                    stable: stabilityRatio(outIds) >= 0.5, tail: tail)
+                    stability: stabilityRatio(outIds), tail: tail)
 }
 
 /// Entry point for `qwisp benchtest`. Returns the markdown report (stdout).
@@ -258,9 +258,9 @@ func runBenchtest(modelDir: String) async -> String {
     md.append("| test | mode | TTFT | decode | tokens | stability |")
     md.append("|---|---|---|---|---|---|")
     for r in rows {
-        md.append(String(format: "| %@ | %@ | %.1fs | %.1f tok/s | %d | %@ |",
+        md.append(String(format: "| %@ | %@ | %.1fs | %.1f tok/s | %d | %@ (%.2f) |",
                          r.name, r.mode, Double(r.ttftMs) / 1000.0, r.tokPerSec, r.tokens,
-                         r.stable ? "ok" : "**LOOPY**"))
+                         r.stability >= 0.5 ? "ok" : "**LOOPY**", r.stability))
     }
     if let long = rows.first(where: { $0.name == "long-600" }) {
         md.append("")

--- a/swift/Sources/qwisp/Config.swift
+++ b/swift/Sources/qwisp/Config.swift
@@ -19,9 +19,9 @@ struct QwispConfig: Codable {
 
 enum Config {
     // ── defaults (the SSoT) ──────────────────────────────────────────────
-    /// Release version. Bump with each release — release.sh verifies the built binary's
-    /// `qwisp version` output matches the tag and aborts on mismatch.
-    static let version = "0.3.2"
+    /// Release version. release.sh auto-syncs this to the tag (commits the bump if needed)
+    /// and still verifies the built binary's `qwisp version` output matches the tag.
+    static let version = "0.3.3"
     static let defaultModel = FileManager.default.homeDirectoryForCurrentUser.path
         + "/.mtplx/models/Youssofal--Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16"
     static let defaultPort = 8080


### PR DESCRIPTION
## What

1. **benchtest stability column is now quantitative**: `ok (0.93)` / `**LOOPY** (0.21)` instead of a boolean. The open observation is run-to-run variance of bolt long-600 LOOPY; community-submitted reports now carry the actual n-gram ratio, so marginal cases near the 0.5 threshold become visible data instead of a coin-flip label. Ships in v0.3.3 **before** the call-for-testers issue so all submitted rows share the format.
2. **release.sh auto-syncs Config.version to the tag** (new step 0b): sed + bump commit on main when needed. Removes the manual-bump-forgotten failure mode; the existing 3b binary-vs-tag guard stays as the independent check. `--dry-run` never commits, so it errors if the version is stale.
3. Config.version → 0.3.3.

## Verification

- Release build: BUILD SUCCEEDED
- `scripts/test_raw.sh` → RAWTESTS 79/79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM