### PR TITLE
feat(streaming): disk persistence for the prefix cache (QWISP_PREFIX_PERSIST, opt-in) — #89

### DIFF
--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -458,13 +458,26 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                 // conversation sharing the system+tools prefix restores a sub-content boundary instead
                 // of re-prefilling it. Boundaries past the divergence point are stale → drop them.
                 let lcp = SeedlessBackend.commonPrefixLen(content, self.arenaContent)
-                let restoreLen = self.prefixSlots.last(where: { $0.len <= lcp })?.len ?? 0
+                var restoreLen = self.prefixSlots.last(where: { $0.len <= lcp })?.len ?? 0
                 if restoreLen > 0, let s = self.prefixSlots.last(where: { $0.len == restoreLen })?.snap {
                     backend.fullRestore?(s)
+                } else if PrefixPersist.enabled,
+                          let hit = PrefixPersist.bestMatch(modelDir: self.modelDir, content: content),
+                          backend.restorePersistentState?(hit.state) == true {
+                    // #89 (opt-in): no in-memory restore point — cross-process warm start from
+                    // disk. The restore wrote the KV bytes + GDN state into THIS arena, so the
+                    // arena path IS hit.tokens now; seed one in-memory slot at that boundary.
+                    self.arenaContent = Array(hit.tokens)
+                    self.prefixSlots = []
+                    if let snap = backend.fullSnapshot?() {
+                        self.prefixSlots = [(len: hit.tokens.count, snap: snap)]
+                    }
+                    restoreLen = hit.tokens.count
+                    PrefixPersist.restoreHits += 1
                 } else if let e = self.prefixEmptySnap {
                     backend.fullRestore?(e)
                 }
-                self.prefixSlots.removeAll { $0.len > lcp }
+                self.prefixSlots.removeAll { $0.len > Swift.max(lcp, restoreLen) }
 
                 // Re-prefill the delta [restoreLen ..< contentLen], snapshotting at stride-aligned
                 // boundaries (so different conversations that share a prefix snapshot at the SAME
@@ -482,6 +495,15 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                 self.prefixSlots.sort { $0.len < $1.len }
                 self.evictSlots()
                 self.arenaContent = content
+                // #89 (opt-in): persist the content-boundary state for cross-process reuse.
+                // The state is exactly at the boundary here (gen-suffix prefill comes next);
+                // persistentState() is a CPU copy of shared buffers, the file write is async.
+                if PrefixPersist.enabled, let blob = backend.persistentState?() {
+                    let model = self.modelDir
+                    DispatchQueue.global(qos: .utility).async {
+                        PrefixPersist.save(modelDir: model, tokens: content, state: blob)
+                    }
+                }
 
                 // Prefill the generation-prompt suffix + decode. prefillTokens = suffix (arena already
                 // holds content); hist = the full prompt so SuffixSpec drafting is unchanged.

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -177,6 +177,66 @@ extension Tell {
         return lines.joined(separator: "\n")
     }
 
+    // #89 gate: PREFIXE2E with a simulated process restart. R1 warms the cache and persists
+    // the content boundary to disk; resetPrefixCache() is the fresh-process equivalent (arena,
+    // providers, in-memory slots all dropped — only the DISK store survives); R2 (extends R1)
+    // must then restore from disk and produce a stream byte-identical to the cache-off path.
+    // restoreHits asserts the disk restore actually fired (byte-identity alone can't tell
+    // "restored" from "silently re-prefilled cold"). QWISP_PREFIX_E2E_C as in prefixCacheE2E.
+    public static func prefixPersistE2E(modelDir: String) -> String {
+        let ec = Tell.envInt("QWISP_PREFIX_E2E_C", 0)
+        let tier: SeedlessTier = ec > 0 ? .streaming(c: ec) : .auto
+        guard let backend = try? SeedlessBackend(modelDir: modelDir, tier: tier) else { return "[prefix-persist-e2e] load fail\nPREFIXPERSISTE2E FAIL" }
+        if ec > 0 { backend.losslessForced = true }
+        let store = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("qwisp-prefix-persist-e2e-\(ProcessInfo.processInfo.processIdentifier)")
+        setenv("QWISP_PREFIX_PERSIST_DIR", store.path, 1)
+        defer { unsetenv("QWISP_PREFIX_PERSIST_DIR"); try? FileManager.default.removeItem(at: store) }
+
+        func toks(_ n: Int, _ salt: Int) -> [Int] { (0..<n).map { (($0 &* 7 &+ salt) % 5000) + 100 } }
+        let c1 = toks(256, 13) + toks(32, 1)
+        let c2 = c1 + toks(40, 2)                    // continues the conversation across the "restart"
+        func req(_ content: [Int]) -> (prompt: [Int], cl: Int) { (content + toks(8, 777), content.count) }
+        let (p1, cl1) = req(c1), (p2, cl2) = req(c2)
+        let maxTok = 24
+
+        final class Box: @unchecked Sendable { var v: [Int] = [] }
+        func gen(_ p: [Int], _ cl: Int) -> [Int] {
+            let box = Box()
+            let sem = DispatchSemaphore(value: 0)
+            let stream = backend.generate(p, options: GenerateOptions(maxTokens: maxTok, promptContentLen: cl))
+            Task { for await t in stream { box.v.append(t) }; sem.signal() }
+            sem.wait()
+            return box.v
+        }
+
+        // Reference: cache OFF (segmented cold path).
+        backend.prefixCacheForced = false
+        let ref2 = gen(p2, cl2)
+        // Persisted run: R1 (cache on + persist writes disk async) → wait for the file →
+        // reset (= restart) → R2 restores from disk.
+        setenv("QWISP_PREFIX_PERSIST", "1", 1)
+        defer { unsetenv("QWISP_PREFIX_PERSIST") }
+        backend.prefixCacheForced = true
+        backend.resetPrefixCache()
+        _ = gen(p1, cl1)
+        var waited = 0.0
+        while waited < 15 {                          // async save → poll for the artifact
+            if let n = try? FileManager.default.contentsOfDirectory(atPath: store.path).count, n > 0 { break }
+            Thread.sleep(forTimeInterval: 0.2); waited += 0.2
+        }
+        backend.resetPrefixCache()                   // "restart": only the disk store survives
+        let hits0 = PrefixPersist.restoreHits
+        let got2 = gen(p2, cl2)
+        let restored = PrefixPersist.restoreHits > hits0
+        let identical = got2 == ref2
+        var lines = ["[prefix-persist-e2e] tier=\(ec > 0 ? "streaming C=\(ec)" : "resident"), maxTok=\(maxTok)"]
+        lines.append("  restart-continue  ref=\(ref2.count)tok  restored=\(got2.count)tok  \(identical ? "IDENTICAL ✅" : "DIVERGE ❌")  diskRestore=\(restored ? "HIT" : "MISS ❌")")
+        if !identical { lines.append("    ref: \(ref2.prefix(12))"); lines.append("    got: \(got2.prefix(12))") }
+        lines.append("PREFIXPERSISTE2E \(identical && restored ? "PASS" : "FAIL")")
+        return lines.joined(separator: "\n")
+    }
+
     // Speed probe for the multi-slot cache: TTFT (time-to-first-token) for a cold request vs a
     // cross-conversation request that shares a large prefix vs an intra-conversation extend.
     // Shows the multi-slot win = skipping re-prefill of the shared system+tools prefix on a NEW convo.

--- a/swift/Sources/QwispCore/PrefixPersist.swift
+++ b/swift/Sources/QwispCore/PrefixPersist.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+// Disk persistence for the cross-request prefix cache (issue #89, follow-up to #76).
+//
+// The in-process cache dies with the process: `qwisp chat` one-shots, service restarts on
+// update, and reboots all re-pay full prefill (streaming prefill is the expensive kind —
+// per-chunk expert IO). This store writes the content-boundary decode state (attention KV
+// used slice + GDN state, via SeedlessFusedForward.persistentStateData) keyed by
+// model + exact token prefix, and restores the longest stored prefix of a new request's
+// content in a fresh process.
+//
+// Doctrine (same as #73): any key mismatch invalidates; restore is verified structurally
+// (shape-checked per layer) and the strict path's losslessness is gated by
+// PREFIXE2E-with-restart before any default flip.
+//
+// Opt-in: QWISP_PREFIX_PERSIST=1 (default OFF until fidelity + footprint data).
+// Caps: QWISP_PREFIX_PERSIST_SLOTS files (LRU by mtime, default 4),
+//       QWISP_PREFIX_PERSIST_MAX_MB per artifact (default 512 — skip larger saves).
+public enum PrefixPersist {
+
+    static let magic: UInt32 = 0x3150_5751          // "QWP1" LE
+    static let format: UInt32 = 1
+
+    public static var enabled: Bool { Tell.envInt("QWISP_PREFIX_PERSIST", 0) != 0 }
+    static var maxSlots: Int { Swift.max(1, Tell.envInt("QWISP_PREFIX_PERSIST_SLOTS", 4)) }
+    static var maxBytes: Int { Swift.max(1, Tell.envInt("QWISP_PREFIX_PERSIST_MAX_MB", 512)) * 1_048_576 }
+
+    static var defaultDir: URL {
+        if let p = ProcessInfo.processInfo.environment["QWISP_PREFIX_PERSIST_DIR"] {
+            return URL(fileURLWithPath: p)     // test/gate isolation hook
+        }
+        return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".cache/qwisp/prefix")
+    }
+
+    /// Diagnostics: number of successful cross-process (disk) restores this process.
+    /// The restart gate asserts this increments — byte-identity alone can't distinguish
+    /// "restored" from "silently re-prefilled cold".
+    nonisolated(unsafe) public static var restoreHits = 0
+
+    static func fnv1a(_ bytes: some Sequence<UInt8>) -> UInt64 {
+        var h: UInt64 = 0xcbf2_9ce4_8422_2325
+        for b in bytes { h = (h ^ UInt64(b)) &* 0x0000_0100_0000_01b3 }
+        return h
+    }
+
+    static func url(dir: URL, modelDir: String, tokens: [Int32]) -> URL {
+        var id = Array(modelDir.utf8)
+        for t in tokens { withUnsafeBytes(of: t.littleEndian) { id.append(contentsOf: $0) } }
+        return dir.appendingPathComponent(String(format: "prefix-%016llx.bin", fnv1a(id)))
+    }
+
+    // File layout: magic ∥ format ∥ modelLen u32 ∥ model utf8 ∥ tokenCount u32 ∥
+    //              tokens Int32 LE ∥ state blob (SeedlessFusedForward layout, opaque here).
+    static func encode(modelDir: String, tokens: [Int32], state: Data) -> Data {
+        var d = Data()
+        func u32(_ v: UInt32) { withUnsafeBytes(of: v.littleEndian) { d.append(contentsOf: $0) } }
+        let m = Data(modelDir.utf8)
+        u32(magic); u32(format); u32(UInt32(m.count))
+        d.append(m)
+        u32(UInt32(tokens.count))
+        tokens.withUnsafeBufferPointer { p in p.baseAddress.map { d.append(Data(bytes: $0, count: tokens.count * 4)) } }
+        d.append(state)
+        return d
+    }
+
+    /// Parse header + tokens (cheap; `wantState` false skips materializing the blob).
+    static func decode(_ d: Data, wantState: Bool) -> (model: String, tokens: [Int32], state: Data)? {
+        var off = 0
+        func u32() -> UInt32? {
+            guard d.count >= off + 4 else { return nil }
+            let v = d.subdata(in: off ..< off + 4).withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+            off += 4
+            return UInt32(littleEndian: v)
+        }
+        guard u32() == magic, u32() == format,
+              let ml = u32().map(Int.init), d.count >= off + ml,
+              let model = String(data: d.subdata(in: off ..< off + ml), encoding: .utf8) else { return nil }
+        off += ml
+        guard let tc = u32().map(Int.init), d.count >= off + tc * 4 else { return nil }
+        let tokens: [Int32] = d.subdata(in: off ..< off + tc * 4).withUnsafeBytes { Array($0.bindMemory(to: Int32.self)) }
+        off += tc * 4
+        return (model, tokens, wantState ? d.subdata(in: off ..< d.count) : Data())
+    }
+
+    /// Persist one content-boundary state. Skips oversized blobs; LRU-evicts beyond maxSlots.
+    public static func save(modelDir: String, tokens: [Int32], state: Data, dir: URL? = nil) {
+        guard state.count <= maxBytes, !tokens.isEmpty else { return }
+        let d = dir ?? defaultDir
+        let fm = FileManager.default
+        try? fm.createDirectory(at: d, withIntermediateDirectories: true)
+        let u = url(dir: d, modelDir: modelDir, tokens: tokens)
+        // Same key = same content: refresh mtime for LRU, skip the (large) rewrite.
+        if fm.fileExists(atPath: u.path) {
+            try? fm.setAttributes([.modificationDate: Date()], ofItemAtPath: u.path)
+            return
+        }
+        try? encode(modelDir: modelDir, tokens: tokens, state: state).write(to: u, options: .atomic)
+        evict(dir: d)
+    }
+
+    /// The stored entry whose token sequence is the LONGEST prefix of `content` (this model).
+    public static func bestMatch(modelDir: String, content: [Int32], dir: URL? = nil) -> (tokens: [Int32], state: Data)? {
+        let d = dir ?? defaultDir
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(at: d, includingPropertiesForKeys: nil) else { return nil }
+        var best: (url: URL, tokens: [Int32])? = nil
+        for f in files where f.pathExtension == "bin" {
+            guard let data = try? Data(contentsOf: f),
+                  let (model, tokens, _) = decode(data, wantState: false),
+                  model == modelDir, tokens.count <= content.count,
+                  tokens.count > (best?.tokens.count ?? 0),
+                  Array(content[0 ..< tokens.count]) == tokens else { continue }
+            best = (f, tokens)
+        }
+        guard let best, let data = try? Data(contentsOf: best.url),
+              let (_, tokens, state) = decode(data, wantState: true) else { return nil }
+        try? fm.setAttributes([.modificationDate: Date()], ofItemAtPath: best.url.path)   // LRU touch
+        return (tokens, state)
+    }
+
+    static func evict(dir: URL) {
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: [.contentModificationDateKey]) else { return }
+        let bins = files.filter { $0.pathExtension == "bin" }
+        guard bins.count > maxSlots else { return }
+        let dated = bins.map { f -> (URL, Date) in
+            ((f, (try? f.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast))
+        }.sorted { $0.1 < $1.1 }
+        for (f, _) in dated.prefix(bins.count - maxSlots) { try? fm.removeItem(at: f) }
+    }
+
+    /// Pure self-check (no GPU, tmp dir): round trip, longest-prefix match, model isolation, LRU.
+    public static func selfCheck() -> [(String, Bool)] {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("qwisp-prefix-selfcheck-\(ProcessInfo.processInfo.processIdentifier)")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let state = Data((0 ..< 64).map { UInt8($0) })
+        let a: [Int32] = [1, 2, 3, 4], ab: [Int32] = [1, 2, 3, 4, 5, 6]
+        save(modelDir: "/m", tokens: a, state: state, dir: tmp)
+        save(modelDir: "/m", tokens: ab, state: state + state, dir: tmp)
+        save(modelDir: "/other", tokens: ab + [7], state: state, dir: tmp)
+        let hitLong = bestMatch(modelDir: "/m", content: ab + [9, 9], dir: tmp)
+        let hitShort = bestMatch(modelDir: "/m", content: [1, 2, 3, 4, 99], dir: tmp)
+        let missDiverge = bestMatch(modelDir: "/m", content: [8, 8, 8], dir: tmp)
+        var checks: [(String, Bool)] = [
+            ("longest_prefix", hitLong?.tokens == ab && hitLong?.state == state + state),
+            ("shorter_prefix", hitShort?.tokens == a && hitShort?.state == state),
+            ("model_isolation", bestMatch(modelDir: "/nope", content: ab, dir: tmp) == nil),
+            ("miss_diverge", missDiverge == nil),
+        ]
+        // LRU: with maxSlots files already present, adding more evicts the oldest.
+        for i in 0 ..< maxSlots + 2 {
+            save(modelDir: "/m", tokens: [100, Int32(i)], state: state, dir: tmp)
+        }
+        let n = (try? FileManager.default.contentsOfDirectory(at: tmp, includingPropertiesForKeys: nil).filter { $0.pathExtension == "bin" }.count) ?? -1
+        checks.append(("lru_cap", n == maxSlots))
+        return checks
+    }
+}

--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -3832,6 +3832,92 @@ public enum SeedlessFusedVerify {
             }
         }
 
+        // ── Disk-persistable state (issue #89) ────────────────────────────────────────
+        // Unlike FullSnapshot (kv LEN only — the bytes live in this forward's arena), this
+        // serializes the actual per-layer decode state so a NEW process can restore it into
+        // a freshly built forward: attention KV used slice (per-head gather from the
+        // head-major arena; maxLen may differ between save and restore) + GDN convHist/state
+        // (current ping-pong side, mirroring writeGdnCache). All buffers are
+        // .storageModeShared → plain CPU memcpy, no GPU work. Additive — decode untouched.
+        // Layout: "QWS1" u32 ∥ format u32 ∥ nLayers u32, then per layer:
+        //   flags u32 (bit0 KV, bit1 GDN)
+        //   KV:  u32 KV,D,len ∥ k bytes (KV·len·D·2) ∥ v bytes
+        //   GDN: u32 convCount,stateCount ∥ convHist bytes (·2) ∥ state bytes (·4)
+        static let persistMagic: UInt32 = 0x3153_5751   // "QWS1" LE
+        static let persistFormat: UInt32 = 1
+
+        public func persistentStateData() -> Data {
+            var d = Data()
+            func u32(_ v: UInt32) { withUnsafeBytes(of: v.littleEndian) { d.append(contentsOf: $0) } }
+            u32(Self.persistMagic); u32(Self.persistFormat); u32(UInt32(layers.count))
+            for L in layers {
+                let flags: UInt32 = (L.kvCache != nil ? 1 : 0) | (L.gdnCache != nil ? 2 : 0)
+                u32(flags)
+                if let kv = L.kvCache {
+                    u32(UInt32(kv.KV)); u32(UInt32(kv.D)); u32(UInt32(kv.len))
+                    let rowBytes = kv.len * kv.D * 2
+                    for buf in [kv.kCache, kv.vCache] {
+                        let base = buf.contents()
+                        for h in 0 ..< kv.KV {
+                            d.append(Data(bytes: base + h * kv.maxLen * kv.D * 2, count: rowBytes))
+                        }
+                    }
+                }
+                if let gc = L.gdnCache {
+                    let convCount = (gc.K - 1) * gc.C, stateCount = gc.Hv * gc.Dv * gc.Dk
+                    u32(UInt32(convCount)); u32(UInt32(stateCount))
+                    d.append(Data(bytes: gc.convHist.contents(), count: convCount * 2))
+                    d.append(Data(bytes: gc.state.contents(), count: stateCount * 4))
+                }
+            }
+            return d
+        }
+
+        /// Restore a persisted blob into THIS forward. false on any shape/format mismatch —
+        /// the caller must then fall back to a cold prefill and MUST NOT trust partial state
+        /// (shapes are validated per layer, but earlier layers may already be written).
+        public func restorePersistentState(_ d: Data) -> Bool {
+            var off = 0
+            func u32() -> UInt32? {
+                guard d.count >= off + 4 else { return nil }
+                let v = d.subdata(in: off ..< off + 4).withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+                off += 4
+                return UInt32(littleEndian: v)
+            }
+            func bytes(into dst: UnsafeMutableRawPointer, count: Int) -> Bool {
+                guard d.count >= off + count else { return false }
+                d.subdata(in: off ..< off + count).withUnsafeBytes { dst.copyMemory(from: $0.baseAddress!, byteCount: count) }
+                off += count
+                return true
+            }
+            guard u32() == Self.persistMagic, u32() == Self.persistFormat,
+                  u32() == UInt32(layers.count) else { return false }
+            for L in layers {
+                guard let flags = u32() else { return false }
+                let expect: UInt32 = (L.kvCache != nil ? 1 : 0) | (L.gdnCache != nil ? 2 : 0)
+                guard flags == expect else { return false }
+                if let kv = L.kvCache {
+                    guard u32() == UInt32(kv.KV), u32() == UInt32(kv.D),
+                          let len = u32().map(Int.init), len <= kv.maxLen else { return false }
+                    let rowBytes = len * kv.D * 2
+                    for buf in [kv.kCache, kv.vCache] {
+                        let base = buf.contents()
+                        for h in 0 ..< kv.KV {
+                            guard bytes(into: base + h * kv.maxLen * kv.D * 2, count: rowBytes) else { return false }
+                        }
+                    }
+                    kv.len = len
+                }
+                if let gc = L.gdnCache {
+                    let convCount = (gc.K - 1) * gc.C, stateCount = gc.Hv * gc.Dv * gc.Dk
+                    guard u32() == UInt32(convCount), u32() == UInt32(stateCount),
+                          bytes(into: gc.convHist.contents(), count: convCount * 2),
+                          bytes(into: gc.state.contents(), count: stateCount * 4) else { return false }
+                }
+            }
+            return off == d.count
+        }
+
         // ── Steel-prefill hybrid (claude/prefill-kernel): GDN dense matmuls via MLX steel ──────
         // Per-layer MLX weight triples (qkv / z / out_proj), keyed by layer array index. Set by the
         // backend builder when QWISP_HYBRID_PREFILL=1; empty → forwardRowsHybrid == forwardRows.

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -89,6 +89,10 @@ extension Tell {
         // Distinct from snapshot/rollback (1-step spec). nil if the backend doesn't support it.
         var fullSnapshot: (() -> Any)? = nil
         var fullRestore: ((Any) -> Void)? = nil
+        // Disk-persistable state (issue #89): serialize/restore the CURRENT decode state
+        // (KV used slice + GDN) as a blob a fresh process can restore. nil = unsupported.
+        var persistentState: (() -> Data)? = nil
+        var restorePersistentState: ((Data) -> Bool)? = nil
         // Steel-prefill hybrid (QWISP_HYBRID_PREFILL=1): prefill-scoped forward with GDN dense
         // matmuls via MLX steel. nil → prefill uses `forward`. Decode/verify NEVER use this.
         var forwardHybrid: (([Int32]) -> MLXArray?)? = nil
@@ -175,6 +179,8 @@ extension Tell {
         backend.fullRestore = { snap in
             if let s = snap as? SeedlessFusedVerify.SeedlessFusedForward.FullSnapshot { fwd.fullRestore(s) }
         }
+        backend.persistentState = { fwd.persistentStateData() }              // issue #89
+        backend.restorePersistentState = { fwd.restorePersistentState($0) }
         // Steel-prefill hybrid (opt-in): wire per-layer GDN MLX weights + the hybrid forward.
         // Chunk = min(1024, maxM): steel wins grow with chunk; callers wanting 1024 pass maxM>=1024.
         // Steel-prefill hybrid: default ON (canonical since refs re-canonicalization);
@@ -271,6 +277,8 @@ extension Tell {
         backend.fullRestore = { snap in
             if let s = snap as? SeedlessFusedVerify.SeedlessFusedForward.FullSnapshot { fwd.fullRestore(s) }
         }
+        backend.persistentState = { fwd.persistentStateData() }              // issue #89
+        backend.restorePersistentState = { fwd.restorePersistentState($0) }
         // Steel-prefill hybrid (opt-in): wire per-layer GDN MLX weights + the hybrid forward.
         // Chunk = min(1024, maxM): steel wins grow with chunk; callers wanting 1024 pass maxM>=1024.
         // Steel-prefill hybrid: default ON (canonical since refs re-canonicalization);

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -32,6 +32,7 @@ if CommandLine.arguments.contains("stream") {
         ("hybrid-estimate", { md, _ in Tell.hybridEstimate(modelDir: md) }),
         ("hybrid-prefill-bench", { md, _ in Tell.hybridPrefillBench(modelDir: md) }),
         ("prefix-cache-e2e", { md, _ in Tell.prefixCacheE2E(modelDir: md) }),
+        ("prefix-persist-e2e", { md, _ in Tell.prefixPersistE2E(modelDir: md) }),   // #89 restart gate
         ("prefix-cache-speed", { md, _ in Tell.prefixCacheSpeedProbe(modelDir: md) }),
         ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),
         ("gqmm2-bench", { _, _ in SeedlessMetalForward.gqmm2Bench() }),   // notes/18 W1 speed sim

--- a/swift/Sources/qwisp/Selftest.swift
+++ b/swift/Sources/qwisp/Selftest.swift
@@ -77,6 +77,9 @@ func runCompletionSelftest(modelDir: String) async -> String {
     check("prefill_line", prefillLine(done: 4096, total: 14490, secs: 151.7) == "prefill 4096/14490 (28%) · 27 tok/s")
     check("prefill_line_norate", prefillLine(done: 64, total: 128, secs: 0) == "prefill 64/128 (50%)")
 
+    // prefix-cache disk persistence (issue #89; pure tmp-dir store checks, no GPU).
+    for (name, ok) in PrefixPersist.selfCheck() { check("prefixpersist_\(name)", ok) }
+
     return lines.joined(separator: "\n") + "\nCOMPTEST \(passed)/\(total)"
 }
 


### PR DESCRIPTION
## What

Refs #89. **Stacked on #102 (#76)** — base branch is `claude/issue76-prefix-streaming`; merge #102 first, then rebase this to main.

The in-process prefix cache dies with the process. This adds an opt-in disk store so `qwisp chat` one-shots, service restarts on update, and reboots restore the content-boundary decode state instead of re-paying full prefill.

- **Engine (additive)**: `persistentStateData()`/`restorePersistentState()` on `SeedlessFusedForward` — unlike `FullSnapshot` (KV *len* only; bytes live in the arena), this serializes the actual KV used slice (per-head gather, so save/restore arenas may have different `maxLen`) + GDN convHist/state. All `.storageModeShared` → plain CPU memcpy, no GPU work, decode path untouched. Per-layer shape validation on restore; `false` → cold prefill fallback.
- **Store**: keyed by model + exact token prefix (FNV-64 filename, full token list in the header for prefix matching). `bestMatch()` restores the longest stored prefix of the new content. LRU by mtime (`QWISP_PREFIX_PERSIST_SLOTS=4`), per-artifact cap (`QWISP_PREFIX_PERSIST_MAX_MB=512`), same-key saves are mtime touches (no rewrite → bounded SSD wear, per the issue's wear note).
- **Wiring**: disk restore fires only when no in-memory restore point matches (fresh process); the content-boundary state is captured exactly at the boundary and written asynchronously.
- **Gate**: `QWISP_RUN=prefix-persist-e2e` — PREFIXE2E with a simulated restart (`resetPrefixCache()` drops arena/providers/slots; only disk survives). PASS requires byte-identity vs the cache-off path **and** `diskRestore=HIT` (a `restoreHits` counter — byte-identity alone can't distinguish restored from silently-cold). `QWISP_PREFIX_E2E_C=64/128` for streaming configs.
- **Default OFF** (`QWISP_PREFIX_PERSIST=1`), per the issue: default decided after fidelity + footprint data.

## Verification

GPU-free (on battery): both schemes build; COMPTEST 20/20 (+5 store checks: longest-prefix match, shorter-prefix fallback, model isolation, divergence miss, LRU cap); BENCHBATCHTEST PASS.

**Pending on AC power — gates this PR's merge (issue acceptance):**
1. RAWTESTS
2. `prefix-persist-e2e` PASS on resident and `QWISP_PREFIX_E2E_C=64`/`128` (strict)
3. Multi-turn TTFT across a real kill-and-restart, before/after
4. On-disk footprint per artifact at realistic prompt lengths (drives the default cap)

mmap-restore (the #86-interaction note) is a follow-up if the restore-side `Data` read shows up in footprint measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)