### PR TITLE
fix(server): serialize decode segments against the deferred async-refresh drain (#47 Part B)

### DIFF
--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -104,6 +104,15 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     public var lossless: Bool { losslessForced ?? (ProcessInfo.processInfo.environment["QWISP_LOSSLESS"] == "1") }
     private var boltServe: BoltServe? = nil
     private var samplingFallbackNoted = false
+    // Segment gate (issue #47): a new request's decode thread must wait for the previous
+    // decode thread's FULL exit. Stream teardown (consumer break / client disconnect) only
+    // requests cooperative cancellation — the old thread keeps running until its next
+    // spec-step boundary and then BoltServe's deferred async-refresh drain, and the server's
+    // AsyncLock is released at teardown, i.e. EARLIER than that exit. Unserialized, the
+    // drain's staged swaps overlap the next request's prefill/ensure() on the same providers
+    // and shared staging arenas (measured: run-to-run nondeterminism, stale-slice arena
+    // corruption, buildBuddyTable force-unwrap crash).
+    private let segGate = DispatchSemaphore(value: 1)
     let modelDir: String
     let tier: SeedlessTier
     let contextLen: Int      // model context window (max_position_embeddings); caps unbounded generation.
@@ -211,6 +220,8 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                     "[qwisp] sampling (temperature/top_p/…) on a streaming tier decodes via strict streaming — bolt is greedy-only, expect strict speed; temperature 0 restores bolt\n".utf8))
             }
             Thread.detachNewThread {
+                self.segGate.wait()           // join the previous segment's decode thread (issue #47)
+                defer { self.segGate.signal() }
                 var seq = promptIds0          // prompt + all accepted tokens so far
                 var produced = 0
                 var budget = Swift.min(baseline, Swift.max(1, ceiling))
@@ -288,6 +299,8 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
         return AsyncStream { continuation in
             continuation.onTermination = { _ in cancel.cancel() }
             Thread.detachNewThread {
+                self.segGate.wait()           // same gate as generate() — one decode thread at a time
+                defer { self.segGate.signal() }
                 // Design B: ensure the arena fits prompt + this request's generation; grow (rebuild,
                 // geometric, monotonic) if not. ponytail: unbounded/huge generations cap at
                 // prefixArenaMax (fits ≤64K total by default); >that falls through upstream. Mid-decode


### PR DESCRIPTION
## What

`SeedlessBackend.segGate` (a `DispatchSemaphore(1)`): each decode thread waits for the previous decode thread's **full** exit — including `BoltServe`'s `defer { drainAsync() }` — before touching the shared providers/staging arenas. 13 lines, one seam, covers server SSE, `complete()`, `qwisp chat`, and `benchtest`. Frozen forward path untouched.

## Why

Early stream termination (stop token / max_tokens break, client disconnect) only requests *cooperative* cancellation. The old decode thread keeps draining staged async-refresh swaps after the stream ends, while the server's AsyncLock has already been released — so the next request's prefill/`ensure()` overlaps the drain on the same `LayerExpertCache` bookkeeping and the same shared ping-pong staging arenas.

Evidence chain (full details in the two #47 investigation comments):
- **Reproduction without hardware**: `QWISP_DEVICE_RAM=8` (bolt C=64), no ballast — the #69-era "GPU pressure" hypothesis is rejected.
- **Sync/async A/B**: `QWISP_BOLT_REFRESH_ASYNC=0` → three byte-stable runs; async → nl 0.32/0.33/0.09. The nondeterminism lives in the async path.
- **Single-segment isolation**: `qwisp chat` ×3 (no following request) → byte-identical with async ON. The machinery is deterministic; the only door is the cross-segment overlap.
- **Artifacts**: 11/211 instrumented swaps installed a stale whole-expert slice (bytecheck); one run SIGTRAPed in `buildBuddyTable` (force-unwrap nil) inside the deferred drain.

## Verification

| gate | result |
|---|---|
| benchtest C=64 async ×3 + debug ×1 | **identical** rows all 4 runs: code 0.80 / nl 0.96 / long 0.00 |
| swap bytecheck (`QWISP_BOLT_DEBUG=1`) | 184/184 `mismatch=NONE` (was 11 failures) |
| nl-256 | LOOPY-variance (0.09–0.35) → deterministic **ok (0.96)** |
| RAWTESTS | 79/79 |
| BENCHBATCHTEST / TOKTEST / COMPTEST | PASS / 3/3 / 13/13 |

**Not fixed here (by design)**: long-600's now-deterministic LOOPY at C=64 = Part A (residency capacity), stays tracked in #47. Optional hardening candidate also noted there: `ExpertArena.loadMany` swallows pread errors (`try?`) — isolation testing says it wasn't the culprit, but fail-loud would be cheap insurance.

Refs #47 (Part B). Do NOT close #47 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)