### PR TITLE
fix(server): strict streaming right-sizes C to the machine's memory budget

### DIFF
--- a/swift/Sources/QwispCore/DeviceCalibration.swift
+++ b/swift/Sources/QwispCore/DeviceCalibration.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Metal
 import MLX
 
 /// device 別自動構成（calibration layer）。起動時に物理 RAM から mode/C/maxK を静的に決め、
@@ -51,6 +52,37 @@ public enum DeviceCalibration {
 
     /// engine 既定 C（QWISP_CACHE_C 未指定時に使う）。実効 RAM(physicalRAMGB)から tier 決定。
     public static func defaultC() -> Int { tier(physicalRAMGB()).1 }
+
+    /// C for the STRICT streaming path only (issue #69). The RAM tier's C=128 carries a
+    /// ~11.4GB wired footprint; on a real 16GB Mac that starves the page cache / GPU
+    /// working set and strict collapses ~10x (field: 1.5-3.4 tok/s on 5 machines;
+    /// ballast-sim reproduced 1.9 and C=64 recovered 6x under identical pressure).
+    /// Budget = recommendedMaxWorkingSetSize (≈ RAM×0.68 on small Macs) × 0.8 margin —
+    /// the wired ceiling that leaves the rest of RAM breathing. bolt keeps the tier C:
+    /// its frozen residency tolerates a big wired set (stable hot subset) and a smaller
+    /// C makes it LOOPY-prone (sim-measured).
+    /// Overrides: QWISP_STRICT_C (direct), QWISP_GPU_BUDGET_GB (budget, for tests/sims).
+    public static func strictStreamingC(tierC: Int) -> Int {
+        let env = ProcessInfo.processInfo.environment
+        if let o = env["QWISP_STRICT_C"], let v = Int(o) { return v }
+        let budgetGB: Double
+        if let o = env["QWISP_GPU_BUDGET_GB"], let v = Double(o) {
+            budgetGB = v
+        } else if let dev = MTLCreateSystemDefaultDevice() {
+            budgetGB = Double(dev.recommendedMaxWorkingSetSize) / 1e9
+        } else {
+            return tierC
+        }
+        return fitC(tierC: tierC, budgetGB: budgetGB)
+    }
+
+    /// Pure fitting rule (self-checked from configtest): largest C ≤ tierC, in steps of
+    /// 32 down to 64, whose estimated wired footprint fits budget×0.8.
+    public static func fitC(tierC: Int, budgetGB: Double) -> Int {
+        var c = tierC
+        while c > 64, estRSS(c) > budgetGB * 0.8 { c -= 32 }
+        return c
+    }
 
 
     /// device-config インスペクタ（モデル不要）。現機 + 各 RAM tier の構成を表示。

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -193,6 +193,15 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
             // L3, buddy remap) by default; --lossless / QWISP_LOSSLESS forces strict. Sampling
             // requests fall back to strict streaming (the bolt loop is greedy-deterministic; v1).
             let useBolt = cfg.isStreaming && !wantSample && !self.lossless
+            // Strict/sampling streaming uses a budget-fit C (issue #69): the tier C's wired
+            // footprint starves a real small-RAM Mac and collapses strict ~10x. bolt keeps
+            // cfg.c — its frozen residency needs the bigger arena and tolerates the wired set.
+            let strictC = cfg.isStreaming ? DeviceCalibration.strictStreamingC(tierC: cfg.c) : cfg.c
+            let strictMaxK = cfg.isStreaming ? Swift.max(4, strictC * 3 / 8) : cfg.maxK
+            if strictC != cfg.c && !useBolt && !samplingFallbackNoted {
+                FileHandle.standardError.write(Data(
+                    "[qwisp] strict streaming: C \(cfg.c)→\(strictC) to fit this machine's memory budget (override: QWISP_STRICT_C)\n".utf8))
+            }
             // The fallback is silent otherwise and reads as a mystery slowdown (field report,
             // issue #45): sampling skips bolt calibration (instant start) and decodes at strict
             // speed. Say so once per process.
@@ -226,7 +235,7 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                     }
                     let sb: Tell.SpecBackend? = cfg.isStreaming
                         ? Tell.streamingBackend(engine: self.engine, modelDir: self.modelDir,
-                                                maxM: cfg.maxM, maxSeqLen: maxSeqLen, C: cfg.c).map { $0.0 }
+                                                maxM: cfg.maxM, maxSeqLen: maxSeqLen, C: strictC).map { $0.0 }
                         : Tell.fusedBackend(engine: self.engine,
                                             maxM: ProcessInfo.processInfo.environment["QWISP_HYBRID_PREFILL"] != "0" ? Swift.max(cfg.maxM, 1032) : cfg.maxM,
                                             maxSeqLen: maxSeqLen)
