### PR TITLE
fix(cli): unsupported checkpoints get a clear error, not a trace trap

### DIFF
--- a/swift/Sources/qwisp/Pull.swift
+++ b/swift/Sources/qwisp/Pull.swift
@@ -12,6 +12,30 @@ enum ModelStore {
         FileManager.default.fileExists(atPath: path + "/config.json")
     }
 
+    /// The engine is specialised to the MTPLX checkpoint layout; anything else must be
+    /// rejected HERE with a real message — engine preconditions die as a bare trace trap
+    /// (issue #51: an oQ4 requant of the same base model SIGTRAPed benchtest). The MTPLX
+    /// pipeline stamps `mtplx_policy` into config.json; that key is the format signature
+    /// (the oQ4 repo lacks it while matching everything else).
+    static func requireSupported(_ modelDir: String) {
+        let url = URL(fileURLWithPath: modelDir).appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: url),
+              let top = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            FileHandle.standardError.write(Data("cannot read \(url.path) — not a model directory?\n".utf8))
+            exit(1)
+        }
+        guard top["mtplx_policy"] == nil else { return }
+        FileHandle.standardError.write(Data("""
+        Unsupported checkpoint: \(modelDir)
+        qwisp is single-model-specialised: it supports the MTPLX build of Qwen3.6-35B-A3B only
+        (\(defaultRepo)). This directory is a different model or a different quant layout of the
+        same base model, and the engine's kernels are shaped for the MTPLX layout exactly.
+            qwisp pull    # download the supported checkpoint (~20 GB) + write config
+
+        """.utf8))
+        exit(1)
+    }
+
     // Download `repo` and point the config file at it. Returns the local model path.
     // HF_ENDPOINT switches the Hub host (mirrors — e.g. https://hf-mirror.com — for regions
     // where huggingface.co is slow or blocked); HF_TOKEN is picked up by HubApi itself.

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -45,8 +45,11 @@ switch args.first {
 case "serve":
     let port = Config.resolvePort(env: ProcessInfo.processInfo.environment, config: qwispConfig, default: Config.defaultPort)
     // A daemon has no TTY — never prompt. Missing model → fail fast with the hint.
-    if ProcessInfo.processInfo.environment["QWISP_FAKE"] != "1" && !ModelStore.isModel(model) {
-        FileHandle.standardError.write(Data((ModelStore.missingModelHint + "\n").utf8)); exit(1)
+    if ProcessInfo.processInfo.environment["QWISP_FAKE"] != "1" {
+        if !ModelStore.isModel(model) {
+            FileHandle.standardError.write(Data((ModelStore.missingModelHint + "\n").utf8)); exit(1)
+        }
+        ModelStore.requireSupported(model)
     }
     let modelID = URL(fileURLWithPath: model).lastPathComponent
     let tok = try await QwispTokenizer(modelDir: model)
@@ -95,6 +98,7 @@ case "chat":
         if env["QWISP_FAKE"] == "1" {
             effModel = model
         } else if let m = await ModelStore.ensureModel(model, allowPrompt: true) {
+            ModelStore.requireSupported(m)
             effModel = m
         } else {
             FileHandle.standardError.write(Data((ModelStore.missingModelHint + "\n").utf8)); exit(1)
@@ -130,6 +134,7 @@ case "benchtest":
     if !ModelStore.isModel(model) {
         FileHandle.standardError.write(Data((ModelStore.missingModelHint + "\n").utf8)); exit(1)
     }
+    ModelStore.requireSupported(model)
     print(await runBenchtest(modelDir: model))
 case "version", "--version", "-v":
     print(Config.version)


### PR DESCRIPTION
Closes #51 — field report: pointing qwisp at [Jundot/Qwen3.6-35B-A3B-oQ4-mtp](https://huggingface.co/Jundot/Qwen3.6-35B-A3B-oQ4-mtp) trace-trapped `benchtest`.

Root cause: the oQ4 repo matches the supported checkpoint in architecture and tensor naming but drops the MTP/extra tensors (2052 vs 2090 weights) and re-mixes per-tensor quantization — the engine's shape preconditions SIGTRAP with zero diagnostics.

Fix: `ModelStore.requireSupported` gates chat/serve/benchtest on the MTPLX format signature (`mtplx_policy` in config.json — stamped by the MTPLX pipeline, absent in requants). Mismatch prints what qwisp supports + `qwisp pull` hint, exit 1.

## Verification
- Guard tested against the actual crashing repo's config.json → clean message, exit 1.
- Supported checkpoint passes; CONFIGTEST 24/24; BUILD SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM