### PR TITLE
ci(bench): conflict-free ingest pipeline (JSON-only bot PRs + regen-on-main)

### DIFF
--- a/.github/workflows/benchtest-ingest.yml
+++ b/.github/workflows/benchtest-ingest.yml
@@ -40,7 +40,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BR"
-          git add bench/
+          # ONLY the per-issue JSON goes in the PR — RESULTS.md is regenerated on main by
+          # benchtest-results.yml after merge. Bot PRs each carrying a full RESULTS.md
+          # snapshot conflicted with each other as soon as one merged (issue #64).
+          git add bench/community/
           git diff --cached --quiet && { echo "no changes to ingest"; exit 0; }
           git commit -m "data(bench): ingest benchtest report #$N"
           git push -f origin "$BR"

--- a/.github/workflows/benchtest-results.yml
+++ b/.github/workflows/benchtest-results.yml
@@ -1,0 +1,35 @@
+# Regenerate bench/RESULTS.md whenever accepted community data lands on main
+# (i.e. the owner merged a bot data PR). Commits straight to main — the merge WAS the
+# approval. The regen commit touches only bench/RESULTS.md, which does not match the
+# paths filter below, so it cannot re-trigger itself.
+name: benchtest-results
+
+on:
+  push:
+    branches: [main]
+    paths: ["bench/community/**"]
+
+concurrency:
+  group: benchtest-results
+  cancel-in-progress: false
+
+jobs:
+  regen:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: regenerate RESULTS.md
+        run: |
+          python3 scripts/benchtest_ingest.py --selftest
+          python3 scripts/benchtest_ingest.py --regen
+      - name: commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add bench/RESULTS.md
+          git diff --cached --quiet && { echo "RESULTS.md unchanged"; exit 0; }
+          git commit -m "data(bench): regenerate RESULTS.md"
+          git pull --rebase origin main
+          git push origin main


### PR DESCRIPTION
Closes #64. Bot data PRs now carry only their own `bench/community/<N>.json` — unique per report, so concurrent reports can never conflict. `benchtest-results.yml` regenerates RESULTS.md on push to main (paths-filtered to `bench/community/**`; the regen commit touches only RESULTS.md so no self-trigger; concurrency group + rebase-before-push serialize batch merges; selftest runs first).

Both workflow files validated with ruby YAML.load_file (per the 0s-parse-failure lesson from PR #44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM