### PR TITLE
feat(bolt): prefix reuse (byte-restored state) + calib warm-start default-ON for mixed — #76/#73

### DIFF
--- a/swift/Sources/QwispCore/BoltServe.swift
+++ b/swift/Sources/QwispCore/BoltServe.swift
@@ -89,6 +89,19 @@ final class BoltServe {
     private static let nE = 256
     private static let Ktop = 8
 
+    // ── #76 bolt-side prefix reuse (in-RAM; QWISP_BOLT_PREFIX=0 opts out) ─────────
+    // The forward is rebuilt per segment, so a len-only FullSnapshot cannot carry KV
+    // across requests — instead the ACTUAL prompt-end state (persistentStateData: KV
+    // used slice + GDN) is kept as a byte blob and restored into the next segment's
+    // fresh forward. One slot, extend-only (agentic loops / segment growth both extend).
+    // ORDER INVARIANT preserved: restore writes state bytes only (no arena ensures) →
+    // delta strict prefill (ensures move slots) → freeze rebuilds tables after, as always.
+    private var prefixToks: [Int32] = []
+    private var prefixBlob: Data? = nil
+    private var prefixEnabled: Bool { Tell.envInt("QWISP_BOLT_PREFIX", 1) != 0 }
+    private let prefixMinToks = 256          // small prompts re-prefill faster than a blob save
+    private var prefixMaxBytes: Int { Swift.max(1, Tell.envInt("QWISP_BOLT_PREFIX_MAX_MB", 512)) * 1_048_576 }
+
     init(engine: SeedlessEngine, modelDir: String, C: Int, maxK: Int, maxM: Int,
          mixedTailDir: String? = nil) {
         self.engine = engine
@@ -103,7 +116,7 @@ final class BoltServe {
     /// tracks the latest recalib window, so this is last-known-good. Called on graceful
     /// shutdown (SeedlessBackend.drain); no-op unless QWISP_CALIB_CACHE=1 and calibrated.
     func saveArtifact() {
-        guard CalibArtifact.enabled, calibrated else { return }
+        guard CalibArtifact.enabled(mixed: mixedTailDir != nil), calibrated else { return }
         CalibArtifact.save(modelDir: modelDir, mixedTailDir: mixedTailDir, C: C,
                            counts: baseCounts, coact: baseCoact)
     }
@@ -217,6 +230,7 @@ final class BoltServe {
     /// One generation segment (mirror of Tell.runSpecLoop's contract: returns out[0..<N],
     /// streams via onToken, stops early on isCancelled). nil on backend error.
     func runSegment(promptIds: [Int32], N: Int, maxSeqLen: Int,
+                    contentLen: Int? = nil,
                     isCancelled: (() -> Bool)? = nil,
                     onToken: ((Int) -> Void)? = nil) -> [Int]? {
         let nLayers = SeedlessEngine.numLayers
@@ -229,7 +243,7 @@ final class BoltServe {
             // Warm-start (issue #73, opt-in QWISP_CALIB_CACHE=1): a valid artifact seeds the
             // freeze basis and skips the strict-speed calib pass; rolling recalib adapts it
             // from live traffic (the artifact seeds, never rules — calib-poisoning doctrine).
-            let warm: (counts: [[Int]], coact: [[[Int]]])? = CalibArtifact.enabled
+            let warm: (counts: [[Int]], coact: [[[Int]]])? = CalibArtifact.enabled(mixed: mixedTailDir != nil)
                 ? CalibArtifact.load(modelDir: modelDir, mixedTailDir: mixedTailDir, C: C,
                                      nLayers: nLayers, nE: nE)
                 : nil
@@ -293,7 +307,7 @@ final class BoltServe {
             baseCounts = counts
             baseCoact = coact
             // Fresh calib is worth keeping even if this process dies ungracefully.
-            if CalibArtifact.enabled {
+            if CalibArtifact.enabled(mixed: mixedTailDir != nil) {
                 CalibArtifact.save(modelDir: modelDir, mixedTailDir: mixedTailDir, C: C,
                                    counts: baseCounts, coact: baseCoact)
             }
@@ -342,8 +356,36 @@ final class BoltServe {
             backend = b; fwd = f
         }
         // Exact (strict) prefill FIRST — its ensures may move arena slots — then freeze.
-        guard let lastNormed = Tell.prefill(promptIds: promptIds, backend: backend),
-              let lg0 = engine.logits(lastNormed, M: 1) else { return nil }
+        // #76: the reuse boundary is the CONTENT boundary (prompt without the trailing
+        // generation-prompt suffix — the suffix tokens differ once the next turn re-renders
+        // the assistant message, so a prompt-end boundary never prefix-matches). If the
+        // stored content-prefix matches, byte-restore it (no ensures; KV positions resume
+        // at the restored len) and prefill only the delta; capture the new content-boundary
+        // state between the two prefill halves.
+        let cl = Swift.min(contentLen ?? promptIds.count, promptIds.count)
+        var start = 0
+        if prefixEnabled, !prefixToks.isEmpty, prefixToks.count < cl,
+           Array(promptIds[0 ..< prefixToks.count]) == prefixToks,
+           let blob = prefixBlob, fwd.restorePersistentState(blob) {
+            start = prefixToks.count
+        }
+        // Content half [start ..< cl] → capture → suffix half [cl ...]. Either half may be
+        // empty; lastNormed must come from the LAST non-empty half.
+        var lastNormed: MLXArray? = nil
+        if start < cl {
+            guard let n = Tell.prefill(promptIds: Array(promptIds[start ..< cl]), backend: backend) else { return nil }
+            lastNormed = n
+        }
+        if prefixEnabled, cl >= prefixMinToks, cl < promptIds.count {
+            // CPU memcpy of shared buffers — the content prefill's CBs completed above.
+            let blob = fwd.persistentStateData()
+            if blob.count <= prefixMaxBytes { prefixBlob = blob; prefixToks = Array(promptIds[0 ..< cl]) }
+        }
+        if cl < promptIds.count {
+            guard let n = Tell.prefill(promptIds: Array(promptIds[cl...]), backend: backend) else { return nil }
+            lastNormed = n
+        }
+        guard let lastNormed, let lg0 = engine.logits(lastNormed, M: 1) else { return nil }
         MLX.eval([lg0])
         var u = MLX.argMax(lg0[0], axis: -1).item(Int.self)
         freeze(fwd)

--- a/swift/Sources/QwispCore/CalibArtifact.swift
+++ b/swift/Sources/QwispCore/CalibArtifact.swift
@@ -12,15 +12,20 @@ import Foundation
 // from live traffic; on graceful shutdown the latest basis is written back
 // (last-known-good). Any key mismatch (model, mixed tail, C, dims, format) invalidates.
 //
-// Opt-in: QWISP_CALIB_CACHE=1. Default OFF until the warm-vs-cold A/B (TF fidelity +
-// LOOPY rate, free-run gate per the attractor doctrine) lands — see #73.
+// Default (warm-vs-cold A/B, 2026-07-19, #73): ON for MIXED residency, opt-in for generic.
+// Mixed cal128 has coverage 256/layer — every expert resident — so the freeze basis cannot
+// change which experts are available: warm decode measured BYTE-IDENTICAL to cold
+// (599/599 tokens × 2 mismatched prompts). Generic bolt (C of 256 resident) showed a
+// transient −5..−10pt TF-fidelity dip over the first ~2-3 recalib windows before
+// converging to cold parity (LOOPY 0/4 both arms) — a visible early-answer quality cost,
+// so generic stays opt-in. QWISP_CALIB_CACHE=1 forces on, =0 forces off (both modes).
 public enum CalibArtifact {
 
     static let magic: UInt32 = 0x3143_5751          // "QWC1" little-endian
     /// Bump on any layout/semantics change — old files then simply miss.
     static let format: UInt32 = 1
 
-    public static var enabled: Bool { Tell.envInt("QWISP_CALIB_CACHE", 0) != 0 }
+    public static func enabled(mixed: Bool) -> Bool { Tell.envInt("QWISP_CALIB_CACHE", mixed ? 1 : 0) != 0 }
 
     /// FNV-1a 64 — stable across processes (Swift's Hasher is per-process seeded).
     static func fnv1a(_ s: String) -> UInt64 {

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -320,6 +320,7 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                         }
                         guard let seg = self.boltServe?.runSegment(
                             promptIds: seq, N: segN, maxSeqLen: maxSeqLen,
+                            contentLen: options.promptContentLen,   // #76: bolt prefix-reuse boundary
                             isCancelled: { cancel.isCancelled || lguard?.trip != nil }, onToken: onTok),
                             !seg.isEmpty else { break }
                         if let g = lguard, let tr = g.trip {

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -237,6 +237,47 @@ extension Tell {
         return lines.joined(separator: "\n")
     }
 
+    // #76 gate (bolt side): bolt-mode decode with the in-RAM prompt-prefix blob
+    // (QWISP_BOLT_PREFIX) vs without must be byte-identical. Two INDEPENDENT backends
+    // (own BoltServe, own arena) are fed the same request sequence so per-process calib
+    // and rolling recalib evolve identically; only the prefix reuse differs. The restored
+    // KV/GDN bytes equal a fresh strict prefill's by construction; freeze() re-ensures
+    // top-C of the same basis either way — divergence would indicate a slot-state leak.
+    public static func prefixBoltE2E(modelDir: String) -> String {
+        let c = Tell.envInt("QWISP_PREFIX_E2E_C", 64)
+        guard let bRef = try? SeedlessBackend(modelDir: modelDir, tier: .streaming(c: c)),
+              let bCached = try? SeedlessBackend(modelDir: modelDir, tier: .streaming(c: c))
+        else { return "[prefix-bolt-e2e] load fail\nPREFIXBOLTE2E FAIL" }
+        func toks(_ n: Int, _ salt: Int) -> [Int] { (0..<n).map { (($0 &* 7 &+ salt) % 5000) + 100 } }
+        let A = toks(300, 13), genSuffix = toks(8, 777)
+        // 3-request extend chain (agentic shape): each request extends the previous content.
+        let reqs = [A + genSuffix,
+                    A + toks(40, 2) + genSuffix,
+                    A + toks(40, 2) + toks(40, 5) + genSuffix]
+        final class Box: @unchecked Sendable { var v: [Int] = [] }
+        func gen(_ b: SeedlessBackend, _ p: [Int], prefix: Bool) -> [Int] {
+            setenv("QWISP_BOLT_PREFIX", prefix ? "1" : "0", 1)
+            let box = Box(); let sem = DispatchSemaphore(value: 0)
+            let s = b.generate(p, options: GenerateOptions(maxTokens: 24, promptContentLen: p.count - 8))
+            Task.detached { for await t in s { box.v.append(t) }; sem.signal() }
+            sem.wait()
+            return box.v
+        }
+        var lines = ["[prefix-bolt-e2e] streaming C=\(c), bolt default mode, 3-request extend chain"]
+        var pass = true
+        for (i, p) in reqs.enumerated() {
+            let r = gen(bRef, p, prefix: false)
+            let g = gen(bCached, p, prefix: true)
+            let ok = r == g && !r.isEmpty
+            pass = pass && ok
+            lines.append("  R\(i + 1) prompt=\(p.count)  ref=\(r.count)tok cached=\(g.count)tok  \(ok ? "IDENTICAL ✅" : "DIVERGE ❌")")
+            if !ok { lines.append("    ref:    \(r.prefix(12))"); lines.append("    cached: \(g.prefix(12))") }
+        }
+        unsetenv("QWISP_BOLT_PREFIX")
+        lines.append("PREFIXBOLTE2E \(pass ? "PASS" : "FAIL")")
+        return lines.joined(separator: "\n")
+    }
+
     // Speed probe for the multi-slot cache: TTFT (time-to-first-token) for a cold request vs a
     // cross-conversation request that shares a large prefix vs an intra-conversation extend.
     // Shows the multi-slot win = skipping re-prefill of the shared system+tools prefix on a NEW convo.

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -33,6 +33,7 @@ if CommandLine.arguments.contains("stream") {
         ("hybrid-prefill-bench", { md, _ in Tell.hybridPrefillBench(modelDir: md) }),
         ("prefix-cache-e2e", { md, _ in Tell.prefixCacheE2E(modelDir: md) }),
         ("prefix-persist-e2e", { md, _ in Tell.prefixPersistE2E(modelDir: md) }),   // #89 restart gate
+        ("prefix-bolt-e2e", { md, _ in Tell.prefixBoltE2E(modelDir: md) }),         // #76 bolt-side gate
         ("prefix-cache-speed", { md, _ in Tell.prefixCacheSpeedProbe(modelDir: md) }),
         ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),
         ("gqmm2-bench", { _, _ in SeedlessMetalForward.gqmm2Bench() }),   // notes/18 W1 speed sim


### PR DESCRIPTION
## What

Two bolt-side productization steps, both backed by fresh GPU measurements.

### 1. Bolt-side prefix cache (#76 remaining half)

Bolt rebuilds its forward per segment, so the strict path's len-only `FullSnapshot` cannot carry KV across requests. Instead the **content-boundary** state (KV used slice + GDN via `persistentStateData`) is kept as one in-RAM blob and **byte-restored** into the next segment's fresh forward; only the delta is strict-prefilled. The ORDER INVARIANT is preserved: restore writes state bytes only (no arena ensures) → delta prefill → `freeze()` rebuilds tables after, as always.

Key finding en route: a **prompt-end** boundary never prefix-matches the next turn (the re-rendered assistant message diverges at the generation-prompt suffix) — measured zero TTFT win until the boundary moved to `contentLen` (same reason the strict path uses it).

- **PREFIXBOLTE2E** (new gate, `QWISP_RUN=prefix-bolt-e2e`): cached vs cache-off **byte-IDENTICAL** on a 3-request extend chain at C=64 and C=128 (two independent backends so calib/recalib evolve identically).
- **Turn-2 TTFT** (2.4K-token conversation, 16GB bolt): **13.9s → 543ms (~26x)**.
- Default ON, `QWISP_BOLT_PREFIX=0` opts out; 512MB blob cap; min 256 content tokens.

### 2. Calib warm-start default-ON for mixed (#73 A/B verdict)

Warm-vs-cold A/B (mismatched story-basis artifact serving code/agentic prompts, C=128, 600-token streams, TF replay + LOOPY battery):

| config | TF fidelity | LOOPY | verdict |
|--------|-------------|-------|---------|
| mixed cal128 (coverage 256/layer) | warm **byte-identical** to cold (599/599 ×2) | — | basis cannot change expert availability → **default ON** (saves the calib pass; 11s→3s/process) |
| generic bolt (C of 256) | transient −5..−10pt, Q1 72.7% → Q4 95.3% (recalib converges) | 0/4 runs both arms | dip is user-visible early-answer quality → **stays opt-in** |

`QWISP_CALIB_CACHE=1/0` force-overrides both modes.

## Gates

RAWTESTS 89/89 · COMPTEST 33/33 · TOKTEST 5/5 · BENCHBATCHTEST PASS · PREFIXBOLTE2E PASS ×2 · default-matrix E2E (mixed warm-starts with no env; generic does not).

Closes #76. Refs #73 (A/B done; issue can close once the generic default question is considered settled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)