### PR TITLE
feat(cli): version-update notice (brew-style, opt-out, benchtest stays silent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ First run: the first chat/serve request loads the model (~20 GB), and on <32 GB 
 one-time bolt calibration — a few minutes at strict speed, with progress on stderr. Later
 requests in the same process decode at full bolt speed.
 
+Update notice: `chat`/`serve` check GitHub releases at most once a day (a single GET, no
+payload — `benchtest` never touches the network) and print one line when a newer version
+exists. Disable with `QWISP_UPDATE_CHECK=0`.
+
 Build from source instead (needs Xcode 26 / Swift 6.3):
 
 ```bash

--- a/swift/Sources/qwisp/UpdateCheck.swift
+++ b/swift/Sources/qwisp/UpdateCheck.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+// Version-update notice (issue #53). A single unauthenticated GET to GitHub's
+// releases/latest — no payload, so not telemetry, but documented and opt-out anyway
+// (QWISP_UPDATE_CHECK=0). benchtest never calls this: it stays network-silent.
+//
+// All output goes to stderr — release.sh's 3b guard string-compares `qwisp version`
+// stdout against the tag, and stdout must stay a bare version string.
+enum UpdateCheck {
+    static let releasesURL = "https://api.github.com/repos/penta2himajin/qwisp/releases/latest"
+    static var stampPath: String {
+        FileManager.default.homeDirectoryForCurrentUser.path + "/.config/qwisp/last-update-check"
+    }
+
+    static var enabled: Bool { ProcessInfo.processInfo.environment["QWISP_UPDATE_CHECK"] != "0" }
+
+    /// Latest release tag ("v0.3.4" → "0.3.4"). nil on ANY failure — the check must never
+    /// surface an error of its own.
+    static func latestVersion(timeout: TimeInterval = 2) async -> String? {
+        guard let url = URL(string: releasesURL) else { return nil }
+        var req = URLRequest(url: url, timeoutInterval: timeout)
+        req.setValue("qwisp/\(Config.version)", forHTTPHeaderField: "User-Agent")
+        guard let (data, _) = try? await URLSession.shared.data(for: req),
+              let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let tag = obj["tag_name"] as? String else { return nil }
+        return tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
+    }
+
+    /// Numeric-aware dotted compare: "0.3.10" > "0.3.4".
+    static func isNewer(_ a: String, than b: String) -> Bool {
+        let pa = a.split(separator: ".").map { Int($0) ?? 0 }
+        let pb = b.split(separator: ".").map { Int($0) ?? 0 }
+        for i in 0 ..< Swift.max(pa.count, pb.count) {
+            let x = i < pa.count ? pa[i] : 0, y = i < pb.count ? pb[i] : 0
+            if x != y { return x > y }
+        }
+        return false
+    }
+
+    /// `qwisp version`: check every time (the user is explicitly asking about versions).
+    static func reportForVersionCommand() async {
+        guard enabled, let latest = await latestVersion() else { return }
+        let line = isNewer(latest, than: Config.version)
+            ? "latest: v\(latest) — upgrade with: brew upgrade qwisp"
+            : "up to date"
+        FileHandle.standardError.write(Data((line + "\n").utf8))
+    }
+
+    /// chat/serve startup: at most once per 24h (mtime stamp), fully in the background,
+    /// one stderr line only when a newer release exists.
+    static func noticeInBackground() {
+        guard enabled else { return }
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: stampPath),
+           let m = attrs[.modificationDate] as? Date, Date().timeIntervalSince(m) < 86_400 { return }
+        try? FileManager.default.createDirectory(
+            atPath: (stampPath as NSString).deletingLastPathComponent, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: stampPath, contents: nil)   // stamp first: failures also wait 24h
+        Task.detached(priority: .background) {
+            guard let latest = await latestVersion(), isNewer(latest, than: Config.version) else { return }
+            FileHandle.standardError.write(Data(
+                "[qwisp] v\(latest) is available (running \(Config.version)) — brew upgrade qwisp   (opt out: QWISP_UPDATE_CHECK=0)\n".utf8))
+        }
+    }
+
+    /// GPU-free self-check for the version compare (the only logic here worth breaking).
+    static func selfCheck() -> (Int, Int, [String]) {
+        var pass = 0
+        var log: [String] = []
+        let cases: [(String, String, Bool)] = [
+            ("0.3.4", "0.3.3", true), ("0.3.3", "0.3.3", false), ("0.3.10", "0.3.4", true),
+            ("1.0.0", "0.9.9", true), ("0.3.3", "0.3.4", false), ("0.4", "0.3.9", true),
+        ]
+        for (a, b, want) in cases {
+            let got = isNewer(a, than: b)
+            if got == want { pass += 1 } else { log.append("FAIL isNewer(\(a), \(b)) → \(got), want \(want)") }
+        }
+        return (pass, cases.count, log)
+    }
+}

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -31,6 +31,8 @@ environment:
   chat sampling (default greedy): QWISP_TEMP QWISP_TOPP QWISP_SEED
                                   QWISP_FREQPEN QWISP_PRESPEN QWISP_LOGIT_BIAS="tok:bias,…"
   note: temperature > 0 on a streaming tier (<32GB) decodes via strict — bolt is greedy-only
+  QWISP_UPDATE_CHECK=0               disable the update notice (a single GET to GitHub
+                                     releases/latest, ≤once/day on chat/serve; no payload)
 
 first run: `qwisp pull` downloads ~20GB. The first chat/serve request loads the model, and
 on <32GB machines runs a one-time bolt calibration (a few minutes; progress goes to stderr).
@@ -51,6 +53,7 @@ case "serve":
         }
         ModelStore.requireSupported(model)
     }
+    UpdateCheck.noticeInBackground()
     let modelID = URL(fileURLWithPath: model).lastPathComponent
     let tok = try await QwispTokenizer(modelDir: model)
     let backend: any LLMBackend
@@ -103,6 +106,7 @@ case "chat":
         } else {
             FileHandle.standardError.write(Data((ModelStore.missingModelHint + "\n").utf8)); exit(1)
         }
+        UpdateCheck.noticeInBackground()
         let tok = try await QwispTokenizer(modelDir: effModel)
         let backend: any LLMBackend
         if env["QWISP_FAKE"] == "1" {
@@ -137,7 +141,8 @@ case "benchtest":
     ModelStore.requireSupported(model)
     print(await runBenchtest(modelDir: model))
 case "version", "--version", "-v":
-    print(Config.version)
+    print(Config.version)   // stdout stays the bare version — release.sh 3b compares it
+    await UpdateCheck.reportForVersionCommand()
 case "selftest":
     print(await runTokenizerSelftest(modelDir: model))
 case "comptest":
@@ -149,6 +154,10 @@ case "sampletest":
 case "gpusampletest":
     let (passed, total, log) = SamplerGPU.distributionSelfCheck()   // GPU kernel vs analytic softmax (no model)
     print(log.joined(separator: "\n") + "\nGPUSAMPLETEST \(passed)/\(total)")
+    if passed != total { exit(1) }
+case "updatetest":
+    let (passed, total, log) = UpdateCheck.selfCheck()   // network-free version-compare check
+    print(log.joined(separator: "\n") + (log.isEmpty ? "" : "\n") + "UPDATETEST \(passed)/\(total)")
     if passed != total { exit(1) }
 case "configtest":
     let (passed, total, log) = Config.selfCheck()   // model/port resolution + config load (no GPU, no model)


### PR DESCRIPTION
Closes #53. Testers on old versions behave differently and never learn a fix shipped — now:

- `qwisp version`: checks GitHub releases/latest each run, verdict on **stderr** (stdout stays the bare version — release.sh's 3b guard string-compares it; verified).
- `chat`/`serve`: ≤once/24h (mtime stamp), background with a 2s budget, one stderr line only when newer exists.
- `benchtest`: never touches the network (the "sends nothing" promise holds literally).
- Opt-out `QWISP_UPDATE_CHECK=0`, documented in --help + README with the explicit note that it's a single no-payload GET.

## Verification
- `updatetest` 6/6 (version-compare self-check) · live check against the real v0.3.3 release → "up to date" · opt-out verified · CONFIGTEST 24/24 · BUILD SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM