### PR TITLE
ux(cli): surface silent waits (model load / bolt calib / sampling fallback) + real --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,18 @@ qwisp pull                                 # download the default model (~20 GB)
 
 qwisp chat "Explain MoE routing in two sentences."
 qwisp chat --max-tokens 256 "…"            # cap length (default: until EOS / context)
+QWISP_TEMP=0.7 qwisp chat "…"              # sampling knobs: QWISP_TEMP / QWISP_TOPP / QWISP_SEED
+                                           #   note: temp>0 on <32GB decodes via strict (bolt is greedy-only)
 
 qwisp serve                                # OpenAI-compatible server on :8080 (QWISP_PORT to change)
 brew services start qwisp                  #   …or run it as a resident background service
 
 qwisp config                               # show effective settings + where each value came from
 ```
+
+First run: the first chat/serve request loads the model (~20 GB), and on <32 GB machines runs a
+one-time bolt calibration — a few minutes at strict speed, with progress on stderr. Later
+requests in the same process decode at full bolt speed.
 
 Build from source instead (needs Xcode 26 / Swift 6.3):
 

--- a/swift/Sources/QwispCore/BoltServe.swift
+++ b/swift/Sources/QwispCore/BoltServe.swift
@@ -130,6 +130,7 @@ final class BoltServe {
         if !calibrated {
             // stderr like the server's perf log — keeps `qwisp benchtest > report.md` clean.
             FileHandle.standardError.write(Data("[qwisp] bolt tier active (near-lossless, streaming default): C=\(C) — pass --lossless for bit-exact strict\n".utf8))
+            FileHandle.standardError.write(Data("[qwisp] calibrating expert routing (one-time per process, runs at strict speed — can take a few minutes on this tier) …\n".utf8))
             guard let (backend1, fwd1, provs) = Tell.streamingBackend(
                 engine: engine, modelDir: modelDir, maxM: maxM, maxSeqLen: maxSeqLen, C: C)
             else { return nil }
@@ -182,6 +183,7 @@ final class BoltServe {
                 if stagingArenas.count < 2 { stagingArenas = [] }
             }
             calibrated = true
+            FileHandle.standardError.write(Data("[qwisp] calibration done — decoding at bolt speed from here\n".utf8))
         }
         guard let providers else { return nil }
 

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -103,6 +103,7 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     public var losslessForced: Bool? = nil
     public var lossless: Bool { losslessForced ?? (ProcessInfo.processInfo.environment["QWISP_LOSSLESS"] == "1") }
     private var boltServe: BoltServe? = nil
+    private var samplingFallbackNoted = false
     let modelDir: String
     let tier: SeedlessTier
     let contextLen: Int      // model context window (max_position_embeddings); caps unbounded generation.
@@ -192,6 +193,14 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
             // L3, buddy remap) by default; --lossless / QWISP_LOSSLESS forces strict. Sampling
             // requests fall back to strict streaming (the bolt loop is greedy-deterministic; v1).
             let useBolt = cfg.isStreaming && !wantSample && !self.lossless
+            // The fallback is silent otherwise and reads as a mystery slowdown (field report,
+            // issue #45): sampling skips bolt calibration (instant start) and decodes at strict
+            // speed. Say so once per process.
+            if cfg.isStreaming && wantSample && !self.lossless && !samplingFallbackNoted {
+                samplingFallbackNoted = true
+                FileHandle.standardError.write(Data(
+                    "[qwisp] sampling (temperature/top_p/…) on a streaming tier decodes via strict streaming — bolt is greedy-only, expect strict speed; temperature 0 restores bolt\n".utf8))
+            }
             Thread.detachNewThread {
                 var seq = promptIds0          // prompt + all accepted tokens so far
                 var produced = 0

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -11,7 +11,36 @@ import QwispCore
 let qwispConfig = Config.load(path: Config.defaultPath)
 let model = Config.resolveModel(env: ProcessInfo.processInfo.environment, config: qwispConfig, default: Config.defaultModel)
 
+let helpText = """
+qwisp \(Config.version) — single-model local inference for Qwen3.6-35B-A3B on Apple Silicon
+
+usage: qwisp <command> [options]
+
+  serve                  OpenAI-compatible server on :8080 (QWISP_PORT / config)
+  chat [opts] <prompt>   one-shot chat; reads stdin if no prompt is given
+      --max-tokens N     cap generation (default: until EOS / context)
+      --lossless         force strict bit-exact mode (streaming tiers default to bolt)
+  pull [hf-repo-id]      download a checkpoint (default: Qwen3.6-35B-A3B MTPLX) + write config
+  config [--defaults]    show effective settings / the full default set
+  benchtest              community benchmark → markdown report + one-click submit URL
+  version                print the version
+
+environment:
+  QWISP_MODEL   model directory      QWISP_PORT      server port
+  QWISP_LOSSLESS=1                   force strict on every tier
+  chat sampling (default greedy): QWISP_TEMP QWISP_TOPP QWISP_SEED
+                                  QWISP_FREQPEN QWISP_PRESPEN QWISP_LOGIT_BIAS="tok:bias,…"
+  note: temperature > 0 on a streaming tier (<32GB) decodes via strict — bolt is greedy-only
+
+first run: `qwisp pull` downloads ~20GB. The first chat/serve request loads the model, and
+on <32GB machines runs a one-time bolt calibration (a few minutes; progress goes to stderr).
+"""
+
 let args = Array(CommandLine.arguments.dropFirst())
+if args.isEmpty || args.contains("--help") || args.contains("-h") || args.first == "help" {
+    print(helpText)
+    exit(0)
+}
 switch args.first {
 case "serve":
     let port = Config.resolvePort(env: ProcessInfo.processInfo.environment, config: qwispConfig, default: Config.defaultPort)
@@ -75,6 +104,8 @@ case "chat":
         if env["QWISP_FAKE"] == "1" {
             backend = FakeBackend(script: tok.encode("(fake backend) hello from qwisp chat."))
         } else {
+            // The load is ~20GB and used to be silent (issue #45) — say what the wait is.
+            FileHandle.standardError.write(Data("[qwisp] loading model from \(URL(fileURLWithPath: effModel).lastPathComponent) …\n".utf8))
             let sb = try SeedlessBackend(modelDir: effModel)
             sb.losslessForced = chatLossless
             backend = sb
@@ -132,5 +163,5 @@ case "config":
         print(Config.effectiveReport(env: ProcessInfo.processInfo.environment, config: qwispConfig, path: Config.defaultPath))
     }
 default:
-    print("usage: qwisp [serve|chat|pull|config|benchtest|version|selftest|comptest|sampletest|configtest]")
+    print(helpText)
 }


### PR DESCRIPTION
Closes #45 — the field-reported CLI-UX gaps from [the r/LocalLLM thread](https://www.reddit.com/r/LocalLLM/comments/1uwa85m/comment/oxikx0u/):

- `qwisp chat` announces the ~20GB model load on stderr (was silent for minutes).
- bolt calibration prints start (one-time, strict-speed, minutes) and completion ("decoding at bolt speed from here").
- sampling on a streaming tier falls back to strict by design (bolt is greedy-only) — this was silent and read as a mystery slowdown; now noted once per process on stderr.
- `qwisp --help`/`-h`/no-args print full usage: chat flags, sampling env knobs (QWISP_TEMP/…), the greedy-only-bolt caveat, and first-run expectations. README Quickstart carries the same.

## Verification
- BUILD SUCCEEDED; `--help` smoke verified; CONFIGTEST 24/24; RAWTESTS 79/79; BENCHBATCHTEST PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM