### PR TITLE
ci(bench): auto-close benchtest issues on data-PR merge + ack comment

### DIFF
--- a/.github/workflows/benchtest-ingest.yml
+++ b/.github/workflows/benchtest-ingest.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
 
@@ -45,5 +46,8 @@ jobs:
           git push -f origin "$BR"
           gh pr create --head "$BR" \
             --title "data(bench): community benchtest report #$N" \
-            --body "Auto-ingested from #$N by the benchtest-ingest workflow. Merging accepts the report into bench/RESULTS.md (owner merge = spam filter)." \
+            --body "Auto-ingested from #$N by the benchtest-ingest workflow. Merging accepts the report into bench/RESULTS.md (owner merge = spam filter).
+
+Closes #$N" \
+            && gh issue comment "$N" --body "Thanks for the report! It parsed cleanly and is queued for [bench/RESULTS.md](https://github.com/penta2himajin/qwisp/blob/main/bench/RESULTS.md). This issue will close automatically once the data PR is merged." \
             || echo "PR already open for $BR — force-push updated it"


### PR DESCRIPTION
Per owner request: benchtest-report issues now (1) get a thank-you/ack comment when the ingest workflow parses them, (2) close automatically when the bot data PR merges (`Closes #N` in the PR body — no extra job needed). Added `issues: write` permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM