### PR TITLE
docs: README Performance reflects the first community wave (5 streaming machines)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ is what we're collecting now.
 | streaming 8 GB (C=64) | bolt (default) | 73–94 tok/s | dev machine, RAM-forced (`QWISP_DEVICE_RAM=8`) — not real 8 GB hardware |
 | streaming 8 GB (C=64) | strict (`--lossless`) | 23–26 tok/s | same |
 | slow-NAND MacBook (~1.5 GB/s reads) | bolt | ~71 tok/s | SSD-throttle approximation (`QWISP_SSD_THROTTLE_GBS=1.5`) |
-| streaming 16 GB (C=128) | bolt (default) | 46–58 tok/s | **community** — M1 Pro (16c GPU) / 16 GB ([#41](https://github.com/penta2himajin/qwisp/issues/41)) |
-| streaming 16 GB (C=128) | strict (`--lossless`) | 2.3 tok/s | same — real 16 GB memory pressure is far harsher than the throttle approximation predicted |
+| streaming 16–18 GB (C=128) | bolt (default) | 20–59 tok/s | **community ×5** — M1→M3 Pro; scales with GPU cores + SSD speed ([RESULTS.md](bench/RESULTS.md)) |
+| streaming 16–18 GB (C=128) | strict (`--lossless`) | 1.5–9.8 tok/s | **community ×5** — real memory pressure is far harsher than the throttle approximation predicted; improves with RAM headroom (18 GB → 9.8) |
 | your Mac | | | **[post a row → #38](https://github.com/penta2himajin/qwisp/issues/38)** |
 
 Modes: **strict** reproduces the quantised greedy token stream bit-for-bit (default on resident;


### PR DESCRIPTION
Updates the 16–18GB streaming rows from the single #41 datapoint to the full first wave (5 machines, M1→M3 Pro): bolt 20–59 tok/s, strict 1.5–9.8 tok/s with the RAM-headroom observation. Provenance column now links the generated [bench/RESULTS.md](https://github.com/penta2himajin/qwisp/blob/main/bench/RESULTS.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM