### PR TITLE
feat(server): prefill progress + prompt-processing speed (issue #86)

### DIFF
--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -487,6 +487,12 @@ extension Tell {
 
     // ── Prefill helper ────────────────────────────────────────────────────
 
+    /// Prefill progress hook (issue #86): called with (done, total) prompt positions —
+    /// (0, total) marks a prefill run's start, then once per chunk. Long prompts on
+    /// streaming tiers prefill for minutes; the CLI/server surface this. nil = silent.
+    /// Single decode thread (segGate) → no synchronization needed.
+    nonisolated(unsafe) public static var prefillProgress: ((Int, Int) -> Void)? = nil
+
     /// Chunked prefill: runs all prompt tokens through the backend, chunk=64.
     /// Returns normed hidden of the very last position [1, H], or nil on error.
     /// mtpHead/mtpFwd (①③ Step 5): ingest prompt pairs (h_i, id_{i+1}) per chunk —
@@ -502,6 +508,7 @@ extension Tell {
         let chunkSize = backend.forwardHybrid != nil ? backend.hybridChunk : 64
         var lastNormed: MLXArray? = nil
         var pos = 0
+        prefillProgress?(0, pLen)
         while pos < pLen {
             let end = Swift.min(pos + chunkSize, pLen)
             let chunk = Array(promptIds[pos ..< end])
@@ -518,6 +525,7 @@ extension Tell {
             // Keep last row [H] — will be overwritten each chunk until the final one.
             lastNormed = normed[chunk.count - 1]    // [H]
             pos = end
+            prefillProgress?(pos, pLen)
         }
         return lastNormed.map { $0.reshaped([1, SeedlessEngine.H]) }   // [1, H]
     }

--- a/swift/Sources/qwisp/ChatCompletion.swift
+++ b/swift/Sources/qwisp/ChatCompletion.swift
@@ -96,6 +96,14 @@ struct ChatCompletionChunk: Codable {
     let choices: [ChunkChoice]
 }
 
+/// One prefill progress line (issue #86): "prefill 4096/14490 (28%) · 27 tok/s".
+/// Shared by the chat CLI (\r-overwritten) and the server log (one line / 10s).
+func prefillLine(done: Int, total: Int, secs: Double) -> String {
+    let pct = total > 0 ? done * 100 / total : 0
+    let rate = secs > 0 ? String(format: " · %.0f tok/s", Double(done) / secs) : ""
+    return "prefill \(done)/\(total) (\(pct)%)\(rate)"
+}
+
 // ── CLI (`qwisp chat`) — thin in-process wrapper over the same core ──────────
 func runChat(prompt: String, tokenizer: QwispTokenizer, backend: any LLMBackend, maxTokens: Int,
              temperature: Double = 0, topP: Double = 1.0, seed: UInt64 = 0,
@@ -103,14 +111,32 @@ func runChat(prompt: String, tokenizer: QwispTokenizer, backend: any LLMBackend,
     let promptIds: [Int]
     do { promptIds = try tokenizer.render(messages: [["role": "user", "content": prompt]]) }
     catch { fputs("chat: render error: \(error)\n", stderr); return }
+    // Prefill progress → stderr (issue #86): a long prompt on a streaming tier prefills for
+    // minutes, previously in silence. \r-overwritten; shown once a prefill run exceeds 1s.
+    // The hook runs on the (single) decode thread; stats are read after drain() below.
+    var pfRunStart: Date? = nil, pfShown = false, pfTok = 0, pfSecs = 0.0
+    Tell.prefillProgress = { done, total in
+        let now = Date()
+        if done == 0 { pfRunStart = now; return }
+        guard let t0 = pfRunStart else { return }
+        let secs = now.timeIntervalSince(t0)
+        if done == total { pfTok += total; pfSecs += secs; pfRunStart = nil }
+        if secs >= 1 {
+            pfShown = true
+            FileHandle.standardError.write(Data("\r[qwisp] \(prefillLine(done: done, total: total, secs: secs))   ".utf8))
+        }
+        if done == total && pfShown { pfShown = false; FileHandle.standardError.write(Data("\n".utf8)) }
+    }
     // Route the reasoning to stderr and the answer to stdout, so `qwisp chat … > file` captures
     // only the answer while the thinking still streams to the terminal.
     var full = "", sentR = "", sentC = ""
-    _ = await runGeneration(promptIds: promptIds, maxTokens: maxTokens, stopIds: tokenizer.stopTokenIds,
+    var tFirst: Date? = nil
+    let r = await runGeneration(promptIds: promptIds, maxTokens: maxTokens, stopIds: tokenizer.stopTokenIds,
                             decode: { tokenizer.decode($0) }, backend: backend,
                             temperature: temperature, topP: topP, seed: seed,
                             frequencyPenalty: frequencyPenalty, presencePenalty: presencePenalty,
                             logitBias: logitBias) { delta in
+        if tFirst == nil { tFirst = Date() }
         full += delta
         let (r, c) = splitThink(full)
         if r.count > sentR.count, r.hasPrefix(sentR) {
@@ -124,6 +150,13 @@ func runChat(prompt: String, tokenizer: QwispTokenizer, backend: any LLMBackend,
     // Exit-teardown fix (#47 handoff): join the decode thread before main returns —
     // it outlives the EOS break above and its MLX evals race static teardown.
     (backend as? SeedlessBackend)?.drain()
+    // Speed summary (issue #86 ask 3): prompt-processing speed alongside generation speed.
+    let pfRate = pfSecs > 0 ? Double(pfTok) / pfSecs : 0
+    let decSecs = tFirst.map { Date().timeIntervalSince($0) } ?? 0
+    let decRate = decSecs > 0 ? Double(max(0, r.completionTokens - 1)) / decSecs : 0
+    // Leading \n: the reasoning stream (stderr) ends mid-line.
+    fputs(String(format: "\n[qwisp] prompt %d tok (%.0f tok/s) · gen %d tok (%.1f tok/s)\n",
+                 promptIds.count, pfRate, r.completionTokens, decRate), stderr)
 }
 
 // ── Core ─────────────────────────────────────────────────────────────────────

--- a/swift/Sources/qwisp/Selftest.swift
+++ b/swift/Sources/qwisp/Selftest.swift
@@ -73,6 +73,10 @@ func runCompletionSelftest(modelDir: String) async -> String {
     // 8+. tool-call parsing (pure; Qwen3.6 <tool_call> → OpenAI tool_calls).
     for (name, ok) in ToolParse.selfCheck() { check("tool_\(name)", ok) }
 
+    // prefill progress line (issue #86; pure formatting).
+    check("prefill_line", prefillLine(done: 4096, total: 14490, secs: 151.7) == "prefill 4096/14490 (28%) · 27 tok/s")
+    check("prefill_line_norate", prefillLine(done: 64, total: 128, secs: 0) == "prefill 64/128 (50%)")
+
     return lines.joined(separator: "\n") + "\nCOMPTEST \(passed)/\(total)"
 }
 

--- a/swift/Sources/qwisp/Server.swift
+++ b/swift/Sources/qwisp/Server.swift
@@ -34,6 +34,36 @@ actor AsyncLock {
     }
 }
 
+// ── Prefill progress → service log (issue #86) ───────────────────────────────
+// A long prompt (e.g. an agentic client's ~15K-token system prompt) prefills for minutes on a
+// streaming tier with a silent log. Emit one progress line per ≥10s, and accumulate per-request
+// prefill tok+secs for logPerf's prefill= field. Generation is serialized (AsyncLock) and the
+// hook runs on the single decode thread, so plain statics suffice.
+enum PrefillLog {
+    nonisolated(unsafe) static var runStart: Date? = nil
+    nonisolated(unsafe) static var lastPrint = Date.distantPast
+    nonisolated(unsafe) static var tok = 0
+    nonisolated(unsafe) static var secs = 0.0
+    static func install() {
+        Tell.prefillProgress = { done, total in
+            let now = Date()
+            if done == 0 { runStart = now; return }
+            guard let t0 = runStart else { return }
+            let runSecs = now.timeIntervalSince(t0)
+            if done == total { tok += total; secs += runSecs; runStart = nil }
+            if done < total && now.timeIntervalSince(lastPrint) >= 10 {
+                lastPrint = now
+                fputs("[qwisp] \(prefillLine(done: done, total: total, secs: runSecs))\n", stderr)
+            }
+        }
+    }
+    /// Per-request read + reset (called from logPerf, after generation completes).
+    static func take() -> (tok: Int, secs: Double) {
+        defer { tok = 0; secs = 0 }
+        return (tok, secs)
+    }
+}
+
 // ── Engine: tokenizer + token-id backend, generation serialized ───────────────
 // @unchecked Sendable is justified: every path that touches the backend's mutable
 // engine/KV state runs under `lock`, so there is never concurrent access.
@@ -47,6 +77,7 @@ final class QwispEngine: @unchecked Sendable {
         self.tokenizer = tokenizer
         self.backend = backend
         self.modelID = modelID
+        PrefillLog.install()
     }
 
     /// True when the client sent a param that is still unsupported (n > 1 only —
@@ -89,8 +120,11 @@ final class QwispEngine: @unchecked Sendable {
         let st = Tell.lastSpecStats
         let tokPerStep = st.steps > 0 ? Double(st.accepted + st.steps) / Double(st.steps) : 0
         let acc = st.drafted > 0 ? 100.0 * Double(st.accepted) / Double(st.drafted) : 0
-        fputs(String(format: "[qwisp] %@ prompt=%d gen=%d ttft=%@ decode=%.1f tok/s (%.2fs) spec[steps=%d tok/step=%.2f accept=%.0f%% d0=%d rej=%d alt=%d]\n",
-                     tag, prompt, gen, ttft, rate, now.timeIntervalSince(t0), st.steps, tokPerStep, acc, st.d0, st.rejects, st.altHits), stderr)
+        // prompt-processing speed (issue #86 ask 3), summed over the request's prefill runs.
+        let pf = PrefillLog.take()
+        let pfRate = pf.secs > 0 ? String(format: "%.0f", Double(pf.tok) / pf.secs) : "-"
+        fputs(String(format: "[qwisp] %@ prompt=%d prefill=%@ tok/s gen=%d ttft=%@ decode=%.1f tok/s (%.2fs) spec[steps=%d tok/step=%.2f accept=%.0f%% d0=%d rej=%d alt=%d]\n",
+                     tag, prompt, pfRate, gen, ttft, rate, now.timeIntervalSince(t0), st.steps, tokPerStep, acc, st.d0, st.rejects, st.altHits), stderr)
     }
 
     /// Non-streaming completion.


### PR DESCRIPTION
## What

Issue #86 asks 2+3: during a long prefill nothing is reported, and prompt-processing speed is invisible. Measured at the emulated 16GB tier: a 14,490-token prompt (OpenCode-starting-prompt scale) prefills for **538s** — previously in total silence.

- **`Tell.prefillProgress`** — optional `(done, total)` hook fired from the shared chunked-prefill loop (`TellRuntime.prefill`). One call site covers strict, bolt and prefix-cache paths. `nil` by default; decode/verify untouched.
- **`qwisp chat`** — `\r`-overwritten stderr progress (`prefill 4096/14490 (28%) · 27 tok/s`) once a prefill run exceeds 1s, plus a final summary: `prompt 2416 tok (201 tok/s) · gen 24 tok (12.3 tok/s)`.
- **`qwisp serve`** — one progress line per ≥10s to the service log + a `prefill=` (prompt tok/s) field in the per-request throughput line.

## Not in scope

- Ask 1 (swap "regression"): triaged — v0.3.5..v0.3.7 contains no memory-affecting code change (13-line decode serialization + a request decoder). ~13GB serve footprint on a 16GB Mac + a coexisting client explains the swap; reply on the issue follows.
- Making streaming prefill *fast* — that's #76 (prefix cache on streaming tiers).

## Gates

RAWTESTS 89/89 · COMPTEST 15/15 (+2 prefill-line checks) · TOKTEST 3/3 · BENCHBATCHTEST PASS.
E2E: 2.4K-token chat at `QWISP_DEVICE_RAM=16` shows live progress + summary; fake-backend serve logs `prefill=-`.

Refs #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)