### PR TITLE
feat: experiment knobs for the #47 Part A boundary sweep (QWISP_CACHE_C, QWISP_BENCHTEST_SKIP_STRICT)

### DIFF
--- a/swift/Sources/QwispCore/DeviceCalibration.swift
+++ b/swift/Sources/QwispCore/DeviceCalibration.swift
@@ -51,7 +51,14 @@ public enum DeviceCalibration {
     }
 
     /// engine 既定 C（QWISP_CACHE_C 未指定時に使う）。実効 RAM(physicalRAMGB)から tier 決定。
-    public static func defaultC() -> Int { tier(physicalRAMGB()).1 }
+    /// QWISP_CACHE_C はこのコメントが約束していた env 契約だが productization で配線が落ちて
+    /// いた（CLI は常に .auto → ここ）。#47 Part A の C 掃引・field workaround 用に復元。
+    public static func defaultC() -> Int {
+        if let v = ProcessInfo.processInfo.environment["QWISP_CACHE_C"], let c = Int(v), c > 0 {
+            return Swift.min(c, 256)
+        }
+        return tier(physicalRAMGB()).1
+    }
 
     /// C for the STRICT streaming path only (issue #69). The RAM tier's C=128 carries a
     /// ~11.4GB wired footprint; on a real 16GB Mac that starves the page cache / GPU

--- a/swift/Sources/qwisp/Benchtest.swift
+++ b/swift/Sources/qwisp/Benchtest.swift
@@ -229,7 +229,12 @@ func runBenchtest(modelDir: String) async -> String {
     }
     // Streaming tiers: measure the strict (--lossless) pair on the first prompt, so the
     // report carries the bolt-vs-strict speed ratio for this hardware.
-    if isStreaming && !lossless {
+    // QWISP_BENCHTEST_SKIP_STRICT=1 drops the pair — for bolt-focused sweeps (e.g. the
+    // #47 Part A matrix), where the strict row reuses the bolt-sized arena under memory
+    // pressure and can dominate wall-clock (~40min/row on an emulated small Mac) without
+    // informing the question. Community reports should keep the default (pair measured).
+    if isStreaming && !lossless
+        && ProcessInfo.processInfo.environment["QWISP_BENCHTEST_SKIP_STRICT"] != "1" {
         backend.losslessForced = true
         if let r = await benchRun(name: "code-256", mode: "strict", prompt: prompts[0].1,
                                   maxTokens: 256, tokenizer: tok, backend: backend) { rows.append(r) }


### PR DESCRIPTION
Two small additive knobs used by the #47 Part A (C=64 capacity LOOPY) boundary measurement:

1. **`QWISP_CACHE_C=<n>`** — wires the env override that `defaultC()`'s doc comment always promised but productization lost (the CLI only ever resolves `.auto` → RAM tier). Clamped to 256, ignored when unset/unparseable. Enables bolt C sweeps (64/80/96/112) and doubles as a field workaround knob.
2. **`QWISP_BENCHTEST_SKIP_STRICT=1`** — drops the strict pair row from benchtest. The pair reuses the bolt-sized arena; under emulated small-Mac pressure it decodes at ~0.4 tok/s (~40 min for one row) while the sweep question is bolt-only. Default (community reports) unchanged.

No behavior change when both are unset. Sweep results land in #47.

Refs #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)