### PR TITLE
probe(dflash): c_draft attribution + accept-vs-ctx trace (#98 G-D analysis)

### DIFF
--- a/swift/Sources/QwispCore/DFlashDispatch.swift
+++ b/swift/Sources/QwispCore/DFlashDispatch.swift
@@ -73,6 +73,11 @@ public final class DFlashDispatch {
         pendingCtx = []
         pendingRows = 0
         guard let ids = logitsArgmaxFn(hidden[0, 1...]), ids.count == blockSize - 1 else { return nil }
+        // Materialize drafter cache state so the lazy graph doesn't accumulate across
+        // blocks (LayerCache.stateArrays idiom) — the arrays were already computed as part
+        // of the ids readback, so this is a cheap pin, not a second compute.
+        let state = caches.flatMap { c in [c.keys, c.values].compactMap { $0 } }
+        if !state.isEmpty { MLX.eval(state) }
         return ids
     }
 

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -130,9 +130,12 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
             drafter: drafter, blockSize: blockSize,
             embedFn: { engine.embed(tokens: $0) },
             logitsArgmaxFn: { h in
-                engine.logits(h, M: h.dim(0)).map { lg in
-                    (0 ..< h.dim(0)).map { MLX.argMax(lg[$0], axis: -1).item(Int.self) }
-                }
+                // c_draft: ONE lazy-graph eval for embed+drafter+lm_head+argmax (see
+                // TellRuntime's twin closure; per-row .item() was 7 evals/block).
+                guard let lg = engine.logits(h, M: h.dim(0)) else { return nil }
+                let ids = MLX.argMax(lg, axis: -1).asType(.int32)
+                ids.eval()
+                return ids.asArray(Int32.self).map { Int($0) }
             })
     }
     private var samplingFallbackNoted = false

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -1083,9 +1083,13 @@ extension Tell {
                     drafter: drafter, blockSize: blockSize,
                     embedFn: { engine.embed(tokens: $0) },
                     logitsArgmaxFn: { h in
-                        engine.logits(h, M: h.dim(0)).map { lg in
-                            (0 ..< h.dim(0)).map { MLX.argMax(lg[$0], axis: -1).item(Int.self) }
-                        }
+                        // c_draft: ONE lazy-graph eval for embed+drafter+lm_head+argmax —
+                        // per-row .item() was 7 separate evals+syncs per block (measured
+                        // c_draft ~4-5 forwards, PR #113 G-D interim).
+                        guard let lg = engine.logits(h, M: h.dim(0)) else { return nil }
+                        let ids = MLX.argMax(lg, axis: -1).asType(.int32)
+                        ids.eval()
+                        return ids.asArray(Int32.self).map { Int($0) }
                     })
                 _ = fwd.attachTap(layerIds: drafter.config.targetLayerIds)
                 dflash = dd
@@ -1178,8 +1182,10 @@ extension Tell {
 
             // #98 DFlash: same slot as mtpDraftSpan above (dflash replaces it when active —
             // the two flags are mutually exclusive by construction, dflash takes priority).
+            var dflashDrafted = false
             if D == 0, let dd = dflash, !useA3, let ds = dd.draft(u: u), !ds.isEmpty {
                 drafts = ds; D = drafts.count
+                dflashDrafted = true
             }
 
             // ★ MTP-D1 (Step 5): u はこの step で必ず commit される → pair (h_prev, u) を
@@ -1306,6 +1312,11 @@ extension Tell {
                 var p = 0
                 while p < D && drafts[p] == evals[p] { p += 1 }
                 dflashHarvest(p + 1)   // rows 0..p = [u]+accepted drafts (both branches below)
+                // measurement-only (QWISP_DFLASH_TRACE): accept vs drafter-ctx length —
+                // separates cold-start ctx from feature-shift as the accept limiter.
+                if dflashDrafted, let dd = dflash, Tell.envFlag("QWISP_DFLASH_TRACE") {
+                    FileHandle.standardError.write(Data("[dflash-trace] ctx=\(dd.ctxRowsFed) p=\(p)/\(D)\n".utf8))
+                }
 
                 if p == D {
                     // ── full accept ───────────────────────────────────────


### PR DESCRIPTION
Part of #98. Measurement round after #113's G-D interim loss.

## Findings

1. **Per-row `.item()` hypothesis falsified**: batching to a single eval left speed unchanged (37.7 vs 37.9 tok/s) — MLX lazy eval had already fused the graph. The real c_draft is the **6-layer MLX drafter forward itself ≈ 5 target-forwards/block** of op-graph/dispatch overhead.
2. **Accept-vs-ctx trace** (`QWISP_DFLASH_TRACE`), N=128 across regimes:
   - **code/agentic: accept climbs with ctx and reaches card level** — blocks with ctx>60 average p≈4.6-4.9 of 7 (T≈5.6-5.9 vs card 5.0-5.7), with frequent 7/7 full accepts. The aggregate shortfall was cold-start ctx, **not** quantized-target feature shift.
   - **shortnl: p≈1.0-1.2 flat at every ctx** (T≈2.2) — below the r_8 break-even (needs T>3.4 even with a FREE drafter). Not cold-start; nl accept genuinely does not transfer at block=8 on this target as-is.
3. All runs remain 128/128 vs ref greedy (lossless invariant holds through the probe changes).

## Arithmetic update

`(c_draft + r_8 3.2 + reject 0.2) / T`:
- code/agentic steady T≈5.6: raw-port c_draft 0.3-0.5 → **1.4-1.5x on draftless spans** (the issue's original expectation, now with measured accept). MLX c_draft≈5 → structural loss.
- shortnl T≈2.2: loss regardless of c_draft; QAD-lineage drafter finetune (arXiv:2607.04244) is the known fallback for nl.

## Consequence

The pre-approved escalation ("raw port only if measured c_draft is too high") is now triggered with a measured prize on code/agentic (d0≈90% of real traffic). Flag stays default OFF until that lands. Cache graph pinning + the trace stay (measurement-only, flag-guarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)