### PR TITLE
fix(pull): clear download-failure path + HF_ENDPOINT mirror support

### DIFF
--- a/swift/Sources/qwisp/Pull.swift
+++ b/swift/Sources/qwisp/Pull.swift
@@ -13,17 +13,37 @@ enum ModelStore {
     }
 
     // Download `repo` and point the config file at it. Returns the local model path.
+    // HF_ENDPOINT switches the Hub host (mirrors — e.g. https://hf-mirror.com — for regions
+    // where huggingface.co is slow or blocked); HF_TOKEN is picked up by HubApi itself.
     static func pull(repo: String = defaultRepo) async throws -> String {
         let sizeNote = repo == defaultRepo ? " (~20 GB — this takes a while)" : ""
+        let endpoint = ProcessInfo.processInfo.environment["HF_ENDPOINT"]
+        if let endpoint {
+            FileHandle.standardError.write(Data("Using Hub endpoint \(endpoint) (HF_ENDPOINT)\n".utf8))
+        }
         FileHandle.standardError.write(Data("Downloading \(repo)\(sizeNote)…\n".utf8))
-        let hub = HubApi()
+        let hub = HubApi(endpoint: endpoint)
         var lastPct = -1
-        let url = try await hub.snapshot(from: repo, matching: []) { progress in
-            let pct = Int(progress.fractionCompleted * 100)
-            if pct != lastPct {
-                lastPct = pct
-                FileHandle.standardError.write(Data("\r  \(pct)%   ".utf8))
+        let url: URL
+        do {
+            url = try await hub.snapshot(from: repo, matching: []) { progress in
+                let pct = Int(progress.fractionCompleted * 100)
+                if pct != lastPct {
+                    lastPct = pct
+                    FileHandle.standardError.write(Data("\r  \(pct)%   ".utf8))
+                }
             }
+        } catch {
+            FileHandle.standardError.write(Data("""
+
+            download failed: \(error.localizedDescription)
+            If huggingface.co is slow or blocked in your region:
+              • try a mirror:   HF_ENDPOINT=https://hf-mirror.com qwisp pull
+              • or download it any other way (e.g. `hf download \(repo)`) and point qwisp at
+                the directory via QWISP_MODEL or "model" in ~/.config/qwisp/config.json
+
+            """.utf8))
+            throw error
         }
         FileHandle.standardError.write(Data("\r  100%\n".utf8))
         let path = url.path

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -153,7 +153,9 @@ case "pull":
     // qwisp pull [hf-repo-id] — download a checkpoint (default: Qwen3.6-35B-A3B MTPLX) and
     // point ~/.config/qwisp/config.json at it.
     let repo = args.dropFirst().first ?? ModelStore.defaultRepo
-    _ = try await ModelStore.pull(repo: repo)
+    // The error itself (with mirror/workaround hints) is printed inside pull() — a raw
+    // uncaught-error crash dump on top of it helps nobody.
+    do { _ = try await ModelStore.pull(repo: repo) } catch { exit(1) }
 case "config":
     // qwisp config           — effective config with per-key provenance
     // qwisp config --defaults — full default set as JSON (for pinning explicitly)


### PR DESCRIPTION
Closes #46 — field-reported from [the r/LocalLLM thread](https://www.reddit.com/r/LocalLLM/comments/1uwa85m/comment/oxikx0u/) ("had to download the model using hf cli, can be regional issue"):

- `HF_ENDPOINT` is now honored (mirrors like hf-mirror.com — the likely regional fix). `HF_TOKEN` already worked via HubApi's environment provider.
- Download failures print the reason + concrete recovery (mirror env var, or hf-cli download + `QWISP_MODEL`), and exit 1 instead of an uncaught-error crash dump.

## Verification
- BUILD SUCCEEDED.
- `HF_ENDPOINT=http://127.0.0.1:9 qwisp pull fake/repo` → clean error + hints, exit code 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM