### PR TITLE
feat(seedless): target-hidden tap accessor for DFlash ctx features (#98 phase 1)

### DIFF
--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -3225,6 +3225,47 @@ public enum SeedlessFusedVerify {
         /// (layerIndex, inds[M*Ktop]) — nil の間は呼び出しコスト無し。
         public var indsCaptureHook: ((Int, [Int32]) -> Void)? = nil
 
+        // ── #98 DFlash phase 1: target-hidden tap ────────────────────────────────────────
+        // Additive persistent f16 side-buffer holding the residual-stream hidden states
+        // (hBuf) of a configurable layer set immediately after each layer's post-MoE
+        // residAdd, for every forward (resident/bolt/strict). These are the DFlash
+        // drafter's ctx features (model.py extract_context_feature offset=1: ctx for
+        // target_layer_id L == hBuf right after layer L's post-MoE residAdd).
+        // tap nil (default) => ZERO added encodes => every existing path byte-identical.
+        public private(set) var tapBuf: MTLBuffer? = nil
+        public private(set) var tapLayerIds: [Int] = []
+
+        /// Validates ids (strictly ascending, unique, each in 0..<layers.count; else nil),
+        /// ensures compileDiagCopyRoute, allocates a shared MTLBuffer of
+        /// layerIds.count*maxM*H*2 bytes, stores both props, returns it.
+        @discardableResult
+        public func attachTap(layerIds: [Int]) -> MTLBuffer? {
+            for (i, id) in layerIds.enumerated() {
+                guard id >= 0, id < layers.count else { return nil }
+                if i > 0, id <= layerIds[i - 1] { return nil }
+            }
+            guard SeedlessMetalForward.compileDiagCopyRoute() else { return nil }
+            guard let buf = device.makeBuffer(length: layerIds.count * maxM * H * 2,
+                                              options: .storageModeShared) else { return nil }
+            tapBuf = buf
+            tapLayerIds = layerIds
+            return buf
+        }
+
+        /// Clears tapBuf and tapLayerIds.
+        public func detachTap() { tapBuf = nil; tapLayerIds = [] }
+
+        /// If tapBuf is set and li is a tap layer, reuse encodeDiagCopyRoute (half branch,
+        /// Ktop=0 keeps the int32 branch dead, E=M*H) to copy hBuf's M*H f16 into slot
+        /// (ti*maxM*H*2). No new kernel. tapBuf nil (default) => no-op => zero added encodes.
+        private func encodeTap(_ enc: MTLComputeCommandEncoder, li: Int, M: Int) {
+            guard let buf = tapBuf, let ti = tapLayerIds.firstIndex(of: li) else { return }
+            SeedlessMetalForward.encodeDiagCopyRoute(enc, inds: hBuf, gl: hBuf,
+                                                indsDst: buf, indsDstByteOffset: 0,
+                                                glDst: buf, glDstByteOffset: ti * maxM * H * 2,
+                                                Ktop: 0, E: M * H)
+        }
+
         public init?(layers specs: [SeedlessVerifyForward.LayerSpec], caches: [SeedlessVerifyForward.LayerCaches],
                      maxM: Int, H: Int, maxSeqLen: Int,
                      numHeads: Int = 16, numKV: Int = 2, headDim: Int = 256,
@@ -3312,11 +3353,12 @@ public enum SeedlessFusedVerify {
         }
 
         /// 1 層を encoder に encode(norm→mixer→resid→postNorm→MoE→resid)。resident/bolt 経路のみ。
-        func encodeLayer(_ enc: MTLComputeCommandEncoder, _ L: Layer, M: Int) {
+        func encodeLayer(_ enc: MTLComputeCommandEncoder, _ L: Layer, li: Int, M: Int) {
             encodePreMoE(enc, L, M: M)
             SeedlessFusedVerify.encodeMoEBlockRows(enc, x: postNorm, out: moeOut, w: L.moe, sc: moeSc,
                                               M: M, E: L.E, I: L.I, Ktop: L.Ktop, H: H)
             SeedlessFusedVerify.encodeResidAdd(enc, h: hBuf, r: moeOut, total: M * H)
+            encodeTap(enc, li: li, M: M)
         }
 
         /// bolt routing telemetry (notes/11 Stage 0 → notes/13 採用で一般化): 非 nil のとき
@@ -3350,6 +3392,7 @@ public enum SeedlessFusedVerify {
                                               M: M, E: L.E, I: L.I, Ktop: L.Ktop, H: H,
                                               slotTable: slotTables[li], diag: diag, bias: biasTuple)
             SeedlessFusedVerify.encodeResidAdd(enc, h: hBuf, r: moeOut, total: M * H)
+            encodeTap(enc, li: li, M: M)
         }
 
         /// MoE 前半 encode: norm → mixer(+cache bookkeeping) → resid → postNorm。
@@ -3480,7 +3523,7 @@ public enum SeedlessFusedVerify {
             case .resident:
                 let cb = queue.makeCommandBuffer()!
                 let enc = cb.makeComputeCommandEncoder()!
-                for L in layers { encodeLayer(enc, L, M: M) }
+                for (li, L) in layers.enumerated() { encodeLayer(enc, L, li: li, M: M) }
                 if let fw = finalNormW {
                     SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: fw, out: normed, rows: M, D: H, eps: eps)
                 }
@@ -3571,6 +3614,7 @@ public enum SeedlessFusedVerify {
                 SeedlessFusedVerify.encodeMoESharedRows(curEnc!, x: postNorm, out: moeOut, w: L.moe, sc: moeSc,
                                                     M: M, I: L.I, H: H, Ktop: L.Ktop)
                 SeedlessFusedVerify.encodeResidAdd(curEnc!, h: hBuf, r: moeOut, total: M * H)
+                encodeTap(curEnc!, li: li, M: M)
 
                 if li + 1 < layers.count {
                     // 次層の pre-MoE + route を同 CB に連結してから flush(route 読み出し)
@@ -3691,7 +3735,7 @@ public enum SeedlessFusedVerify {
                 let cb = queue.makeCommandBuffer()!
                 let enc = cb.makeComputeCommandEncoder()!
                 encodeEmbed(enc)
-                for L in layers { encodeLayer(enc, L, M: M) }
+                for (li, L) in layers.enumerated() { encodeLayer(enc, L, li: li, M: M) }
                 encodeFinalOps(enc)
                 enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
                 SeedlessFusedForward.profLastGPUMs = (cb.gpuEndTime - cb.gpuStartTime) * 1000.0
@@ -3784,7 +3828,7 @@ public enum SeedlessFusedVerify {
             switch streamMode {
             case .resident:
                 let cb = queue.makeCommandBuffer()!; let enc = cb.makeComputeCommandEncoder()!
-                encodeEmbed(enc); for L in layers { encodeLayer(enc, L, M: M) }; encodeFinalSample(enc)
+                encodeEmbed(enc); for (li, L) in layers.enumerated() { encodeLayer(enc, L, li: li, M: M) }; encodeFinalSample(enc)
                 enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
             case .bolt:
                 let cb = queue.makeCommandBuffer()!; let enc = cb.makeComputeCommandEncoder()!
@@ -4223,7 +4267,7 @@ public enum SeedlessFusedVerify {
                     if diagRouteBufs != nil { diagChainSlot = k }
                     for (li, L) in layers.enumerated() { encodeLayerBolt(enc, L, M: 1, li: li) }
                 } else {
-                    for L in layers { encodeLayer(enc, L, M: 1) }
+                    for (li, L) in layers.enumerated() { encodeLayer(enc, L, li: li, M: 1) }
                 }
 
                 // ── Final ops: fnorm + lm_head + argmax → chainBuf[k] ─────────────

--- a/swift/Sources/QwispCore/SeedlessVerifyTests.swift
+++ b/swift/Sources/QwispCore/SeedlessVerifyTests.swift
@@ -49,7 +49,7 @@ public enum SeedlessVerifyTests {
         MLXRandom.seed(UInt64(42))
         var lines: [String] = []
         var passed = 0
-        let total = 89
+        let total = 91
 
         // Nested runner: records result and increments counter
         func run(_ name: String, body: () -> (Bool, String)) {
@@ -5413,6 +5413,158 @@ public enum SeedlessVerifyTests {
             // k4 far beyond budget clamps to budget/slot4=64, leaving m2=0.
             let over = DeviceCalibration.mixedKM(budgetBytes: budget, slot4Bytes: slot4, slot2Bytes: slot2, k4: 999)
             if over.k4 != 64 || over.m2 != 0 { return (false, "k4=999 → \(over) != (64,0)") }
+            return (true, "ok")
+        }
+
+        // ── #98 DFlash phase 1: target-hidden tap locked tests (90-91) ──────
+        //
+        // WRITE-LOCKED: implementer MUST NOT modify these tests.
+        // Encodes the DFlash drafter's ctx-feature tap: attachTap(layerIds:) installs a
+        // persistent f16 side-buffer that, after every forward, holds hBuf (residual
+        // stream) right after each tapped layer's post-MoE residAdd. dflash reference
+        // (model.py extract_context_feature, offset=1): ctx for target_layer_id L ==
+        // HF hidden_states[L+1] == hBuf immediately after layer L's residAdd.
+        //
+        // Test 90 (G-tap-bitexact): tap slot i == a FRESH engine built from the truncated
+        // spec prefix specs[0...tapLayerIds[i]] run on the same input. This holds because
+        // forwardRows(finalNormW:nil) returns hBuf after the LAST layer's residAdd, which
+        // for the truncated engine IS the tap value of that layer in the full engine
+        // (layers 0..L identical + deterministic + same init caches → identical hBuf).
+        // Taps at first/middle/last layer (0, 2, 5). RED: attachTap STUB returns nil.
+        run("dflash_tap_bitexact") {
+            guard SeedlessMetalForward.ensure() != nil else { return (false, "no device") }
+            let nLayers = 6, M = 4, maxSeq = 32
+            let tapIds = [0, 2, 5]   // first, middle, last layer
+            // 6 alternating GDN(even)/attn(odd) layers.
+            var specs: [SeedlessVerifyForward.LayerSpec] = []
+            for li in 0 ..< nLayers {
+                let isLin = (li % 2 == 0)
+                specs.append(SeedlessVerifyForward.LayerSpec(
+                    isLinear: isLin,
+                    inputLN: MLXRandom.normal([stH]).asType(.float16),
+                    postLN: MLXRandom.normal([stH]).asType(.float16),
+                    gdn: isLin ? stMkGdnW() : nil,
+                    attn: isLin ? nil : stMkAttnW(),
+                    moe: stMkMoE().w, moeE: stE, moeI: stI))
+            }
+            // Shared initial cache state (same objects → full & truncated engines identical).
+            let cs0 = MLXRandom.normal([stCK - 1, stConvDim]).asType(.float16)
+            let rs0 = MLXRandom.normal([1, stHv, stDv, stDk]).asType(.float32)
+            let kc0 = MLXRandom.normal([stNkv, 8, stHd]).asType(.float16)
+            let vc0 = MLXRandom.normal([stNkv, 8, stHd]).asType(.float16)
+            MLX.eval([cs0, rs0, kc0, vc0])
+            func freshCachesFor(_ count: Int) -> [SeedlessVerifyForward.LayerCaches] {
+                (0 ..< count).map { li in
+                    (li % 2 == 0)
+                        ? SeedlessVerifyForward.LayerCaches(convState: cs0, recState: rs0)
+                        : SeedlessVerifyForward.LayerCaches(kCache: kc0, vCache: vc0)
+                }
+            }
+            guard let eng = SeedlessFusedVerify.SeedlessFusedForward(
+                    layers: specs, caches: freshCachesFor(nLayers),
+                    maxM: M, H: stH, maxSeqLen: maxSeq)
+            else { return (false, "engine nil") }
+            guard let tapBuf = eng.attachTap(layerIds: tapIds)
+            else { return (false, "attachTap nil (STUB not implemented)") }
+            if eng.tapLayerIds != tapIds { return (false, "tapLayerIds=\(eng.tapLayerIds) want=\(tapIds)") }
+            let x = MLXRandom.normal([M, stH]).asType(.float16); x.eval()
+            guard eng.forwardRows(x, M: M) != nil else { return (false, "forwardRows nil") }
+            // Reference: fresh truncated engine per tap id; its returned hBuf == the tap value.
+            let slotStride = M * stH   // maxM == M here
+            for (ti, L) in tapIds.enumerated() {
+                let prefix = Array(specs[0 ... L])
+                guard let refEng = SeedlessFusedVerify.SeedlessFusedForward(
+                        layers: prefix, caches: freshCachesFor(L + 1),
+                        maxM: M, H: stH, maxSeqLen: maxSeq)
+                else { return (false, "ref engine nil L=\(L)") }
+                guard let ref = refEng.forwardRows(x, M: M) else { return (false, "ref fwd nil L=\(L)") }
+                ref.eval()
+                let ptr = tapBuf.contents().bindMemory(to: Float16.self, capacity: tapIds.count * slotStride)
+                let slot = MLXArray(Array(UnsafeBufferPointer(
+                    start: ptr.advanced(by: ti * slotStride), count: M * stH)), [M, stH])
+                let (ok, d) = bitEqual(slot, ref)
+                if !ok { return (false, "tap L=\(L): \(d)") }
+            }
+            return (true, "ok")
+        }
+
+        // Test 91 (G-tap-off-invariant): tap-on does NOT perturb the numeric path, AND the
+        // stepArgmax path actually executes the tap encode. Two identical engines (shared
+        // weights + head): A attachTap([0,2,5]), B no tap. Feed each output token back as
+        // the next input for 6 sequential stepArgmax steps from the same start token — the
+        // two token streams MUST be identical at every step (tap adds encodes but never
+        // reads/mutates the numeric path). Additionally, A's tap slot for layer 5 must be
+        // non-zero after the steps (proof the copy fired). RED: attachTap STUB → nil.
+        run("dflash_tap_off_invariant") {
+            guard SeedlessMetalForward.ensure() != nil else { return (false, "no device") }
+            let V = 256, nLayers = 6, maxSeq = 32
+            let tapIds = [0, 2, 5]
+            let firstToken = Int32(7)
+            // Shared layer weights (same objects → both engines are the identical model).
+            var specs: [SeedlessVerifyForward.LayerSpec] = []
+            for li in 0 ..< nLayers {
+                let isLin = (li % 2 == 0)
+                specs.append(SeedlessVerifyForward.LayerSpec(
+                    isLinear: isLin,
+                    inputLN: MLXRandom.normal([stH]).asType(.float16),
+                    postLN: MLXRandom.normal([stH]).asType(.float16),
+                    gdn: isLin ? stMkGdnW() : nil,
+                    attn: isLin ? nil : stMkAttnW(),
+                    moe: stMkMoE().w, moeE: stE, moeI: stI))
+            }
+            let cs0 = MLXRandom.normal([stCK - 1, stConvDim]).asType(.float16)
+            let rs0 = MLXRandom.normal([1, stHv, stDv, stDk]).asType(.float32)
+            let kc0 = MLXRandom.normal([stNkv, 8, stHd]).asType(.float16)
+            let vc0 = MLXRandom.normal([stNkv, 8, stHd]).asType(.float16)
+            MLX.eval([cs0, rs0, kc0, vc0])
+            func freshCaches() -> [SeedlessVerifyForward.LayerCaches] {
+                (0 ..< nLayers).map { li in
+                    (li % 2 == 0)
+                        ? SeedlessVerifyForward.LayerCaches(convState: cs0, recState: rs0)
+                        : SeedlessVerifyForward.LayerCaches(kCache: kc0, vCache: vc0)
+                }
+            }
+            // Shared head weights (embed = lm_head = 4-bit q), same objects for both engines.
+            let ewf = MLXRandom.normal([V, stH]).asType(.float16)
+            let (ewq, esc, ebiOpt) = MLX.quantized(ewf, groupSize: 64, bits: 4, mode: .affine)
+            guard let ebi = ebiOpt else { return (false, "embed biases nil") }
+            let lwf = MLXRandom.normal([V, stH]).asType(.float16)
+            let (lwq, lsc, lbiOpt) = MLX.quantized(lwf, groupSize: 64, bits: 4, mode: .affine)
+            guard let lbi = lbiOpt else { return (false, "lm biases nil") }
+            let fnW = MLXRandom.normal([stH]).asType(.float16)
+            MLX.eval([ewq, esc, ebi, lwq, lsc, lbi, fnW])
+            let maxM = 4
+            func mkEng() -> SeedlessFusedVerify.SeedlessFusedForward? {
+                guard let e = SeedlessFusedVerify.SeedlessFusedForward(
+                        layers: specs, caches: freshCaches(),
+                        maxM: maxM, H: stH, maxSeqLen: maxSeq) else { return nil }
+                guard e.attachHead(embedW: ewq, embedS: esc, embedB: ebi,
+                                   lmW: lwq, lmS: lsc, lmB: lbi,
+                                   fnW: fnW, vocab: V) else { return nil }
+                return e
+            }
+            guard let engA = mkEng() else { return (false, "engA nil") }
+            guard let engB = mkEng() else { return (false, "engB nil") }
+            guard let tapBuf = engA.attachTap(layerIds: tapIds)
+            else { return (false, "attachTap nil (STUB not implemented)") }
+            // 6 sequential stepArgmax, feeding each output token back.
+            var curA = firstToken, curB = firstToken
+            for step in 0 ..< 6 {
+                guard let tA = engA.stepArgmax([curA]) else { return (false, "engA step \(step) nil") }
+                guard let tB = engB.stepArgmax([curB]) else { return (false, "engB step \(step) nil") }
+                if tA[0] != tB[0] {
+                    return (false, "token divergence step \(step): tap-on=\(tA[0]) tap-off=\(tB[0])")
+                }
+                curA = Int32(tA[0]); curB = Int32(tB[0])
+            }
+            // The tap copy must have fired: slot for layer 5 (tapIds index 2), row 0, not all zero.
+            let slotStride = maxM * stH
+            let li5 = tapIds.firstIndex(of: 5)!
+            let ptr = tapBuf.contents().bindMemory(to: Float16.self, capacity: tapIds.count * slotStride)
+            let row0 = UnsafeBufferPointer(start: ptr.advanced(by: li5 * slotStride), count: stH)
+            if !row0.contains(where: { $0 != Float16(0) }) {
+                return (false, "tap slot for layer 5 all-zeros — copy did not fire")
+            }
             return (true, "ok")
         }
 


### PR DESCRIPTION
Part of #98 (DFlash devloop phase 1 of the plan in the 2026-07-19 recon comment).

## What

Additive persistent f16 tap buffer on `SeedlessFusedForward` that, after every forward, holds the residual stream (`hBuf`) immediately after the post-MoE residAdd of a configurable layer set — the DFlash drafter's ctx features. Real-model tap set will be `{1,6,11,16,22,27,32,37}`.

- **Indexing verified against upstream**: dflash `model.py` `extract_context_feature` uses `offset = 1`, i.e. ctx for `target_layer_id L` == HF `hidden_states[L+1]` == output of layer L — exactly `hBuf` after layer L's residAdd.
- `attachTap(layerIds:)` / `detachTap()`; slot `i` = byte offset `i*maxM*H*2`, row-major `[M, H]` f16, rows `[0, M)` valid per forward.
- Copy reuses the existing `diag_copy_route` telemetry kernel (`Ktop=0` ⇒ int32 branch dead, `E=M*H` half copy) — **no new kernel**.
- Wired after every post-MoE residAdd across all three per-layer styles (`encodeLayer` with new `li` param / `encodeLayerBolt` / `runStrictLayers`), covering `forwardRows` / `stepArgmax` / `stepSampleRows` × resident/bolt/strict.
- `tap == nil` (default) ⇒ zero added encodes ⇒ every existing path byte-identical by construction (frozen-path Prohibition 3: additive only, no restructure).

## Locked tests (total 89 → 91)

- **90 `dflash_tap_bitexact`**: 6-layer synthetic GDN/attn engine, taps `[0,2,5]`; each tap slot byte-equals (`Float16` bitPattern) a fresh engine built from the truncated spec prefix `specs[0...L]` run on the same input.
- **91 `dflash_tap_off_invariant`**: two identical engines with heads, tap-on vs tap-off — identical greedy token streams over 6 sequential `stepArgmax` steps, plus a copy-fired non-zero assert.

## Gates

- RAWTESTS **91/91** (`scripts/test_raw.sh`)
- BENCHBATCHTEST PASS
- Build Release SUCCEEDED

Produced by the devloop TDD workflow (Opus locked tests → Sonnet implement → Sonnet adversarial review, round-1 PASS); driver-audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)