### PR TITLE
feat(server): chat_template_kwargs (enable_thinking=false) + chat --no-thinking

### DIFF
--- a/swift/Sources/qwisp/ChatCompletion.swift
+++ b/swift/Sources/qwisp/ChatCompletion.swift
@@ -54,6 +54,24 @@ struct ChatCompletionRequest: Codable {
     let logit_bias: [String: Double]?   // OpenAI: token-id string → bias
     var tools: [Tool]? = nil            // function-calling tool specs
     var tool_choice: JSONValue? = nil   // accepted; the model decides (auto)
+    // Extra Jinja variables for the chat template (issue #77), e.g.
+    // {"enable_thinking": false} — the Qwen3.6 template then pre-closes the think block.
+    var chat_template_kwargs: [String: JSONValue]? = nil
+}
+
+extension ChatCompletionRequest {
+    /// chat_template_kwargs.enable_thinking == false (issue #77): the template emits an empty
+    /// `<think>\n\n</think>` in the generation prompt, so the model's output IS the answer —
+    /// splitThink must be bypassed (no `</think>` will ever appear in the output).
+    var thinkingDisabled: Bool {
+        if case .bool(false) = chat_template_kwargs?["enable_thinking"] { return true }
+        return false
+    }
+}
+
+/// splitThink, unless thinking is disabled for this request — then all output is content.
+func splitOutput(_ s: String, thinkingDisabled: Bool) -> (reasoning: String, content: String) {
+    thinkingDisabled ? ("", s) : splitThink(s)
 }
 
 // Qwen3.6 is a reasoning model: the chat template injects `<think>` into the generation prompt,
