### PR TITLE
fix(server): accept array-form message content (OpenAI parts) — unblocks opencode (#82)

### DIFF
--- a/swift/Sources/qwisp/ChatCompletion.swift
+++ b/swift/Sources/qwisp/ChatCompletion.swift
@@ -6,9 +6,33 @@ import QwispCore
 // adapter and the real SeedlessBackend wiring sit on top.
 
 // ── Request ────────────────────────────────────────────────────────────────
+
+/// OpenAI message `content`: the spec allows EITHER a plain string OR an array of typed
+/// parts (`[{"type":"text","text":...}, ...]`). Clients like opencode send the array form
+/// even for text-only turns (#82: `Type mismatch … expected 'String'`). Decode both,
+/// flattening text parts to one string; non-text parts (images) are dropped — qwisp is
+/// text-only, so a multimodal client at least gets its text through instead of a 4xx.
+struct MessageContent: Codable {
+    let text: String?
+    init(text: String?) { self.text = text }
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if c.decodeNil() { text = nil; return }
+        if let s = try? c.decode(String.self) { text = s; return }
+        struct Part: Codable { let type: String?; let text: String? }
+        let parts = try c.decode([Part].self)   // let a genuinely malformed content still 4xx
+        let joined = parts.compactMap { $0.type == "text" ? $0.text : nil }.joined()
+        text = joined.isEmpty ? nil : joined
+    }
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        try c.encode(text)   // round-trips as a plain string
+    }
+}
+
 struct ChatMessage: Codable {
     let role: String
-    let content: String?                // nil for assistant messages that are only tool_calls
+    let content: MessageContent?         // string OR array of parts (#82); nil for tool-only turns
     var tool_calls: [ReqToolCall]? = nil // assistant → previous function calls (history)
     var tool_call_id: String? = nil      // role:"tool" → which call this result answers
     var name: String? = nil

--- a/swift/Sources/qwisp/Config.swift
+++ b/swift/Sources/qwisp/Config.swift
@@ -162,6 +162,23 @@ enum Config {
         try? FileManager.default.removeItem(atPath: tmp + ".json")
         try? FileManager.default.removeItem(atPath: wpath)
 
+        // OpenAI message content: string, array-of-parts (opencode, #82), and null all decode.
+        func decodeReq(_ json: String) -> ChatCompletionRequest? {
+            try? JSONDecoder().decode(ChatCompletionRequest.self, from: Data(json.utf8))
+        }
+        let strForm = decodeReq(#"{"messages":[{"role":"user","content":"hi"}]}"#)
+        check("content string", strForm?.messages.first?.content?.text == "hi")
+        let arrForm = decodeReq(#"{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}"#)
+        check("content array (opencode #82)", arrForm?.messages.first?.content?.text == "hi")
+        let multiPart = decodeReq(#"{"messages":[{"role":"user","content":[{"type":"text","text":"a"},{"type":"text","text":"b"}]}]}"#)
+        check("content multi-part joins", multiPart?.messages.first?.content?.text == "ab")
+        let imgPart = decodeReq(#"{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"x"}},{"type":"text","text":"hi"}]}]}"#)
+        check("content drops non-text part", imgPart?.messages.first?.content?.text == "hi")
+        let toolOnly = decodeReq(#"{"messages":[{"role":"assistant","content":null,"tool_calls":[]}]}"#)
+        check("content null → nil", toolOnly != nil && toolOnly?.messages.first?.content?.text == nil)
+        check("content renders in dict",
+              (arrForm?.messages.first?.renderDict["content"] as? String) == "hi")
+
         return (passed, total, log)
     }
 }

--- a/swift/Sources/qwisp/Tools.swift
+++ b/swift/Sources/qwisp/Tools.swift
@@ -62,7 +62,7 @@ struct ToolCallDelta: Codable { let index: Int; let id: String?; let type: Strin
 extension ChatMessage {
     var renderDict: [String: any Sendable] {
         var d: [String: any Sendable] = ["role": role]
-        if let content { d["content"] = content }
+        if let content = content?.text { d["content"] = content }
         if let tool_calls {
             d["tool_calls"] = tool_calls.map { tc -> [String: any Sendable] in
                 let fn: [String: any Sendable] = ["name": tc.function.name,


### PR DESCRIPTION
## What

OpenAI's chat message `content` may be **either** a string **or** an array of typed parts (`[{"type":"text","text":"..."}]`). qwisp decoded only the string form, so [opencode](https://github.com/sst/opencode) — which always sends the array form — failed to connect with `Type mismatch for 'messages.1.content' key, expected 'String' type` (#82).

A `MessageContent` decoder now accepts:
- plain string → as-is
- array of parts → text parts joined; non-text (image) parts dropped (qwisp is text-only, so a multimodal client gets its text through instead of a 4xx)
- `null` → nil (assistant tool-only turns)

It re-encodes as a plain string. The only read site (`renderDict`) becomes `content?.text`; response/delta output types are untouched.

## Verification

End-to-end against a live server (`QWISP_DEVICE_RAM=8`):

| request form | before | after |
|---|---|---|
| `content: "hi"` (string) | 200 | 200 (unchanged) |
| `content: [{type:text,text:"hi"}]` (opencode) | **400 type mismatch** | **200**, `prompt_tokens` identical to string form |

Gates: CONFIGTEST 35/35 (+6 content decode cases: string / array / multi-part join / non-text drop / null / renders-in-dict), RAWTESTS 79/79, COMPTEST 13/13, TOKTEST 3/3.

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)