### PR TITLE
feat(dflash): dispatch wiring — block drafts on draftless spans, QWISP_DFLASH opt-in (#98 phase 3)

### DIFF
--- a/swift/Sources/QwispCore/DFlashDispatch.swift
+++ b/swift/Sources/QwispCore/DFlashDispatch.swift
@@ -1,0 +1,86 @@
+import Foundation
+import MLX
+import Metal
+
+/// #98 DFlash phase 3: dispatch wiring.
+///
+/// Drives the DFlash block drafter (DFlashDrafter) on the draftless (D==0) decode span,
+/// gated by `QWISP_DFLASH` (default OFF ⇒ this object is never constructed and every path
+/// stays byte-identical). Resident tier only (v1 tier scoping).
+///
+/// Divergence from the Python `model_mlx` reference: v1 feeds ONLY committed rows as ctx
+/// (pendingCtx is appended post-accept, in the tap harvest), so the drafter cache never
+/// contains rejected rows and `trimTo` is not called by the dispatch. (model_mlx trims
+/// because it feeds hidden before knowing the accept; we don't.)
+///
+public final class DFlashDispatch {
+    let drafter: DFlashDrafter
+    var caches: [DFlashKVCache]
+    let blockSize: Int                          // QWISP_DFLASH_BLOCK, default 8
+    let maskId: Int32                           // drafter.config.maskTokenId
+    let nTap: Int, H: Int, ctxDim: Int          // nTap = |targetLayerIds|; ctxDim = ctxFeatureDim; H = ctxDim/nTap (tap hidden)
+    // Injected hooks (testability: locked tests pass synthetic closures):
+    let embedFn: ([Int32]) -> MLXArray?         // engine.embed wrapped → [M,H] f16
+    let logitsArgmaxFn: (MLXArray) -> [Int]?    // drafter hidden [L,H] → per-row argmax ids
+    // ctx accumulation (pending until next draft call):
+    private(set) var pendingCtx: [Float16] = [] // pendingRows * ctxDim, row-major
+    private(set) var pendingRows: Int = 0
+    private(set) var ctxRowsFed: Int = 0        // total ctx rows in drafter cache
+
+    public init(drafter: DFlashDrafter, blockSize: Int,
+                embedFn: @escaping ([Int32]) -> MLXArray?,
+                logitsArgmaxFn: @escaping (MLXArray) -> [Int]?) {
+        self.drafter = drafter
+        self.caches = drafter.makeCaches()
+        self.blockSize = blockSize
+        self.maskId = Int32(drafter.config.maskTokenId)
+        self.nTap = drafter.config.targetLayerIds.count
+        self.ctxDim = drafter.config.ctxFeatureDim
+        self.H = self.nTap > 0 ? self.ctxDim / self.nTap : 0
+        self.embedFn = embedFn
+        self.logitsArgmaxFn = logitsArgmaxFn
+    }
+
+    /// Append committed rows [0,rows) of the per-forward tap buffer to pendingCtx.
+    /// For row r, appends the concatenation over tap slots t=0..<nTap of
+    /// `tapBuf[t*maxM*H + r*H ..< +H]` (tap-slot order = targetLayerIds order).
+    public func appendCtx(tapBuf: MTLBuffer, maxM: Int, rows: Int) {
+        guard rows > 0, nTap > 0, H > 0 else { return }
+        let ptr = tapBuf.contents().assumingMemoryBound(to: Float16.self)
+        pendingCtx.reserveCapacity(pendingCtx.count + rows * ctxDim)
+        for r in 0 ..< rows {
+            for t in 0 ..< nTap {
+                let base = t * maxM * H + r * H
+                for h in 0 ..< H { pendingCtx.append(ptr[base + h]) }
+            }
+        }
+        pendingRows += rows
+    }
+
+    /// Returns blockSize-1 draft token ids, or nil (caller falls back to the old path).
+    /// v1 semantics (see file-header note): only called with pendingRows >= 1 (there is
+    /// always >= 1 new committed row since the last draft — the anchor commit). Cold start
+    /// (pendingRows == 0, nothing harvested yet) and "no new ctx since the last draft" both
+    /// collapse to the same `pendingRows == 0` check.
+    public func draft(u: Int) -> [Int]? {
+        guard pendingRows > 0 else { return nil }
+        let tokens: [Int32] = [Int32(u)] + Array(repeating: maskId, count: blockSize - 1)
+        guard let embedded = embedFn(tokens) else { return nil }
+        let noise = embedded.reshaped([1, blockSize, -1])
+        let ctx = MLXArray(pendingCtx, [1, pendingRows, ctxDim])
+        let hidden = drafter.forward(noise: noise, ctx: ctx, caches: caches)
+        ctxRowsFed += pendingRows
+        pendingCtx = []
+        pendingRows = 0
+        guard let ids = logitsArgmaxFn(hidden[0, 1...]), ids.count == blockSize - 1 else { return nil }
+        return ids
+    }
+
+    /// Fresh caches, clears pending/ctxRowsFed (new request/segment).
+    public func reset() {
+        caches = drafter.makeCaches()
+        pendingCtx = []
+        pendingRows = 0
+        ctxRowsFed = 0
+    }
+}

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -103,6 +103,38 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     public var losslessForced: Bool? = nil
     public var lossless: Bool { losslessForced ?? (ProcessInfo.processInfo.environment["QWISP_LOSSLESS"] == "1") }
     private var boltServe: BoltServe? = nil
+    // #98 DFlash phase 3: opt-in QWISP_DFLASH=1, resident tier only. Built once (lazily) per
+    // instance and reused across requests — loading the drafter checkpoint per-request would
+    // be a needless disk read. nil (flag off, or load failure) → dflashIfEnabled() returns nil
+    // every call → every runSpecLoop seam stays byte-identical (nil-guarded).
+    private var dflash: DFlashDispatch? = nil
+    private var dflashLoadAttempted = false
+    private func dflashIfEnabled() -> DFlashDispatch? {
+        guard Tell.envFlag("QWISP_DFLASH") else { return nil }
+        if dflash == nil, !dflashLoadAttempted {
+            dflashLoadAttempted = true
+            dflash = SeedlessBackend.makeDFlash(engine: engine)
+        }
+        return dflash
+    }
+    private static func makeDFlash(engine: SeedlessEngine) -> DFlashDispatch? {
+        let dir = ProcessInfo.processInfo.environment["QWISP_DFLASH_DIR"]
+            ?? "\(FileManager.default.homeDirectoryForCurrentUser.path)/.mtplx/models/z-lab--Qwen3.6-35B-A3B-DFlash"
+        guard let drafter = DFlashDrafter.load(dir: URL(fileURLWithPath: dir)) else {
+            FileHandle.standardError.write(Data(
+                "[qwisp] WARN: QWISP_DFLASH=1 but drafter load failed (\(dir)) — running without DFlash\n".utf8))
+            return nil
+        }
+        let blockSize = Tell.envInt("QWISP_DFLASH_BLOCK", 8)
+        return DFlashDispatch(
+            drafter: drafter, blockSize: blockSize,
+            embedFn: { engine.embed(tokens: $0) },
+            logitsArgmaxFn: { h in
+                engine.logits(h, M: h.dim(0)).map { lg in
+                    (0 ..< h.dim(0)).map { MLX.argMax(lg[$0], axis: -1).item(Int.self) }
+                }
+            })
+    }
     private var samplingFallbackNoted = false
     // Segment gate (issue #47): a new request's decode thread must wait for the previous
     // decode thread's FULL exit. Stream teardown (consumer break / client disconnect) only
@@ -146,6 +178,10 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     var prefixSnapStride: Int { Swift.max(512, Tell.envInt("QWISP_PREFIX_SNAP_STRIDE", 2048)) }
     var prefixMaxSlots: Int { Swift.max(2, Tell.envInt("QWISP_PREFIX_MAX_SLOTS", 6)) }
     private var prefixBackend: Tell.SpecBackend?
+    // #98 DFlash phase 3: the fwd handle for the persistent prefix-cache backend (tap
+    // source), rebuilt alongside prefixBackend on arena growth. nil on streaming tiers /
+    // build failure — same nil-guarded contract as everywhere else in this file.
+    private var prefixFwd: SeedlessFusedVerify.SeedlessFusedForward? = nil
     // Streaming tier (#76): the C-slot expert arena persists across cached-backend rebuilds
     // (only the KV/GDN arena is rebuilt on growth) — rebuilding providers would re-stream GBs.
     private var prefixProviders: [ArenaExpertProvider]? = nil
@@ -339,13 +375,31 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                         budget = Swift.min(budget * 2, 65536)
                         continue
                     }
-                    let sb: Tell.SpecBackend? = cfg.isStreaming
-                        ? Tell.streamingBackend(engine: self.engine, modelDir: self.modelDir,
-                                                maxM: cfg.maxM, maxSeqLen: maxSeqLen, C: strictC).map { $0.0 }
-                        : Tell.fusedBackend(engine: self.engine,
-                                            maxM: ProcessInfo.processInfo.environment["QWISP_HYBRID_PREFILL"] != "0" ? Swift.max(cfg.maxM, 1032) : cfg.maxM,
-                                            maxSeqLen: maxSeqLen)
+                    // #98 DFlash phase 3: resident tier always builds via fusedBackendWithFwd
+                    // (fusedBackend is just `.map { $0.0 }` of this — identical either way) so
+                    // the fwd handle is available for the tap when QWISP_DFLASH is active.
+                    var segFwd: SeedlessFusedVerify.SeedlessFusedForward? = nil
+                    let sb: Tell.SpecBackend?
+                    if cfg.isStreaming {
+                        sb = Tell.streamingBackend(engine: self.engine, modelDir: self.modelDir,
+                                                   maxM: cfg.maxM, maxSeqLen: maxSeqLen, C: strictC).map { $0.0 }
+                    } else if let (b, fwd) = Tell.fusedBackendWithFwd(
+                        engine: self.engine,
+                        maxM: ProcessInfo.processInfo.environment["QWISP_HYBRID_PREFILL"] != "0" ? Swift.max(cfg.maxM, 1032) : cfg.maxM,
+                        maxSeqLen: maxSeqLen) {
+                        segFwd = fwd
+                        sb = b
+                    } else {
+                        sb = nil
+                    }
                     guard let backend = sb else { break }
+                    // dflash nil (QWISP_DFLASH unset, or streaming tier) → dd nil → runSpecLoop's
+                    // seam is a no-op, byte-identical to pre-change.
+                    let dd = cfg.isStreaming ? nil : self.dflashIfEnabled()
+                    if let dd, let fwd = segFwd {
+                        _ = fwd.attachTap(layerIds: dd.drafter.config.targetLayerIds)
+                        dd.reset()   // fresh segment re-prefills `seq` from scratch into a new backend
+                    }
                     // Each segment dispatches to greedy or sampling. Sampling keeps its own state
                     // per segment (RNG restarts, so vary the seed by `produced` to avoid reusing the
                     // same stream across segment boundaries). ponytail: penalty counts reset per
@@ -380,7 +434,8 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                                                toks: toks, outPath: outP)
                     } else {
                         seg = Tell.runSpecLoop(promptIds: seq, backend: backend, engine: self.engine,
-                                               N: segN, maxK: strictMaxK, isCancelled: { cancel.isCancelled }, onToken: onTok)
+                                               N: segN, maxK: strictMaxK, isCancelled: { cancel.isCancelled }, onToken: onTok,
+                                               dflash: dd, dflashFwd: segFwd)
                     }
                     guard let seg, !seg.isEmpty else { break }
                     // Greedy strict flows through the guard (unified seq/produced + re-arm);
@@ -430,6 +485,7 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                     newLen = Swift.min(newLen, self.prefixArenaMax)
                     if newLen < needed { newLen = needed }
                     let built: Tell.SpecBackend?
+                    var builtFwd: SeedlessFusedVerify.SeedlessFusedForward? = nil
                     if cfg.isStreaming {
                         // #76 strict streaming: budget-fit C (#69) + persistent expert arena —
                         // existingProviders survive KV-arena growth rebuilds.
@@ -443,13 +499,22 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                         } else { built = nil }
                     } else {
                         // Steel-prefill hybrid wants chunk=1024 → bump maxM (scratch ~200MB, resident tier).
+                        // #98 DFlash phase 3: fusedBackendWithFwd (fusedBackend is just its `.0`) so the
+                        // fwd handle is available for the tap when QWISP_DFLASH is active.
                         let mm = ProcessInfo.processInfo.environment["QWISP_HYBRID_PREFILL"] != "0" ? Swift.max(cfg.maxM, 1032) : cfg.maxM
-                        built = Tell.fusedBackend(engine: self.engine, maxM: mm, maxSeqLen: newLen)
+                        if let (b, fwd) = Tell.fusedBackendWithFwd(engine: self.engine, maxM: mm, maxSeqLen: newLen) {
+                            builtFwd = fwd
+                            built = b
+                        } else { built = nil }
                     }
                     guard let b = built else {
                         continuation.finish(); return
                     }
                     self.prefixBackend = b; self.prefixArenaLen = newLen
