### PR TITLE
fix(chat): join decode thread before exit (MLX teardown race, rc 133/139)

### DIFF
--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -113,6 +113,16 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     // and shared staging arenas (measured: run-to-run nondeterminism, stale-slice arena
     // corruption, buildBuddyTable force-unwrap crash).
     private let segGate = DispatchSemaphore(value: 1)
+
+    /// Join the in-flight decode thread, if any. A consumer that breaks out of the stream
+    /// (EOS is detected consumer-side only) leaves the detached thread running — possibly a
+    /// whole segment rebuild + re-prefill with no cancellation checks — and a CLI that then
+    /// returns from main races C++ static teardown of the MLX scheduler singleton
+    /// (rc 133/139 SIGTRAP/SIGSEGV in get_default_stream, #47 handoff). Call before exit.
+    public func drain() {
+        segGate.wait()
+        segGate.signal()
+    }
     let modelDir: String
     let tier: SeedlessTier
     let contextLen: Int      // model context window (max_position_embeddings); caps unbounded generation.

--- a/swift/Sources/qwisp/ChatCompletion.swift
+++ b/swift/Sources/qwisp/ChatCompletion.swift
@@ -121,6 +121,9 @@ func runChat(prompt: String, tokenizer: QwispTokenizer, backend: any LLMBackend,
         }
     }
     fputs("\n", stdout)
+    // Exit-teardown fix (#47 handoff): join the decode thread before main returns —
+    // it outlives the EOS break above and its MLX evals race static teardown.
+    (backend as? SeedlessBackend)?.drain()
 }
 
 // ── Core ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
`qwisp chat` crashed after complete output (rc 139 SIGSEGV in `Scheduler::get_default_stream`, rc 133 SIGTRAP via `ErrorHandler` in `MLXArray.eval` — 5 matching `.ips` from 2026-07-18). Handoff "Next Action" item.

**Root cause**: EOS is detected consumer-side only (`GenerateOptions.stopTokens` is never checked in the decode loop), so the consumer's EOS break leaves the detached decode thread running — possibly mid `BoltServe.runSegment` backend rebuild + strict re-prefill, which has **no cancellation checks** (seconds of MLX evals) — while `main` returns and C++ static teardown destroys the MLX scheduler singleton under it.

**Fix** (+13 lines): `SeedlessBackend.drain()` — wait+signal on the existing `segGate`, which already brackets the decode thread's full lifetime — called at the end of `runChat`. No decode thread outlives main. Server unaffected (long-running; SIGTERM skips static destructors). Frozen forward path untouched.

**Repro note**: the race is stochastic — 0/6 interactive attempts (needs the EOS break to land inside a segment-transition window); today's w4c battery hit it 5 times with matching signatures.

## Verification
- 5 consecutive full-length chat runs → rc 0, under `QWISP_CTX_BASELINE=16` (transition-heavy, race window maximized) — the handoff's completion criterion
- `scripts/test_raw.sh` → RAWTESTS 89/89
- `scripts/test_bench_batch.sh` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)