@@ -240,7 +249,7 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                     if gpuSample {
                         // GPU sampler: temperature/top_p/penalties/logit_bias on-GPU, tiny readback.
                         // top_p lowers acceptance → narrower draft cuts forward + per-row work.
-                        let sampMaxK = options.topP < 1.0 ? Swift.min(cfg.maxK, 24) : cfg.maxK
+                        let sampMaxK = options.topP < 1.0 ? Swift.min(strictMaxK, 24) : strictMaxK
                         seg = Tell.runSpecSampleLoopGPU(promptIds: seq, backend: backend, engine: self.engine,
                                                         N: segN, maxK: sampMaxK, temperature: options.temperature,
                                                         topP: options.topP, seed: options.seed &+ UInt64(produced),
@@ -250,14 +259,14 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                     } else if wantSample {
                         // CPU sampling fallback (QWISP_SAMPLE_CPU / no head): logits readback, maxK ≤ 8.
                         seg = Tell.runSpecSampleLoop(promptIds: seq, backend: backend, engine: self.engine,
-                                                     N: segN, maxK: Swift.min(cfg.maxK, 8), temperature: options.temperature,
+                                                     N: segN, maxK: Swift.min(strictMaxK, 8), temperature: options.temperature,
                                                      topP: options.topP, seed: options.seed &+ UInt64(produced),
                                                      frequencyPenalty: options.frequencyPenalty,
                                                      presencePenalty: options.presencePenalty, logitBias: options.logitBias,
                                                      isCancelled: { cancel.isCancelled }, onToken: onTok)
                     } else {
                         seg = Tell.runSpecLoop(promptIds: seq, backend: backend, engine: self.engine,
-                                               N: segN, maxK: cfg.maxK, isCancelled: { cancel.isCancelled }, onToken: onTok)
+                                               N: segN, maxK: strictMaxK, isCancelled: { cancel.isCancelled }, onToken: onTok)
                     }
                     guard let seg, !seg.isEmpty else { break }
                     seq += seg.map { Int32($0) }

--- a/swift/Sources/qwisp/Config.swift
+++ b/swift/Sources/qwisp/Config.swift
@@ -1,4 +1,5 @@
 import Foundation
+import QwispCore
 
 // Resident-service config. `brew services` runs qwisp as a LaunchAgent, which does NOT
 // inherit the shell environment — so the model path can't come only from QWISP_MODEL.
@@ -128,6 +129,14 @@ enum Config {
         check("default lossless off",  resolveLossless(env: [:], config: empty) == false)
         check("source lossless env",   sourceOfLossless(env: ["QWISP_LOSSLESS": "1"], config: empty) == "env")
         check("source lossless config", sourceOfLossless(env: [:], config: cfg) == "config")
+
+        // strict-streaming C budget fit (issue #69): 16GB Mac (budget 10.9) → 64,
+        // 18GB (12.3) → 96, forced-approx on a big machine (48+) → tier C unchanged.
+        check("fitC 16GB → 64",   DeviceCalibration.fitC(tierC: 128, budgetGB: 10.9) == 64)
+        check("fitC 18GB → 96",   DeviceCalibration.fitC(tierC: 128, budgetGB: 12.3) == 96)
+        check("fitC big → tierC", DeviceCalibration.fitC(tierC: 128, budgetGB: 48) == 128)
+        check("fitC floor is 64", DeviceCalibration.fitC(tierC: 128, budgetGB: 1) == 64)
+        check("fitC 8GB tier stays", DeviceCalibration.fitC(tierC: 64, budgetGB: 5.4) == 64)
 
         // defaultsJSON carries the keys
         let dj = defaultsJSON()


### PR DESCRIPTION
Closes #69 — the systematic ~10x strict-streaming collapse on real 16GB Macs.

## Root cause (sim-confirmed)
The 16GB tier's C=128 carries a ~11.4GB wired footprint (RSS-verified); on a real 16GB Mac that starves the page cache / GPU working set. Reproduced locally with a **GPU working-set ballast** (37GiB wired MTLBuffers kept hot by a 10ms touch kernel): strict 29.3 → **1.9 tok/s** — dead-center of the field range (1.5–3.4). RAM-only ballast explains just ~2x.

## Fix
Strict/sampling streaming resolves C via `DeviceCalibration.strictStreamingC`: largest C (steps of 32, floor 64) with `estRSS(C) ≤ recommendedMaxWorkingSetSize × 0.8` → 16GB Mac = C 64, 18GB = 96, big machines = tier C unchanged. **bolt keeps the tier C** (frozen residency needs the arena; field-proven fine; smaller C makes it LOOPY-prone). Stderr notice on reduction; `QWISP_STRICT_C` / `QWISP_GPU_BUDGET_GB` overrides.

## Verification
| condition (forced 16GB budget) | strict before | strict after |
|---|---|---|
| no pressure | 29.3 | 25.5 (C=64 cost, expected) |
| 37GiB GPU ballast (emulated 16GB Mac) | **1.9** | **10.1 (5.3x)** |

bolt rows unchanged in all conditions. RAWTESTS 79/79 · BENCHBATCHTEST PASS · CONFIGTEST 29/29 (5 new `fitC` checks). Real-hardware confirmation: the #69 probe ask stays open — testers running `QWISP_DEVICE_RAM=8 qwisp benchtest` on v0.3.4 approximate this fix's effect today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkrZ6qBgwgbuNcC62q64DM