@@ -107,9 +125,11 @@ func prefillLine(done: Int, total: Int, secs: Double) -> String {
 // ── CLI (`qwisp chat`) — thin in-process wrapper over the same core ──────────
 func runChat(prompt: String, tokenizer: QwispTokenizer, backend: any LLMBackend, maxTokens: Int,
              temperature: Double = 0, topP: Double = 1.0, seed: UInt64 = 0,
-             frequencyPenalty: Double = 0, presencePenalty: Double = 0, logitBias: [Int: Double] = [:]) async {
+             frequencyPenalty: Double = 0, presencePenalty: Double = 0, logitBias: [Int: Double] = [:],
+             noThinking: Bool = false) async {
     let promptIds: [Int]
-    do { promptIds = try tokenizer.render(messages: [["role": "user", "content": prompt]]) }
+    do { promptIds = try tokenizer.render(messages: [["role": "user", "content": prompt]],
+                                          additionalContext: noThinking ? ["enable_thinking": false] : nil) }
     catch { fputs("chat: render error: \(error)\n", stderr); return }
     // Prefill progress → stderr (issue #86): a long prompt on a streaming tier prefills for
     // minutes, previously in silence. \r-overwritten; shown once a prefill run exceeds 1s.
@@ -138,7 +158,7 @@ func runChat(prompt: String, tokenizer: QwispTokenizer, backend: any LLMBackend,
                             logitBias: logitBias) { delta in
         if tFirst == nil { tFirst = Date() }
         full += delta
-        let (r, c) = splitThink(full)
+        let (r, c) = splitOutput(full, thinkingDisabled: noThinking)
         if r.count > sentR.count, r.hasPrefix(sentR) {
             FileHandle.standardError.write(Data(String(r.dropFirst(sentR.count)).utf8)); sentR = r
         }

--- a/swift/Sources/qwisp/QwispTokenizer.swift
+++ b/swift/Sources/qwisp/QwispTokenizer.swift
@@ -37,12 +37,16 @@ struct QwispTokenizer {
 
     /// Render chat messages (+ optional tool specs) → token ids (chat_template + generation prompt).
     /// Messages/tools are `[String: any Sendable]` so they can carry tool_calls, tool results, and
-    /// arbitrary tool JSON schemas through to the Jinja template.
+    /// arbitrary tool JSON schemas through to the Jinja template. `additionalContext` feeds extra
+    /// Jinja variables (issue #77: chat_template_kwargs, e.g. enable_thinking=false); nil renders
+    /// byte-identically to the previous signature.
     func render(messages: [[String: any Sendable]], tools: [[String: any Sendable]]? = nil,
-                addGenerationPrompt: Bool = true) throws -> [Int] {
+                addGenerationPrompt: Bool = true,
+                additionalContext: [String: any Sendable]? = nil) throws -> [Int] {
         let ct: ChatTemplateArgument? = chatTemplate.map { .literal($0) }
         return try tokenizer.applyChatTemplate(messages: messages, chatTemplate: ct,
                                                addGenerationPrompt: addGenerationPrompt, truncation: false,
-                                               maxLength: nil, tools: tools)
+                                               maxLength: nil, tools: tools,
+                                               additionalContext: additionalContext)
     }
 }

--- a/swift/Sources/qwisp/Selftest.swift
+++ b/swift/Sources/qwisp/Selftest.swift
@@ -77,6 +77,18 @@ func runCompletionSelftest(modelDir: String) async -> String {
     check("prefill_line", prefillLine(done: 4096, total: 14490, secs: 151.7) == "prefill 4096/14490 (28%) · 27 tok/s")
     check("prefill_line_norate", prefillLine(done: 64, total: 128, secs: 0) == "prefill 64/128 (50%)")
 
+    // chat_template_kwargs (issue #77; pure decode + split routing).
+    let kwReq = try? JSONDecoder().decode(ChatCompletionRequest.self, from: Data(
+        #"{"messages":[{"role":"user","content":"hi"}],"chat_template_kwargs":{"enable_thinking":false}}"#.utf8))
+    check("kwargs_thinking_disabled", kwReq?.thinkingDisabled == true)
+    let plainReq = try? JSONDecoder().decode(ChatCompletionRequest.self, from: Data(
+        #"{"messages":[{"role":"user","content":"hi"}]}"#.utf8))
+    check("kwargs_omitted_thinking_on", plainReq?.thinkingDisabled == false)
+    let so = splitOutput("The direct answer.", thinkingDisabled: true)
+    check("split_nothink_all_content", so.content == "The direct answer." && so.reasoning.isEmpty)
+    let so2 = splitOutput("pondering</think>\nAnswer.", thinkingDisabled: false)
+    check("split_think_unchanged", so2.reasoning == "pondering" && so2.content == "Answer.")
+
     return lines.joined(separator: "\n") + "\nCOMPTEST \(passed)/\(total)"
 }
 
@@ -117,6 +129,20 @@ func runTokenizerSelftest(modelDir: String) async -> String {
     check("chat_template_preserves_content") {
         let ids = try tok.render(messages: [["role": "user", "content": "MAGICWORD42"]])
         return tok.decode(ids).contains("MAGICWORD42")
+    }
+    // issue #77: enable_thinking=false pre-closes the think block in the generation prompt;
+    // nil additionalContext must render byte-identically to the plain signature.
+    check("template_enable_thinking_false") {
+        let msgs: [[String: any Sendable]] = [["role": "user", "content": "Hi"]]
+        let off = try tok.render(messages: msgs, additionalContext: ["enable_thinking": false])
+        let raw = tok.tokenizer.decode(tokens: off, skipSpecialTokens: false)
+        return raw.hasSuffix("<think>\n\n</think>\n\n")
+    }
+    check("template_default_thinking_on") {
+        // Omitted kwargs keep the old behavior: generation prompt opens an unclosed think block.
+        let msgs: [[String: any Sendable]] = [["role": "user", "content": "Hi"]]
+        let ids = try tok.render(messages: msgs)
+        return tok.tokenizer.decode(tokens: ids, skipSpecialTokens: false).hasSuffix("<think>\n")
     }
 
     return lines.joined(separator: "\n") + "\nTOKTEST \(passed)/\(total)"

--- a/swift/Sources/qwisp/Server.swift
+++ b/swift/Sources/qwisp/Server.swift
@@ -103,9 +103,12 @@ final class QwispEngine: @unchecked Sendable {
     private func prompt(_ req: ChatCompletionRequest) throws -> (ids: [Int], maxTokens: Int, stop: [Int], contentLen: Int) {
         let msgs = req.messages.map { $0.renderDict }
         let tools = req.tools?.map { $0.spec }
-        let ids = try tokenizer.render(messages: msgs, tools: tools)
+        // chat_template_kwargs (issue #77) → extra Jinja variables, e.g. enable_thinking:false.
+        let kwargs = req.chat_template_kwargs.map { $0.mapValues { $0.sendable } }
+        let ids = try tokenizer.render(messages: msgs, tools: tools, additionalContext: kwargs)
         // Content boundary (prompt WITHOUT the generation-prompt suffix) → the prefix-cache reuse point.
-        let contentLen = (try? tokenizer.render(messages: msgs, tools: tools, addGenerationPrompt: false).count) ?? ids.count
+        let contentLen = (try? tokenizer.render(messages: msgs, tools: tools, addGenerationPrompt: false,
+                                                additionalContext: kwargs).count) ?? ids.count
         return (ids, req.max_tokens ?? -1, tokenizer.stopTokenIds, contentLen)   // omitted → until EOS/context
     }
 
@@ -141,7 +144,7 @@ final class QwispEngine: @unchecked Sendable {
         await lock.release()
         logPerf("complete", prompt: p.ids.count, gen: r.completionTokens, t0: t0, tFirst: tFirst)
         let id = "chatcmpl-\(UUID().uuidString.prefix(24))"
-        let (reasoning, afterThink) = splitThink(r.text)
+        let (reasoning, afterThink) = splitOutput(r.text, thinkingDisabled: req.thinkingDisabled)
         let (content, toolCalls) = ToolParse.parse(afterThink)
         let finish = toolCalls.isEmpty ? r.finishReason : "tool_calls"
         return ChatCompletionResponse(
@@ -184,7 +187,7 @@ final class QwispEngine: @unchecked Sendable {
             outIds.append(tok)
             if tFirst == nil { tFirst = Date() }
             // Split thinking from answer: reasoning → delta.reasoning_content, answer → delta.content.
-            let (r, afterThink) = splitThink(tokenizer.decode(outIds))
+            let (r, afterThink) = splitOutput(tokenizer.decode(outIds), thinkingDisabled: req.thinkingDisabled)
             if r.count > sentR.count, r.hasPrefix(sentR) {
                 try await send(Delta(reasoning_content: String(r.dropFirst(sentR.count))), nil); sentR = r
             }
@@ -196,7 +199,7 @@ final class QwispEngine: @unchecked Sendable {
             if p.maxTokens >= 0 && outIds.count >= p.maxTokens { finish = "length"; break }  // <0 = until EOS/context
         }
         // Buffered tool calls: parse the completed output and emit them as tool_calls deltas.
-        let (_, toolCalls) = ToolParse.parse(splitThink(tokenizer.decode(outIds)).content)
+        let (_, toolCalls) = ToolParse.parse(splitOutput(tokenizer.decode(outIds), thinkingDisabled: req.thinkingDisabled).content)
         for (i, tc) in toolCalls.enumerated() {
             try await send(Delta(tool_calls: [ToolCallDelta(index: i, id: tc.id, type: "function", function: tc.function)]), nil)
         }

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -20,6 +20,7 @@ usage: qwisp <command> [options]
   chat [opts] <prompt>   one-shot chat; reads stdin if no prompt is given
       --max-tokens N     cap generation (default: until EOS / context)
       --lossless         force strict bit-exact mode (streaming tiers default to bolt)
+      --no-thinking      skip the <think> phase (enable_thinking=false; answers start immediately)
   pull [hf-repo-id]      download a checkpoint (default: Qwen3.6-35B-A3B MTPLX) + write config
   config [--defaults]    show effective settings / the full default set
   benchtest              community benchmark → markdown report + one-click submit URL
@@ -81,6 +82,8 @@ case "chat":
     var maxTokens = -1
     var chatLossless = Config.resolveLossless(env: ProcessInfo.processInfo.environment, config: qwispConfig)
     if let i = rest.firstIndex(of: "--lossless") { chatLossless = true; rest.remove(at: i) }
+    var noThinking = false   // issue #77: enable_thinking=false via the chat template
+    if let i = rest.firstIndex(of: "--no-thinking") { noThinking = true; rest.remove(at: i) }
     if let i = rest.firstIndex(where: { $0 == "--max-tokens" || $0.hasPrefix("--max-tokens=") }) {
         let flag = rest[i]
         if let eq = flag.firstIndex(of: "=") {
@@ -134,7 +137,8 @@ case "chat":
         }
         await runChat(prompt: prompt, tokenizer: tok, backend: backend, maxTokens: maxTokens,
                       temperature: temp, topP: topP, seed: seed,
-                      frequencyPenalty: freqPen, presencePenalty: presPen, logitBias: bias)
+                      frequencyPenalty: freqPen, presencePenalty: presPen, logitBias: bias,
+                      noThinking: noThinking)
     }
 case "benchtest":
     // Community benchmark (call-for-testers): env + tiered speed/stability, markdown to stdout.


### PR DESCRIPTION
## What

Closes #77. The server now honors `"chat_template_kwargs": {"enable_thinking": false}` (previously silently dropped), and `qwisp chat` gains `--no-thinking` on the same plumbing.

- **Plumbing**: `ChatCompletionRequest.chat_template_kwargs: [String: JSONValue]` → `QwispTokenizer.render(additionalContext:)` → swift-transformers `applyChatTemplate` Jinja context. The model's `chat_template.jinja` (L149) already honors it.
- **Output routing (the non-obvious part)**: with `enable_thinking:false` the template pre-closes the think block in the generation prompt, so the model output never contains `</think>` — `splitThink` would misroute the entire answer into `reasoning_content` (empty `content`, exactly the failure OpenCode users would hit). `splitOutput()` bypasses the split for such requests across complete/SSE/tool-call parsing.
- Omitted kwargs: byte-identical rendering + unchanged split behavior.

## Why it matters

On streaming tiers (~20 tok/s) thinking tokens are the most expensive tokens a user can spend. Measured during #86 triage: a default request burned all 128 max_tokens inside `<think>` and returned empty `content`.

## Verification

GPU-free (on battery — engine untouched, QwispCore has no diff):
- COMPTEST 19/19 (+4: kwargs decode, thinkingDisabled, split routing both ways)
- TOKTEST 5/5 (+2: rendered prompt ends `<think>\n\n</think>\n\n` with kwargs; default still ends `<think>\n`)
- BENCHBATCHTEST PASS
- Fake-backend serve E2E: kwargs request → answer in `content` / `reasoning_content` null; default request unchanged.

**Pending on AC power before merge**: real-model e2e (issue acceptance: output starts without `<think>`, prompt renders with empty think block) + RAWTESTS run for gate discipline.

Refs #86 (empty-content symptom observed there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)