+                    self.prefixFwd = builtFwd
+                    if let fwd = builtFwd, let dd = self.dflashIfEnabled() {
+                        _ = fwd.attachTap(layerIds: dd.drafter.config.targetLayerIds)
+                    }
                     self.prefixEmptySnap = b.fullSnapshot?()
                     self.prefixSlots = []; self.arenaContent = []   // new arena → old snapshots invalid
                 }
@@ -517,10 +582,17 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                 let maxK = cfg.isStreaming
                     ? Swift.max(4, DeviceCalibration.strictStreamingC(tierC: cfg.c) * 3 / 8)
                     : cfg.maxK
+                // #98 DFlash: this whole cached call is one generation segment for the drafter
+                // (the target's KV persists via restore, but the drafter's own small ctx cache
+                // doesn't track restores) — reset() so it starts cold each request, matching the
+                // segmented path's "reset() per new generation segment" contract.
+                let dd = cfg.isStreaming ? nil : self.dflashIfEnabled()
+                dd?.reset()
                 _ = Tell.runSpecLoop(promptIds: full, backend: backend, engine: self.engine,
                                      N: genBudget, maxK: maxK, prefillTokens: genSuffix,
                                      isCancelled: { cancel.isCancelled },
-                                     onToken: { continuation.yield($0) })
+                                     onToken: { continuation.yield($0) },
+                                     dflash: dd, dflashFwd: self.prefixFwd)
                 continuation.finish()
             }
         }
@@ -528,7 +600,7 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
 
     /// Test/override hook: drop the persistent arena + all restore points (start cold).
     public func resetPrefixCache() {
-        prefixBackend = nil; prefixProviders = nil; prefixArenaLen = 0; prefixEmptySnap = nil
+        prefixBackend = nil; prefixFwd = nil; prefixProviders = nil; prefixArenaLen = 0; prefixEmptySnap = nil
         arenaContent = []; prefixSlots = []
     }
 

