### PR TITLE
probe(dflash): real-checkpoint oracle parity (#98 phase 2b)

### DIFF
--- a/oracle/dflash_model_mlx.py
+++ b/oracle/dflash_model_mlx.py
@@ -1,0 +1,582 @@
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from threading import RLock
+from typing import Any, Dict, List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+from huggingface_hub import snapshot_download
+from mlx_lm.generate import generation_stream
+from mlx_lm.models.base import create_causal_mask
+from mlx_lm.models.cache import KVCache, RotatingKVCache, can_trim_prompt_cache, make_prompt_cache
+from mlx_lm.models.qwen3 import MLP
+from mlx_lm.models.rope_utils import initialize_rope
+from mlx_lm.sample_utils import make_sampler
+from mlx_lm.tokenizer_utils import TokenizerWrapper
+
+try:
+    import mlx_lm.models.gated_delta as _gd_mod
+    _HAS_GDN = True
+except ImportError:
+    _HAS_GDN = False
+
+
+_GDN_PATCH_LOCK = RLock()
+
+
+@dataclass
+class DFlashConfig:
+    hidden_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    intermediate_size: int
+    vocab_size: int
+    rms_norm_eps: float
+    rope_theta: float
+    max_position_embeddings: int
+    block_size: int
+    target_layer_ids: Tuple[int, ...]
+    num_target_layers: int
+    mask_token_id: int = 0
+    rope_scaling: Optional[Dict[str, Any]] = None
+    layer_types: Tuple[str, ...] = field(default_factory=tuple)
+    sliding_window: Optional[int] = None
+    final_logit_softcapping: Optional[float] = None
+
+
+def _build_rope(
+    head_dim: int,
+    rope_theta: float,
+    max_position_embeddings: int,
+    rope_scaling: Optional[Dict[str, Any]],
+):
+    return initialize_rope(
+        dims=head_dim,
+        base=rope_theta,
+        traditional=False,
+        scaling_config=rope_scaling,
+        max_position_embeddings=max_position_embeddings,
+    )
+
+
+class DFlashAttention(nn.Module):
+    def __init__(self, config: DFlashConfig, layer_idx: int):
+        super().__init__()
+        dim = config.hidden_size
+        self.n_heads = n_heads = config.num_attention_heads
+        self.n_kv_heads = n_kv_heads = config.num_key_value_heads
+        self.scale = config.head_dim ** -0.5
+        self.is_sliding = config.layer_types[layer_idx] == "sliding_attention"
+        self.sliding_window = config.sliding_window if self.is_sliding else None
+        self.q_proj = nn.Linear(dim, n_heads * config.head_dim, bias=False)
+        self.k_proj = nn.Linear(dim, n_kv_heads * config.head_dim, bias=False)
+        self.v_proj = nn.Linear(dim, n_kv_heads * config.head_dim, bias=False)
+        self.o_proj = nn.Linear(n_heads * config.head_dim, dim, bias=False)
+        self.q_norm = nn.RMSNorm(config.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(config.head_dim, eps=config.rms_norm_eps)
+
+    def __call__(self, x, x_ctx, rope, cache):
+        B, L, _ = x.shape
+        S = x_ctx.shape[1]
+        if self.is_sliding:
+            keep_ctx = self.sliding_window - 1
+            if S > keep_ctx:
+                skip = S - keep_ctx
+                x_ctx = x_ctx[:, skip:]
+                S = x_ctx.shape[1]
+                cache.offset += skip
+        queries = self.q_proj(x)
+        ctx_keys = self.k_proj(x_ctx)
+        ctx_values = self.v_proj(x_ctx)
+        prop_keys = self.k_proj(x)
+        prop_values = self.v_proj(x)
+        queries = self.q_norm(queries.reshape(B, L, self.n_heads, -1)).transpose(0, 2, 1, 3)
+        ctx_keys = self.k_norm(ctx_keys.reshape(B, S, self.n_kv_heads, -1)).transpose(0, 2, 1, 3)
+        ctx_values = ctx_values.reshape(B, S, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        prop_keys = self.k_norm(prop_keys.reshape(B, L, self.n_kv_heads, -1)).transpose(0, 2, 1, 3)
+        prop_values = prop_values.reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        queries = rope(queries, offset=cache.offset + S)
+        ctx_keys = rope(ctx_keys, offset=cache.offset)
+        prop_keys = rope(prop_keys, offset=cache.offset + S)
+        keys, values = cache.update_and_fetch(ctx_keys, ctx_values)
+        ctx_len = keys.shape[2]
+        keys = mx.concatenate([keys, prop_keys], axis=2)
+        values = mx.concatenate([values, prop_values], axis=2)
+        mask = None
+        if self.is_sliding:
+            mask = (
+                "causal" if ctx_len + L <= self.sliding_window
+                else create_causal_mask(L, offset=ctx_len, window_size=self.sliding_window)
+            )
+        output = mx.fast.scaled_dot_product_attention(queries, keys, values, scale=self.scale, mask=mask)
+        return self.o_proj(output.transpose(0, 2, 1, 3).reshape(B, L, -1))
+
+
+class DFlashDecoderLayer(nn.Module):
+    def __init__(self, config: DFlashConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = DFlashAttention(config, layer_idx)
+        self.mlp = MLP(config.hidden_size, config.intermediate_size)
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def __call__(self, x, x_ctx, rope, cache):
+        h = x + self.self_attn(self.input_layernorm(x), x_ctx, rope, cache)
+        return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class DFlashDraftModel(nn.Module):
+    def __init__(self, config: DFlashConfig):
+        super().__init__()
+        self.config = config
+        if not self.config.layer_types:
+            self.config.layer_types = ("full_attention",) * self.config.num_hidden_layers
+        concat_dim = len(config.target_layer_ids) * config.hidden_size
+        self.fc = nn.Linear(concat_dim, config.hidden_size, bias=False)
+        self.hidden_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.layers = [DFlashDecoderLayer(config, i) for i in range(config.num_hidden_layers)]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rope = _build_rope(
+            config.head_dim,
+            config.rope_theta,
+            config.max_position_embeddings,
+            config.rope_scaling,
+        )
+        self.embed_tokens = None
+        self.lm_head = None
+        self.embed_scale = 1.0
+
+    def bind(self, target_model):
+        if hasattr(target_model, "embed_tokens"):
+            inner = target_model
+        elif hasattr(target_model, "model") and hasattr(target_model.model, "embed_tokens"):
+            inner = target_model.model
+        elif (hasattr(target_model, "language_model") and
+              hasattr(target_model.language_model, "model") and
+              hasattr(target_model.language_model.model, "embed_tokens")):
+            inner = target_model.language_model.model
+        else:
+            raise AttributeError(f"Cannot find embed_tokens in {type(target_model).__name__}")
+        self.embed_tokens = inner.embed_tokens
+        self.embed_scale = getattr(self.embed_tokens, "embed_scale", getattr(inner, "embed_scale", 1.0))
+        lm = getattr(target_model, "language_model", target_model)
+        self.lm_head = getattr(target_model, "lm_head", None) or getattr(lm, "lm_head", None) or self.embed_tokens.as_linear
+        return self
+
+    def make_cache(self):
+        caches = []
+        for layer_type in self.config.layer_types:
+            if layer_type == "sliding_attention":
+                if self.config.sliding_window is None:
+                    raise ValueError("Draft config must define sliding_window for sliding_attention layers.")
+                caches.append(RotatingKVCache(max_size=self.config.sliding_window - 1, keep=0))
+            else:
+                caches.append(KVCache())
+        return caches
+
+    def __call__(
+        self,
+        inputs,
+        target_hidden,
+        cache,
+        logits_start: int = 0,
+    ):
+        h = self.embed_tokens(inputs) * self.embed_scale
+        h_ctx = self.hidden_norm(self.fc(target_hidden))
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, h_ctx, self.rope, c)
+        if logits_start:
+            h = h[:, logits_start:]
+        logits = self.lm_head(self.norm(h))
+        if self.config.final_logit_softcapping is not None:
+            cap = self.config.final_logit_softcapping
+            logits = mx.tanh(logits / cap) * cap
+        return logits
+
+
+def load(model_id: str):
+    from mlx_lm import load as mlx_lm_load
+    return mlx_lm_load(model_id)
+
+
+def load_draft(draft_id: str) -> DFlashDraftModel:
+    path = Path(snapshot_download(draft_id, allow_patterns=["*.safetensors", "*.json"]))
+    cfg = json.loads((path / "config.json").read_text())
+    layer_types = tuple(cfg.get("layer_types") or ["full_attention"] * cfg["num_hidden_layers"])
+    if len(layer_types) != cfg["num_hidden_layers"]:
+        raise ValueError("Draft config layer_types length must match num_hidden_layers.")
+    unknown_layer_types = set(layer_types) - {"full_attention", "sliding_attention"}
+    if unknown_layer_types:
+        raise ValueError(f"Unsupported draft layer_types: {sorted(unknown_layer_types)}.")
+    if "sliding_attention" in layer_types and cfg.get("sliding_window") is None:
+        raise ValueError("Draft config must define sliding_window for sliding_attention layers.")
+    config = DFlashConfig(
+        hidden_size=cfg["hidden_size"],
+        num_hidden_layers=cfg["num_hidden_layers"],
+        num_attention_heads=cfg["num_attention_heads"],
+        num_key_value_heads=cfg["num_key_value_heads"],
+        head_dim=cfg["head_dim"],
+        intermediate_size=cfg["intermediate_size"],
+        vocab_size=cfg["vocab_size"],
+        rms_norm_eps=cfg["rms_norm_eps"],
+        rope_theta=cfg["rope_theta"],
+        max_position_embeddings=cfg["max_position_embeddings"],
+        block_size=cfg["block_size"],
+        target_layer_ids=tuple(cfg["dflash_config"]["target_layer_ids"]),
+        num_target_layers=cfg["num_target_layers"],
+        mask_token_id=cfg["dflash_config"]["mask_token_id"],
+        rope_scaling=cfg.get("rope_scaling"),
+        layer_types=layer_types,
+        sliding_window=cfg.get("sliding_window"),
+        final_logit_softcapping=cfg.get("final_logit_softcapping"),
+    )
+    weights = {k: v for f in path.glob("*.safetensors") for k, v in mx.load(str(f)).items()}
+    model = DFlashDraftModel(config)
+    model.load_weights(list(weights.items()))
+    return model
+
+
+def _trim_recent_cache(cache: List[Any], num_tokens: int) -> None:
+    if num_tokens <= 0:
+        return
+    for c in cache:
+        n = min(getattr(c, "offset", num_tokens), num_tokens)
+        if n <= 0:
+            continue
+        if isinstance(c, RotatingKVCache) and c.keys is not None:
+            c.keys = c._temporal_order(c.keys)
+            c.values = c._temporal_order(c.values)
+            c.keys = c.keys[..., :-n, :]
+            c.values = c.values[..., :-n, :]
+            c.offset -= n
+            c._idx = c.keys.shape[2]
+        elif hasattr(c, "trim"):
+            c.trim(n)
+
+
+class _LayerHook:
+    def __init__(self, layer, idx, storage):
+        self._layer, self._idx, self._storage = layer, idx, storage
+
+    def __call__(self, *args, **kwargs):
+        out = self._layer(*args, **kwargs)
+        self._storage[self._idx] = out[0] if isinstance(out, tuple) else out
+        return out
+
+    def __getattr__(self, name):
+        return getattr(self._layer, name)
+
+
+def _get_layers(model):
+    if hasattr(model, "model") and hasattr(model.model, "layers"):
+        return model.model.layers
+    if hasattr(model, "language_model") and hasattr(model.language_model, "layers"):
+        return model.language_model.layers
+    if hasattr(model, "layers"):
+        return model.layers
+    raise AttributeError(f"Cannot find layers in {type(model).__name__}")
+
+
+def _patch_model(model, layer_ids):
+    if hasattr(model, "_hidden_states"):
+        return
+    model._hidden_states = [None] * len(layer_ids)
+    layers = _get_layers(model)
+    for i, lid in enumerate(layer_ids):
+        layers[lid] = _LayerHook(layers[lid], i, model._hidden_states)
+
+
+class _GDNStateCapture:
+    def __init__(self):
+        self.conv_data = []
+        self._gdn_inputs = []
+        self._gdn_cls = None
+        self._orig_call = None
+        self._patched_call = None
+        self._closed = False
+        _GDN_PATCH_LOCK.acquire()
+        try:
+            self._patch()
+        except Exception:
+            _GDN_PATCH_LOCK.release()
+            raise
+
+    def _patch(self):
+        from mlx_lm.models.qwen3_5 import GatedDeltaNet
+        self._gdn_cls = GatedDeltaNet
+        self._orig_call = GatedDeltaNet.__call__
+        capture = self
+
+        def _capturing_gdn_call(self_layer, inputs, mask=None, cache=None):
+            B, S, _ = inputs.shape
+            if self_layer.sharding_group is not None:
+                from mlx_lm.models.qwen3_5 import sum_gradients
+                inputs = sum_gradients(self_layer.sharding_group)(inputs)
+            qkv = self_layer.in_proj_qkv(inputs)
+            z = self_layer.in_proj_z(inputs).reshape(B, S, self_layer.num_v_heads, self_layer.head_v_dim)
+            b, a = self_layer.in_proj_b(inputs), self_layer.in_proj_a(inputs)
+            conv_state = cache[0] if (cache is not None and cache[0] is not None) else mx.zeros((B, self_layer.conv_kernel_size - 1, self_layer.conv_dim), dtype=inputs.dtype)
+            if mask is not None:
+                qkv = mx.where(mask[..., None], qkv, 0)
+            conv_input = mx.concatenate([conv_state, qkv], axis=1)
+            capture.conv_data.append((conv_input, self_layer.conv_kernel_size))
+            if cache is not None:
+                cache[0] = conv_input[:, -(self_layer.conv_kernel_size - 1):]
+            conv_out = nn.silu(self_layer.conv1d(conv_input))
+            q, k, v = [
+                t.reshape(B, S, h, d)
+                for t, h, d in zip(
+                    mx.split(conv_out, [self_layer.key_dim, 2 * self_layer.key_dim], -1),
+                    [self_layer.num_k_heads, self_layer.num_k_heads, self_layer.num_v_heads],
+                    [self_layer.head_k_dim, self_layer.head_k_dim, self_layer.head_v_dim],
+                )
+            ]
+            state = cache[1] if cache else None
+            inv_scale = k.shape[-1] ** -0.5
+            q = (inv_scale ** 2) * mx.fast.rms_norm(q, None, 1e-6)
+            k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+            capture._gdn_inputs.append((q, k, v, a, b, self_layer.A_log, self_layer.dt_bias, state, mask))
+            out, new_state = _gd_mod.gated_delta_update(
+                q, k, v, a, b, self_layer.A_log, self_layer.dt_bias, state, mask, use_kernel=True
+            )
+            if cache is not None:
+                cache[1] = new_state
+            out = self_layer.norm(out, z)
+            out = self_layer.out_proj(out.reshape(B, S, -1))
+            if self_layer.sharding_group is not None:
+                out = mx.distributed.all_sum(out, group=self_layer.sharding_group)
+            return out
+
+        self._patched_call = _capturing_gdn_call
+        GatedDeltaNet.__call__ = _capturing_gdn_call
+
+    def clear(self):
+        self.conv_data.clear()
+        self._gdn_inputs.clear()
+
+    def close(self):
+        if self._closed:
+            return
+        try:
+            if self._gdn_cls is not None and self._gdn_cls.__call__ is self._patched_call:
+                self._gdn_cls.__call__ = self._orig_call
+        finally:
+            self._closed = True
+            self._gdn_cls = None
+            self._orig_call = None
+            self._patched_call = None
+            _GDN_PATCH_LOCK.release()
+
+    def rollback(self, cache, accepted, trim):
+        n_non_trimmable = sum(1 for c in cache if not c.is_trimmable())
+        assert n_non_trimmable == len(self._gdn_inputs), (
+            f"non-trimmable cache count ({n_non_trimmable}) != "
+            f"captured GDN inputs ({len(self._gdn_inputs)}); "
+            "DFlash MLX rollback assumes every non-trimmable cache is a GatedDeltaNet layer"
+        )
+        j = 0
+        for c in cache:
+            if c.is_trimmable():
+                c.trim(trim)
+            else:
+                q, k, v, a, b, A_log, dt_bias, init_state, mask = self._gdn_inputs[j]
+                n = accepted + 1
+                _, state = _gd_mod.gated_delta_update(
+                    q[:, :n], k[:, :n], v[:, :n], a[:, :n], b[:, :n],
+                    A_log, dt_bias, init_state,
+                    None if mask is None else mask[:, :n],
+                    use_kernel=True,
+                )
+                c.cache[1] = state
+                conv_input, K = self.conv_data[j]
+                c.cache[0] = conv_input[:, accepted + 1 : accepted + K]
+                j += 1
+
+
+@dataclass
+class GenerationResponse:
+    text: str
+    tokens: List[int]
+    accepted: int
+    prompt_tokens: int
+    prompt_tps: float
+    generation_tokens: int
+    generation_tps: float
+    peak_memory: float
+    finish_reason: Optional[str] = None
+
+
+def _make_response(
+    text,
+    tokens,
+    accepted,
+    prompt_size,
+    prompt_tps,
+    n,
+    tic,
+    finish_reason=None,
+):
+    return GenerationResponse(
+        text, tokens, accepted, prompt_size, prompt_tps,
+        n, n / (time.perf_counter() - tic), mx.get_peak_memory() / 1e9, finish_reason,
+    )
+
+
+def stream_generate(
+    model, draft, tokenizer, prompt,
+    block_size=None, max_tokens=256, temperature=0.0, sampler=None,
+):
+    _patch_model(model, draft.config.target_layer_ids)
+    block_size = block_size if block_size is not None else int(draft.config.block_size)
+    sampler = sampler or make_sampler(temp=temperature)
+
+    if not isinstance(tokenizer, TokenizerWrapper):
+        tokenizer = TokenizerWrapper(tokenizer)
+
+    if not isinstance(prompt, mx.array):
+        if isinstance(prompt, str):
+            add_special_tokens = tokenizer.bos_token is None or not prompt.startswith(tokenizer.bos_token)
+            prompt = tokenizer.encode(prompt, add_special_tokens=add_special_tokens)
+        prompt = mx.array(prompt)
+
+    detokenizer = tokenizer.detokenizer
+    mask_id = int(draft.config.mask_token_id)
+    tokens = prompt.tolist()
+
+    target_cache = make_prompt_cache(model)
+    draft_cache = make_prompt_cache(draft)
+    draft.bind(model)
+    _target_can_trim = can_trim_prompt_cache(target_cache)
+    if not _target_can_trim and not _HAS_GDN:
+        raise RuntimeError(
+            "This MLX model requires gated-delta rollback support, but "
+            "mlx_lm.models.gated_delta is unavailable."
+        )
+    _capture = _GDNStateCapture() if not _target_can_trim else None
+
+    try:
+        tic = time.perf_counter()
+        with mx.stream(generation_stream):
+            logits = model(prompt[None], target_cache)
+            hidden = mx.concatenate(model._hidden_states, axis=-1)
+        mx.eval(logits, hidden)
+        prompt_tps = prompt.size / (time.perf_counter() - tic)
+
+        tic = time.perf_counter()
+        token = sampler(logits[:, -1:])[0, 0].item()
+        tokens.append(token)
+        n = 1
+
+        if token in tokenizer.eos_token_ids:
+            detokenizer.add_token(token)
+            detokenizer.finalize()
+            yield _make_response(detokenizer.last_segment, [token], 1, prompt.size, prompt_tps, n, tic, "stop")
+            return
+
+        detokenizer.add_token(token)
+        yield _make_response(
+            detokenizer.last_segment,
+            [token],
+            1,
+            prompt.size,
+            prompt_tps,
+            n,
+            tic,
+        )
+
+        while n < max_tokens:
+            bs = min(block_size, max_tokens - n + 1)
+            if bs <= 1:
+                break
+
+            with mx.stream(generation_stream):
+                block = mx.array([[tokens[-1]] + [mask_id] * (bs - 1)])
+                draft_logits = draft(
+                    block,
+                    hidden,
+                    draft_cache,
+                    logits_start=1,
+                )
+                if (trim_n := draft_cache[0].offset - (prompt.size + n - 1)) > 0:
+                    _trim_recent_cache(draft_cache, trim_n)
+                draft_tokens = sampler(draft_logits)
+            mx.async_eval(draft_tokens)
+
+            if _capture is not None:
+                _capture.clear()
+            with mx.stream(generation_stream):
+                verify_input = mx.concatenate([mx.array([[tokens[-1]]]), draft_tokens], axis=1)
+                logits = model(verify_input, target_cache)
+                hidden = mx.concatenate(model._hidden_states, axis=-1)
+                target_tokens = sampler(logits)
+            mx.async_eval(target_tokens, hidden)
+
+            d_list, t_list = draft_tokens[0].tolist(), target_tokens[0].tolist()
+            accepted = next((i for i in range(len(d_list)) if d_list[i] != t_list[i]), len(d_list))
+            new_tokens = d_list[:accepted] + [t_list[accepted]]
+            new_tokens = new_tokens[:max_tokens - n]
+
+            eos_idx = next((i for i, t in enumerate(new_tokens) if t in tokenizer.eos_token_ids), None)
+            if eos_idx is not None:
+                new_tokens = new_tokens[:eos_idx + 1]
+                for t in new_tokens:
+                    detokenizer.add_token(t)
+                detokenizer.finalize()
+                tokens.extend(new_tokens)
+                n += len(new_tokens)
+                yield _make_response(
+                    detokenizer.last_segment,
+                    new_tokens,
+                    accepted + 1,
+                    prompt.size,
+                    prompt_tps,
+                    n,
+                    tic,
+                    "stop",
+                )
+                return
+
+            for t in new_tokens:
+                detokenizer.add_token(t)
+            tokens.extend(new_tokens)
+            n += len(new_tokens)
+
+            if n % 256 == 0:
+                mx.clear_cache()
+
+            yield _make_response(
+                detokenizer.last_segment,
+                new_tokens,
+                accepted + 1,
+                prompt.size,
+                prompt_tps,
+                n,
+                tic,
+            )
+
+            trim = bs - accepted - 1
+            if trim > 0:
+                if _target_can_trim:
+                    _trim_recent_cache(target_cache, trim)
+                elif _capture is not None:
+                    _capture.rollback(target_cache, accepted, trim)
+            hidden = hidden[:, :accepted + 1, :]
+
+        detokenizer.finalize()
+        yield _make_response(
+            detokenizer.last_segment,
+            [],
+            0,
+            prompt.size,
+            prompt_tps,
+            n,
+            tic,
+            "length",
+        )
+    finally:
+        if _capture is not None:
+            _capture.close()

--- a/oracle/dflash_parity.py
+++ b/oracle/dflash_parity.py
@@ -1,0 +1,111 @@
+# DFlash drafter parity reference generator (#98 phase 2b).
+#
+# Runs the vendored upstream drafter (dflash_model_mlx.py, verbatim from z-lab/dflash)
+# on the real checkpoint with weights cast to float16 (matching the Swift port's dtype),
+# on deterministic random inputs, and writes inputs + module-level outputs (final-normed
+# hidden, NO embed/lm_head — the exact contract of DFlashDrafter.forward) to a
+# safetensors bundle. The Swift side (QWISP_RUN=dflash-parity) replays and compares.
+#
+# Cases:
+#   A: call1 (S=17, L=8) -> out1; call2 (S=5, L=8) -> out2;
+#      trim 2 rows (reject rollback) -> call3 (S=3, L=8) -> out3
+#   B: fresh cache, S=4100 > sliding_window-1 (crop + windowed-causal mask branch), L=8 -> outB
+#
+# Usage: <mlx-python> oracle/dflash_parity.py [ckpt_dir] [out_path]
+
+import json
+import sys
+from pathlib import Path
+
+import mlx.core as mx
+
+sys.path.insert(0, str(Path(__file__).parent))
+from dflash_model_mlx import DFlashConfig, DFlashDraftModel, _trim_recent_cache
+
+
+def load_f16(ckpt: Path) -> DFlashDraftModel:
+    cfg = json.loads((ckpt / "config.json").read_text())
+    config = DFlashConfig(
+        hidden_size=cfg["hidden_size"],
+        num_hidden_layers=cfg["num_hidden_layers"],
+        num_attention_heads=cfg["num_attention_heads"],
+        num_key_value_heads=cfg["num_key_value_heads"],
+        head_dim=cfg["head_dim"],
+        intermediate_size=cfg["intermediate_size"],
+        vocab_size=cfg["vocab_size"],
+        rms_norm_eps=cfg["rms_norm_eps"],
+        rope_theta=cfg["rope_parameters"]["rope_theta"],
+        max_position_embeddings=cfg["max_position_embeddings"],
+        block_size=cfg["dflash_config"]["block_size"],
+        target_layer_ids=tuple(cfg["dflash_config"]["target_layer_ids"]),
+        num_target_layers=cfg["num_target_layers"],
+        mask_token_id=cfg["dflash_config"]["mask_token_id"],
+        rope_scaling=cfg.get("rope_scaling"),
+        layer_types=tuple(cfg["layer_types"]),
+        sliding_window=cfg.get("sliding_window"),
+        final_logit_softcapping=cfg.get("final_logit_softcapping"),
+    )
+    weights = {}
+    for f in ckpt.glob("*.safetensors"):
+        for k, v in mx.load(str(f)).items():
+            weights[k] = v.astype(mx.float16)  # match the Swift port's f16 cast
+    model = DFlashDraftModel(config)
+    model.load_weights(list(weights.items()))
+    return model
+
+
+def forward_module(model, noise, ctx, cache):
+    """Module-level forward matching DFlashDrafter.forward: final-normed hidden,
+    no embed/lm_head (verbatim slice of DFlashDraftModel.__call__)."""
+    h_ctx = model.hidden_norm(model.fc(ctx))
+    h = noise
+    for layer, c in zip(model.layers, cache):
+        h = layer(h, h_ctx, model.rope, c)
+    return model.norm(h)
+
+
+def main():
+    ckpt = Path(sys.argv[1]) if len(sys.argv) > 1 else (
+        Path.home() / ".mtplx/models/z-lab--Qwen3.6-35B-A3B-DFlash")
+    out_path = sys.argv[2] if len(sys.argv) > 2 else "/tmp/dflash_parity.safetensors"
+
+    model = load_f16(ckpt)
+    H = model.config.hidden_size
+    F = len(model.config.target_layer_ids) * model.config.hidden_size  # ctx feature dim
+    L = 8
+
+    mx.random.seed(0)
+    bundle = {}
+
+    def rnd(shape):
+        return mx.random.normal(shape).astype(mx.float16)
+
+    # Case A: sequential blocks + trim rollback
+    cache = model.make_cache()
+    noise1, ctx1 = rnd((1, L, H)), rnd((1, 17, F))
+    out1 = forward_module(model, noise1, ctx1, cache)
+    noise2, ctx2 = rnd((1, L, H)), rnd((1, 5, F))
+    out2 = forward_module(model, noise2, ctx2, cache)
+    _trim_recent_cache(cache, 2)  # reject rollback: drop last 2 committed rows
+    noise3, ctx3 = rnd((1, L, H)), rnd((1, 3, F))
+    out3 = forward_module(model, noise3, ctx3, cache)
+    bundle.update(noise1=noise1, ctx1=ctx1, out1=out1,
+                  noise2=noise2, ctx2=ctx2, out2=out2,
+                  noise3=noise3, ctx3=ctx3, out3=out3)
+
+    # Case B: crop + windowed-causal mask branch (S > sliding_window-1)
+    cacheB = model.make_cache()
+    noiseB, ctxB = rnd((1, L, H)), rnd((1, 4100, F))
+    outB = forward_module(model, noiseB, ctxB, cacheB)
+    bundle.update(noiseB=noiseB, ctxB=ctxB, outB=outB)
+
+    mx.eval(*bundle.values())
+    mx.save_safetensors(out_path, bundle)
+    print(f"[dflash-parity-ref] wrote {out_path}")
+    for k in ("out1", "out2", "out3", "outB"):
+        a = bundle[k]
+        print(f"  {k}: shape={a.shape} mean|x|={mx.abs(a).mean().item():.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/swift/Sources/QwispCore/DFlashParityProbe.swift
+++ b/swift/Sources/QwispCore/DFlashParityProbe.swift
@@ -1,0 +1,62 @@
+import Foundation
+import MLX
+
+// #98 phase 2b: real-checkpoint parity probe — replay oracle/dflash_parity.py's call
+// sequence on DFlashDrafter and compare module outputs (final-normed hidden) against
+// the Python reference bundle. QWISP_RUN=dflash-parity.
+// Env: QWISP_DFLASH_DIR (default ~/.mtplx/models/z-lab--Qwen3.6-35B-A3B-DFlash),
+//      QWISP_DFLASH_PARITY (default /tmp/dflash_parity.safetensors).
+public enum DFlashParityProbe {
+    static func cmp(_ got: MLXArray, _ ref: MLXArray, _ name: String) -> String {
+        got.eval(); ref.eval()
+        let g = got.asType(.float16).reshaped([-1]).asArray(Float16.self)
+        let r = ref.asType(.float16).reshaped([-1]).asArray(Float16.self)
+        guard g.count == r.count else { return "\(name): SHAPE MISMATCH \(g.count) vs \(r.count)" }
+        var bitEq = 0
+        var maxAbs: Float = 0, maxRel: Float = 0
+        for i in 0 ..< g.count {
+            if g[i].bitPattern == r[i].bitPattern { bitEq += 1 }
+            let a = abs(Float(g[i]) - Float(r[i]))
+            maxAbs = max(maxAbs, a)
+            let d = max(abs(Float(r[i])), 1e-3)
+            maxRel = max(maxRel, a / d)
+        }
+        let pct = 100.0 * Double(bitEq) / Double(g.count)
+        return String(format: "%@: bitEq=%.2f%% maxAbs=%.3e maxRel=%.3e", name, pct, maxAbs, maxRel)
+    }
+
+    public static func run() -> String {
+        let env = ProcessInfo.processInfo.environment
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let dir = env["QWISP_DFLASH_DIR"] ?? "\(home)/.mtplx/models/z-lab--Qwen3.6-35B-A3B-DFlash"
+        let bundlePath = env["QWISP_DFLASH_PARITY"] ?? "/tmp/dflash_parity.safetensors"
+
+        guard let drafter = DFlashDrafter.load(dir: URL(fileURLWithPath: dir)) else {
+            return "[dflash-parity] FAIL: DFlashDrafter.load(\(dir)) nil"
+        }
+        guard let bundle = try? loadArrays(url: URL(fileURLWithPath: bundlePath)) else {
+            return "[dflash-parity] FAIL: bundle load \(bundlePath) (run oracle/dflash_parity.py first)"
+        }
+        func need(_ k: String) -> MLXArray? { bundle[k] }
+        guard let n1 = need("noise1"), let c1 = need("ctx1"), let o1 = need("out1"),
+              let n2 = need("noise2"), let c2 = need("ctx2"), let o2 = need("out2"),
+              let n3 = need("noise3"), let c3 = need("ctx3"), let o3 = need("out3"),
+              let nB = need("noiseB"), let cB = need("ctxB"), let oB = need("outB")
+        else { return "[dflash-parity] FAIL: bundle missing keys" }
+
+        var lines: [String] = ["[dflash-parity] drafter=\(dir)"]
+
+        // Case A: sequential blocks + trim rollback (mirror of dflash_parity.py)
+        let caches = drafter.makeCaches()
+        lines.append(cmp(drafter.forward(noise: n1.asType(.float16), ctx: c1.asType(.float16), caches: caches), o1, "out1"))
+        lines.append(cmp(drafter.forward(noise: n2.asType(.float16), ctx: c2.asType(.float16), caches: caches), o2, "out2"))
+        drafter.trimTo(committed: caches[0].offset - 2, caches: caches)
+        lines.append(cmp(drafter.forward(noise: n3.asType(.float16), ctx: c3.asType(.float16), caches: caches), o3, "out3"))
+
+        // Case B: crop + windowed-causal mask branch
+        let cachesB = drafter.makeCaches()
+        lines.append(cmp(drafter.forward(noise: nB.asType(.float16), ctx: cB.asType(.float16), caches: cachesB), oB, "outB"))
+
+        return lines.joined(separator: "\n")
+    }
+}

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -38,6 +38,7 @@ if CommandLine.arguments.contains("stream") {
         ("prefix-cache-speed", { md, _ in Tell.prefixCacheSpeedProbe(modelDir: md) }),
         ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),
         ("gqmm2-bench", { _, _ in SeedlessMetalForward.gqmm2Bench() }),   // notes/18 W1 speed sim
+        ("dflash-parity", { _, _ in DFlashParityProbe.run() }),           // #98 phase 2b oracle parity
     ]
     if let name = env["QWISP_RUN"] {
         if let r = runners.first(where: { $0.0 == name }) {


### PR DESCRIPTION
Part of #98. Driver follow-up promised in #110: exercises the Swift `DFlashDrafter` against the vendored upstream reference (`oracle/dflash_model_mlx.py`, verbatim z-lab/dflash) on the real 772MB checkpoint.

## Method

`oracle/dflash_parity.py` (MLX python, weights cast f16 to match the port) writes fixed-seed inputs + module-level outputs; `QWISP_RUN=dflash-parity` replays them on `DFlashDrafter` and compares. Four cases: 3 sequential blocks including a 2-row trim rollback, plus S=4100 in one call — the **sliding crop + windowed-causal mask branch** that the synthetic locked tests could not reach (flagged in #110's review).

## Result — algorithmic parity confirmed

| case | maxAbs | note |
|------|--------|------|
| out1 | 1.56e-2 | first block, S=17 |
| out2 | 1.56e-2 | cached second block |
| out3 | 9.0e-3 | after 2-row trim rollback |
| outB | 7.8e-3 | crop + windowed mask (S=4100) |

mean|x| ≈ 0.79, so worst-element diff ≈ 2%. Diffs are uniform across all cases — including the crop/windowed branch, which shows the *smallest* diff. An algorithmic bug (wrong key set / mask off-by-one / bad offset) would produce O(1) diffs concentrated in outB; this pattern is f16 rounding divergence between python mlx 0.31.2 and mlx-swift kernel builds (bitEq ~20% is consistent: one differing kernel cascades). Mask boundary was additionally verified against `mlx_lm.create_causal_mask` source in #110.

The drafter is off the lossless path (a wrong draft only lowers accept), so kernel-build-level rounding differences are acceptable by design; verify remains exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)