--- a/swift/Sources/QwispCore/SeedlessVerifyTests.swift
+++ b/swift/Sources/QwispCore/SeedlessVerifyTests.swift
@@ -90,7 +90,7 @@ public enum SeedlessVerifyTests {
         MLXRandom.seed(UInt64(42))
         var lines: [String] = []
         var passed = 0
-        let total = 93
+        let total = 95
 
         // Nested runner: records result and increments counter
         func run(_ name: String, body: () -> (Bool, String)) {
@@ -5678,6 +5678,106 @@ public enum SeedlessVerifyTests {
             MLX.eval([firstRun, secondRun])
             let (eqB, dtB) = bitEqual(firstRun, secondRun)
             if !eqB { return (false, "trim rollback mismatch: \(dtB)") }
+            return (true, "ok")
+        }
+
+        // ── DFlash dispatch (#98 phase 3) locked tests ────────────────────
+
+        // Test 94: dflash_ctx_assembly
+        // appendCtx accumulates committed tap rows into pendingCtx in row-major
+        // [rows × ctxDim] with row = concat over tap slots t of tapBuf[t][r][0..<H]
+        // (tap-slot order = targetLayerIds order). Two harvests (rows=2 then rows=3)
+        // accumulate 5 rows total; the tap buffer is per-forward, so the second harvest
+        // re-reads rows 0..2 of the SAME buffer (rows restart at 0 each harvest) and the
+        // reference reflects that. Bit-exact (Float16 bitPattern).
+        run("dflash_ctx_assembly") {
+            guard let (device, _) = SeedlessMetalForward.ensure() else { return (false, "no device") }
+            var cfg = dflashTestConfig()
+            cfg.ctxFeatureDim = 24                        // ctxDim = nTap(3) * tapH(8)
+            let weights = dflashTestWeights(cfg)
+            guard let drafter = DFlashDrafter(config: cfg, weights: weights)
+            else { return (false, "DFlashDrafter init returned nil (STUB)") }
+            let disp = DFlashDispatch(drafter: drafter, blockSize: 4,
+                                      embedFn: { _ in nil }, logitsArgmaxFn: { _ in nil })
+            let nTap = 3, maxM = 4, H = 8
+            // synthetic tap buffer [nTap, maxM, H], value = t*1000 + r*10 + h (exact in f16).
+            func val(_ t: Int, _ r: Int, _ h: Int) -> Float16 { Float16(t * 1000 + r * 10 + h) }
+            var flat = [Float16](repeating: 0, count: nTap * maxM * H)
+            for t in 0..<nTap { for r in 0..<maxM { for h in 0..<H {
+                flat[t * maxM * H + r * H + h] = val(t, r, h)
+            } } }
+            guard let buf = flat.withUnsafeBytes({ p in
+                device.makeBuffer(bytes: p.baseAddress!, length: flat.count * 2, options: .storageModeShared)
+            }) else { return (false, "makeBuffer nil") }
+            disp.appendCtx(tapBuf: buf, maxM: maxM, rows: 2)
+            disp.appendCtx(tapBuf: buf, maxM: maxM, rows: 3)
+            // reference: [2 rows] ++ [3 rows], each row = concat over t of tapBuf[t][r][0..<H].
+            var ref = [Float16]()
+            for rows in [2, 3] { for r in 0..<rows { for t in 0..<nTap { for h in 0..<H {
+                ref.append(val(t, r, h))
+            } } } }
+            let got = disp.pendingCtx
+            guard got.count == ref.count else {
+                return (false, "pendingCtx count \(got.count) != \(ref.count) (STUB?)")
+            }
+            for i in 0..<ref.count where got[i].bitPattern != ref[i].bitPattern {
+                return (false, "ctx@\(i) got=\(got[i]) ref=\(ref[i])")
+            }
+            return (true, "ok")
+        }
+
+        // Test 95: dflash_dispatch_draft_fallback
+        // (a) cold start (no ctx harvested) → draft nil (fallback contract);
+        // (b) after harvest(rows:2), draft(u:5) → exactly blockSize-1 tokens all == 7,
+        //     embedFn called with [u]++[maskId × (blockSize-1)], and a second draft with no
+        //     new harvest → nil (pendingRows == 0 rule);
+        // (c) after reset(), draft → nil again (fresh-instance state).
+        run("dflash_dispatch_draft_fallback") {
+            guard let (device, _) = SeedlessMetalForward.ensure() else { return (false, "no device") }
+            var cfg = dflashTestConfig()
+            cfg.ctxFeatureDim = 24                        // matches test 94: ctxDim = nTap(3)*tapH(8)
+            let weights = dflashTestWeights(cfg)
+            let block = 4
+            // fixed pre-generated embed output (deterministic under the seed): [block, H=64].
+            let embedOut = MLXRandom.normal([block, 64]).asType(.float16)
+            MLX.eval([embedOut])
+            var lastEmbedTokens: [Int32]? = nil
+            let embedFn: ([Int32]) -> MLXArray? = { toks in lastEmbedTokens = toks; return embedOut }
+            let logitsArgmaxFn: (MLXArray) -> [Int]? = { h in (0..<h.dim(0)).map { _ in 7 } }
+            guard let drafter = DFlashDrafter(config: cfg, weights: weights)
+            else { return (false, "DFlashDrafter init returned nil (STUB)") }
+            let disp = DFlashDispatch(drafter: drafter, blockSize: block,
+                                      embedFn: embedFn, logitsArgmaxFn: logitsArgmaxFn)
+
+            // (a) cold start: no ctx harvested → nil.
+            if disp.draft(u: 3) != nil { return (false, "cold-start draft should be nil") }
+
+            // synthetic tap buffer (test-94 builder) for harvest(rows:2).
+            let nTap = 3, maxM = 4, H = 8
+            var flat = [Float16](repeating: 0, count: nTap * maxM * H)
+            for t in 0..<nTap { for r in 0..<maxM { for h in 0..<H {
+                flat[t * maxM * H + r * H + h] = Float16(t * 1000 + r * 10 + h)
+            } } }
+            guard let buf = flat.withUnsafeBytes({ p in
+                device.makeBuffer(bytes: p.baseAddress!, length: flat.count * 2, options: .storageModeShared)
+            }) else { return (false, "makeBuffer nil") }
+            disp.appendCtx(tapBuf: buf, maxM: maxM, rows: 2)
+
+            // (b) draft after harvest → blockSize-1 tokens, all == 7.
+            lastEmbedTokens = nil
+            guard let ds = disp.draft(u: 5) else { return (false, "draft returned nil (STUB)") }
+            guard ds.count == block - 1 else { return (false, "draft count \(ds.count) != \(block - 1)") }
+            if ds.contains(where: { $0 != 7 }) { return (false, "draft tokens != 7: \(ds)") }
+            let wantTokens: [Int32] = [5] + Array(repeating: Int32(cfg.maskTokenId), count: block - 1)
+            guard lastEmbedTokens == wantTokens else {
+                return (false, "embed tokens \(String(describing: lastEmbedTokens)) != \(wantTokens)")
+            }
+            // second draft without new harvest → nil (pendingRows == 0).
+            if disp.draft(u: 6) != nil { return (false, "draft without new ctx should be nil") }
+
+            // (c) reset → fresh-instance state (draft → nil again).
+            disp.reset()
+            if disp.draft(u: 7) != nil { return (false, "post-reset draft should be nil") }
             return (true, "ok")
         }
 

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -591,7 +591,13 @@ extension Tell {
                              N: Int, maxK: Int, useA3: Bool = false,
                              prefillTokens: [Int32]? = nil,
                              isCancelled: (() -> Bool)? = nil,
-                             onToken: ((Int) -> Void)? = nil) -> [Int]? {
+                             onToken: ((Int) -> Void)? = nil,
+                             // #98 DFlash phase 3: nil-guarded seam (same contract as
+                             // mtpDraftSpan/mtpHead) — dflash nil (default) leaves every
+                             // path below byte-identical. dflashFwd is the tap source
+                             // (attachTap'd by the caller); both travel together.
+                             dflash: DFlashDispatch? = nil,
+                             dflashFwd: SeedlessFusedVerify.SeedlessFusedForward? = nil) -> [Int]? {
         // prefixCache: when the backend's cache already holds a prefix of `promptIds`, pass the
         // remaining suffix as prefillTokens (forward appends it at the cache's current position).
         // `hist` still uses the full promptIds so SuffixSpec drafting is unchanged (speed preserved).
@@ -612,10 +618,19 @@ extension Tell {
         // greedy stream stays byte-identical while collapsing K CPU round-trips to 1.
         // Strict streaming wires no chain fn (needs a CPU turn per step to ensure/pread
         // the expert union) → nil → per-step fallback by construction. QWISP_CHAIN_K=0 opts out.
-        let chainK = Tell.envInt("QWISP_CHAIN_K", SeedlessFusedVerify.SeedlessFusedForward.chainKDefault)
+        // dflash non-nil forces chainK=0: chain steps overwrite tap row 0 per step and would
+        // starve the drafter's ctx (DFlash takes over the D==0 span instead of the chain).
+        let chainK = dflash != nil ? 0
+            : Tell.envInt("QWISP_CHAIN_K", SeedlessFusedVerify.SeedlessFusedForward.chainKDefault)
         // Incremental streaming seam: onToken nil → zero behavior change (out/return unchanged).
         var streamed = 0
         func flush() { if let onToken { while streamed < out.count { onToken(out[streamed]); streamed += 1 } } }
+        // Tap harvest (nil-guarded): dflash inactive under A3 (guard !useA3, matches the
+        // draft-attempt guard below). tapBuf missing (not attached) → no-op.
+        func dflashHarvest(_ rows: Int) {
+            guard !useA3, let dd = dflash, let fwd = dflashFwd, let tb = fwd.tapBuf else { return }
+            dd.appendCtx(tapBuf: tb, maxM: fwd.maxM, rows: rows)
+        }
 
         // isCancelled nil → `?? false` → loop condition byte-identical (RAWTESTS 79/79).
         // Set by the streaming backend when the consumer drops the stream, so an
@@ -623,8 +638,14 @@ extension Tell {
         // to N and orphaning the GPU (see SeedlessBackend.generate).
         while out.count < N && !(isCancelled?() ?? false) {
             flush()
-            let drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: Tell.suffixMinMatch,
+            var drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: Tell.suffixMinMatch,
                                           traceAlts: Tell.traceAltsEnabled)
+            // #98 DFlash: only when SuffixSpec found nothing (draftless span) and not under A3
+            // (dflash is inactive there — see dflashHarvest). Falls back to the old per-step
+            // path on nil (cold start / any failure), unchanged behavior.
+            if drafts.isEmpty, !useA3, let dd = dflash, let ds = dd.draft(u: u), !ds.isEmpty {
+                drafts = ds
+            }
             let D      = drafts.count
             stSteps += 1; stDrafted += D; if D == 0 { stD0 += 1 }
 
@@ -656,6 +677,7 @@ extension Tell {
                 } else {
                     guard let evals = backend.stepArgmax([Int32(u)]) else { return nil }
                     out.append(u); hist.append(u)
+                    dflashHarvest(1)
                     u = evals[0]
                 }
                 continue
@@ -705,6 +727,7 @@ extension Tell {
                 var p = 0
                 while p < D && drafts[p] == evals[p] { p += 1 }
                 stAccepted += p
+                dflashHarvest(p + 1)   // rows 0..p = [u]+accepted drafts (both branches below)
 
                 if p == D {
                     out.append(u); hist.append(u)
@@ -1045,6 +1068,33 @@ extension Tell {
             print("[raw-spec] NOTE: QWISP_MTP_DRAFT ignored (QWISP_RAW_A3 set — mutually exclusive)")
         }
 
+        // ── DFlash block drafter (#98 phase 3, resident tier only) ─────────
+        // Opt-in QWISP_DFLASH=1, same gating shape as QWISP_MTP_DRAFT above (resident fused
+        // tier, !useA3). Flag off / other tiers → dflash=nil → the loop below is
+        // byte-identical to pre-change (nil-guarded seam contract). Load failure never
+        // fatal — warn and run without DFlash.
+        var dflash: DFlashDispatch? = nil
+        if Tell.envFlag("QWISP_DFLASH"), let fwd = _residentFwd, fwd.streamMode == .resident, !useA3 {
+            let dir = ProcessInfo.processInfo.environment["QWISP_DFLASH_DIR"]
+                ?? "\(FileManager.default.homeDirectoryForCurrentUser.path)/.mtplx/models/z-lab--Qwen3.6-35B-A3B-DFlash"
+            if let drafter = DFlashDrafter.load(dir: URL(fileURLWithPath: dir)) {
+                let blockSize = Tell.envInt("QWISP_DFLASH_BLOCK", 8)
+                let dd = DFlashDispatch(
+                    drafter: drafter, blockSize: blockSize,
+                    embedFn: { engine.embed(tokens: $0) },
+                    logitsArgmaxFn: { h in
+                        engine.logits(h, M: h.dim(0)).map { lg in
+                            (0 ..< h.dim(0)).map { MLX.argMax(lg[$0], axis: -1).item(Int.self) }
+                        }
+                    })
+                _ = fwd.attachTap(layerIds: drafter.config.targetLayerIds)
+                dflash = dd
+                print("[raw-spec] DFlash dispatch active (block=\(blockSize))")
+            } else {
+                print("[raw-spec] WARN: QWISP_DFLASH=1 but drafter load failed (\(dir)) — running without DFlash")
+            }
+        }
+
         // reuse-rerank setup (flag-off = zero-cost nil path, notes/10 §1c-1e)
         let _useRerank = isStreaming && Tell.envFlag("QWISP_REUSE_RERANK")
         let _reuseAlpha = Double(Tell.envFloat("QWISP_REUSE_ALPHA", 0.0))
@@ -1094,7 +1144,15 @@ extension Tell {
         // Phase II-a: QWISP_CHAIN_K=<k>opt-in GPU token-feedback chained greedy decode.
         // Only the D==0 non-A3/empty-pending greedy span uses the chain path; A3 and draft-
         // bearing steps keep the per-step path (snapshot/rollback + suffix-draft needs CPU tokens).
-        let chainK = Tell.envInt("QWISP_CHAIN_K", SeedlessFusedVerify.SeedlessFusedForward.chainKDefault)
+        // dflash non-nil forces chainK=0 (same reasoning as runSpecLoop: chain steps would
+        // starve the drafter's ctx by overwriting tap row 0 every step).
+        let chainK = dflash != nil ? 0
+            : Tell.envInt("QWISP_CHAIN_K", SeedlessFusedVerify.SeedlessFusedForward.chainKDefault)
+        // Tap harvest (nil-guarded, mirrors runSpecLoop's dflashHarvest).
+        func dflashHarvest(_ rows: Int) {
+            guard !useA3, let dd = dflash, let fwd = _residentFwd, let tb = fwd.tapBuf else { return }
+            dd.appendCtx(tapBuf: tb, maxM: fwd.maxM, rows: rows)
+        }
 
         let t0 = DispatchTime.now()
 
@@ -1111,11 +1169,17 @@ extension Tell {
             //   下の verify path が必ず照合する(reject 経路は greedy と同一 token 列)ので lossless。
             //   flag off = mtpHead nil = mtpDraftSpan nil = このブロック不変(byte-identity)。
             var mtpDrafted = false
-            if D == 0, mtpHead != nil, pending.isEmpty,
+            if D == 0, dflash == nil, mtpHead != nil, pending.isEmpty,
                let d = mtpDraftSpan(head: mtpHead, hPrevBuf: _residentFwd?.normedBuffer,
                                     rowOfU: rowOfU, u: u) {
                 drafts = [d]; D = 1
                 mtpDrafted = true
+            }
+
+            // #98 DFlash: same slot as mtpDraftSpan above (dflash replaces it when active —
+            // the two flags are mutually exclusive by construction, dflash takes priority).
+            if D == 0, let dd = dflash, !useA3, let ds = dd.draft(u: u), !ds.isEmpty {
+                drafts = ds; D = drafts.count
             }
 
             // ★ MTP-D1 (Step 5): u はこの step で必ず commit される → pair (h_prev, u) を
@@ -1175,6 +1239,7 @@ extension Tell {
                     guard let evals = backend.stepArgmax([Int32(u)])
                     else { return "[raw-spec] ERROR: step(D=0) nil" }
                     out.append(u); hist.append(u)
+                    dflashHarvest(1)
                     u = evals[0]
                     rowOfU = 0
                 }
@@ -1240,7 +1305,7 @@ extension Tell {
 
                 var p = 0
                 while p < D && drafts[p] == evals[p] { p += 1 }
-
+                dflashHarvest(p + 1)   // rows 0..p = [u]+accepted drafts (both branches below)
 
                 if p == D {
                     // ── full accept ───────────────────────────────────────


### PR DESCRIPTION
Part of #98 (phase 3 — final wiring phase). Follows #109 (tap), #110 (drafter), #111 (parity).

## What

- **`DFlashDispatch`** (new file): accumulates committed rows' ctx features from tap harvests, drafts a block via the drafter + target embed/lm_head, cold-start nil fallback; engine hooks injected as closures (locked-testable).
- **`runSpecLoop` / `Tell.run`**: additive nil-guarded seams in the old MTP-D1 slot — DFlash drafts only when SuffixSpec found nothing (notes/15 hybrid policy); `chainK` forced 0 while active (chain steps overwrite tap row 0 and would starve the drafter ctx); tap harvest of rows 0..p after every verify.
- **Server path**: builds via `fusedBackendWithFwd`, re-attaches the tap across prefix-cache arena rebuilds, drafter loaded once per process.
- `QWISP_DFLASH` unset (default) ⇒ every seam is a nil guard ⇒ byte-identical by construction.

## Locked tests (93 → 95)

94 `dflash_ctx_assembly` (tap→ctx layout bit-exact vs CPU reference, tap-slot order = target_layer_ids order), 95 `dflash_dispatch_draft_fallback` (cold-start nil / block shape / pendingRows drain / reset). RAWTESTS **95/95**.

## Real-model gates (M1 Max, resident C=256, code regime, N=128)

- **G-B (lossless): PASS** — `QWISP_DFLASH=1` vs off ⇒ OUT_TOKENS **byte-identical**, with `accept/step=3.19` (the drafter genuinely engaged; verify-gated acceptance).
- **G-D (speed, interim): measured LOSS** — 36.9–37.9 tok/s vs 82.1 flag-off (reproducible). Despite healthy accept, **c_draft is ~4–5 target-forwards by inversion** (assumed ~0.3 in the issue arithmetic). This is exactly the "measure c_draft EARLY" unknown — now measured. Prime suspect: `logitsArgmaxFn` does per-row `MLX.argMax(...).item()` = 7 separate graph evals + syncs per block, plus MLX round trips for embed/drafter-forward.

## Consequence

Flag stays **default OFF** (this PR is mergeable: correctness-complete, byte-identical off). Next phase = c_draft reduction: single-eval batched argmax readback first (cheap, likely large), then raw-path draft head (`qmm4Tiled`+`argmax_rows` on the drafter hidden) if still short, per the issue's pre-approved escalation ("raw port only if measured c_draft is too high").

Produced by the devloop TDD workflow (round-1 adversarial review PASS incl. the real-model gate runs); driver-audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)