### PR TITLE
probe(dflash): fused draft+verify CB + dflash_fmm16 drafter kernel (#98 A1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ results*.json
 
 # macOS
 .DS_Store
+*.profraw

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,4 +1,4 @@
-# HANDOFF: #98 A1 CLOSED-NEGATIVE (fused CB shipped, fusion hypothesis falsified) — PR #115 open; next: owner decision (fused drafter kernel devloop vs park #98)
+# HANDOFF: #98 A1 drafter SOLVED (fmm16, 13.4ms) but aggregate still loses — corrected economics: next go/no-go = prefill-ctx bootstrap (accept lever). PR #115 open
 Date: 2026-07-19 | Status: DECISION-PENDING | Branch: claude/issue98-dflash-rawdrafter | Root: /Users/penta2himajin/repos/qwisp
 
 > STOP: Before trusting anything below, run the checks in "Verify First".
@@ -7,50 +7,52 @@ Date: 2026-07-19 | Status: DECISION-PENDING | Branch: claude/issue98-dflash-rawd
 
 ## Verify First
 - `git branch --show-current` → `claude/issue98-dflash-rawdrafter`; `git status` → clean.
-- `git log --oneline -2` → `059699c` chore(profraw) on `a99afe3` probe(dflash) fused CB. main == `fadae32`.
-- PR #115 OPEN (ready) → merge on green review; RAWTESTS **98/98** (total=98 guard now), COMPTEST 33/33, TOKTEST 5/5, BENCHBATCH PASS — all verified this session on a fresh binary.
-- `brew services info qwisp | head -2` → Running: true (stop before ANY GPU run; start after).
-- Model artifacts unchanged: `~/.mtplx/models/Youssofal--Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16`, drafter `~/.mtplx/models/z-lab--Qwen3.6-35B-A3B-DFlash/`.
+- `git log --oneline -1` → `2d120fe` feat(dflash) dflash_fmm16. main == `fadae32`.
+- PR #115 OPEN (ready, title mentions fmm16); gates verified this session: RAWTESTS **98/98**, BENCHBATCH PASS, COMPTEST 33/33, TOKTEST 5/5.
+- `brew services info qwisp | head -2` → Running: true (STOP before ANY GPU run; check `ps aux | grep -E "qwisp serve|qwisp-poc"` first — user asked for a GPU-process check before every GPU run).
 
-## Next Action
-1. Merge PR #115 on green (default-OFF, correctness-neutral, all gates green).
-2. OWNER DECISION on #98: (a) fused drafter layer kernel devloop (verify-class Metal fusion; est. drafter ~10-16ms/block → code ~90-105 tok/s vs 82.7 = +10-25%; devloop-scale) or (b) PARK #98 at the seam+record and pick another workstream (default per earlier queue: batching #6; also parked: #112 stable-prefix persist = devloop-1-loop size, QAD finetune recon 5-min first step).
+## Current Numbers (N=128 resident, M1 Max 64GB)
+- fused DFlash: code **52.9** / agentic 50.8 / longctx 58.9 / shortnl 27.9 — all 128/128 lossless.
+- flag-off: 82.7 / 76.0 / 90.5 / 81.9. DFlash loses on aggregate in every regime.
+- drafter CB in-loop 13.4ms (c_draft ≈ 1.1×F, F=12.1ms); standalone 7ms; kernel probe: lm_head 622MB f16 3.25ms/191GB/s, dependent chain 0.055ms/GEMM.
 
-## A1 Verdict (measured 2026-07-19, full record = issue #98 comment + commit a99afe3)
-- flag-off code 82.7 tok/s vs fused DFlash 32.2 (agentic 26.3 / longctx 44.3 / shortnl 15.0). Lossless 128/128 × 4 regimes with fusion ON.
-- FALSIFIED (do not re-propose): ① CPU-round-trip/CB-context as drafter cost (fusion bought ~2 tok/s; drafter slow even first-in-CB while verify section of SAME CB fast) ② GPU clock ramp (in-CB high-occupancy ballast ran slow itself +34ms, sped up nothing) ③ buffer provenance (Metal-owned copies = noCopy aliases, 39ms both) ④ MPS granularity (~0.5-1ms/encode; ≥44 calls/block ⇒ floor 25-45ms > ≤15ms bar).
-- Stage split (ctx=1): SDPA ≈2ms; lm_head ≈33-36ms and layers ≈20-24ms REGARDLESS of implementation (qmm4_tiled ≙ MPS f16; hand-rolled ≙ MPS) — dispatch-granularity-bound, not kernel-choice-bound.
-- KILLER ARITHMETIC: at drafter ~110ms/block even p=7/7 every block = 71 tok/s < 82.7 flag-off. Fused drafter kernel is PREREQUISITE to any dflash win, not an optimization.
+## THE CORRECTED COST MODEL (memorize this; the old projection was wrong)
+cost/tok = (c_draft + r_8 + P_rej·r_(p̄+1) + cpu) / T, in units of F=12.1ms.
+- r_8 ≈ 3.2 (verify M=8 = 38.7ms — round-3 economics misread this as ~12ms).
+- P_rej·r_(p̄+1) ≈ 19.4ms/block at code (partial-reject rebuild; OMITTED from the
+  original #98 projection "95-105 tok/s" — that number was wrong).
+- Aggregate code T=4.19 ⇒ even c_draft=0 loses (62ms > 50.7 parity). Measured 52.9 fits the model.
+- Steady tail (ctx>60) T≈6 ⇒ parity..+8% now; ~+15% at c_draft 0.5.
+⇒ THE DRAFTER IS NO LONGER THE BOTTLENECK. Binding constraints: cold-start ctx (aggregate T) and the structural r_8+rebuild cost.
 
-## What Shipped (branch, PR #115)
-- Fused draft+verify seam: `stepArgmax(draftPrologue:draftTokensBuf:)` additive (default nil = byte-identical, resident-only); drafter prologue → blit draft ids → M-row verify in ONE CB, one readback. `DFlashDispatch.draftFused`; fused-first in runSpecLoop + raw-spec bench loop (snapshot BEFORE fused step). `QWISP_DFLASH_NOFUSE=1` = split-path A/B.
-- `DFlashRawDrafter`: prepare()/encode(cb:)/finish() split; GEMMs = MPSMatrixMultiplication; lm_head = dequantized f16 (+0.6GB, resident-only); ctx path per-row M=1 GEMMs (batched MPS is NOT byte-M-invariant → would break locked 97); weights COPIED to Metal-owned buffers (noCopy obligation dropped); dflash_fmm_tiled kernel deleted (falsified).
-- Locked test 98 `dflash_fused_draft_verify`: fused ≡ split bit-equal (drafts/evals/KV/GDN). total=98.
+## Next Action (owner picked "kernel" branch this session; now a new fork)
+1. Merge PR #115 on green (still valid: default-OFF, all gates green, big kernel + record).
+2. NEXT GO/NO-GO: **prefill-ctx bootstrap prototype** — feed prompt-derived ctx rows to the drafter at block 1 so aggregate T reaches the steady 5.6-6. Ceiling if it works: code ~75-90 / longctx ~85-100 vs 82.7/90.5 ⇒ win only if aggregate T ≥ ~5.5. If bootstrap fails → #98 parks as "shipped opt-in, default OFF, loses on aggregate".
+3. Secondary (only if bootstrap greens): drafter polish 13.4→~7ms (fuse small ops, argmax tune) = +3-4 tok/s class; hysteresis dispatch (shortnl auto-off) before any default-ON talk.
+4. Probably NO-GO (check before attempting): rebuild-avoidance via partial GDN rewind — needs per-row GDN state snapshots (same physics as spec-gdn-incompat).
+
+## What Shipped This Session (branch, PR #115; commits a99afe3 + 2d120fe)
+- Fused draft+verify seam (stepArgmax additive draftPrologue/draftTokensBuf; DFlashDispatch.draftFused; QWISP_DFLASH_NOFUSE A/B; locked test 98; total=98).
+- dflash_fmm16 kernel (qmv-class f16 M-row GEMM, M-invariant by construction ⇒ ctx batching legal under locked-97; MPS deleted; ONE encoder).
+- lm_head dequant f16 (+0.6GB resident-only); drafter weights copied to Metal-owned buffers.
+- Probes: QWISP_RUN=dflash-gemm-bench (kernel bw), dflash-raw-bench (forward), QWISP_DFLASH_TRACE ([dflash-fused-time]/[dflash-raw-time]/[dflash-trace]).
+
+## Falsified / Closed (do not re-propose — full trail in #98 comments 2026-07-19 ×3)
+- CPU-round-trip/CB-context as drafter cost; GPU clock ramp (2nd kill); buffer provenance (noCopy vs copied); allocation granularity (slab vs separate); memory pressure (91% free); MPS granularity (~0.5-1ms/encode); fmm_rows/fmm_tiled kernel shapes (35GB/s class); qmm4_tiled barrier-tree at drafter shapes (33ms); per-row `.item()`; MLX drafter as shipping path; block=16; sliding ring-buffer v1.
+- "Mystery in-loop tax": NEVER EXISTED — it was kernel bandwidth + MPS overhead + misreading r_8 as 12ms.
 
 ## Commands
 - build: `cd swift && xcodebuild build -scheme qwisp-poc -configuration Release -destination 'platform=macOS' -derivedDataPath ./.xcode-build-rel -skipPackagePluginValidation`
-- gates: `scripts/test_raw.sh` (98/98) / `scripts/test_completion.sh` 33/33 / `scripts/test_tokenizer.sh` 5/5 / `scripts/test_bench_batch.sh` PASS
-- bench: `QWISP_DFLASH=1 QWISP_GEN=128 QWISP_RUN=raw-spec QWISP_MTP_REF=refs/resident/code.safetensors swift/.xcode-build-rel/Build/Products/Release/qwisp-poc stream` (+`QWISP_DFLASH_TRACE=1` → [dflash-fused-time]/[dflash-trace]; `QWISP_DFLASH_NOFUSE=1` → split + [dflash-raw-time]; `QWISP_DFLASH_MLX=1` → MLX drafter)
-- drafter micro-bench: `QWISP_RUN=dflash-raw-bench` (back-to-back, synthetic V=8192 head, ~39ms steady)
+- gates: scripts/test_raw.sh (98/98) / test_completion.sh 33/33 / test_tokenizer.sh 5/5 / test_bench_batch.sh PASS
+- bench: `QWISP_DFLASH=1 QWISP_GEN=128 QWISP_RUN=raw-spec QWISP_MTP_REF=refs/resident/{code,agentic,longctx,shortnl}.safetensors .../qwisp-poc stream`
 
 ## Do Not Touch
-- `swift/Sources/QwispCore/SeedlessVerifyTests.swift`: WRITE-LOCKED (total=98 guard).
-- Frozen forward path: additive nil-guarded seams only (stepArgmax prologue params are the precedent-conform additive seam).
-- `refs/*.safetensors`: raw greedy only. `refs/resident/*` = N=128 G-D refs (exist locally).
-- Never two GPU processes (incl. brew service).
+- SeedlessVerifyTests.swift WRITE-LOCKED (total=98). Frozen forward path: additive nil-guarded seams only. refs/* raw-greedy only. Never two GPU processes; ps-check before every GPU run (user instruction this session).
 
-## Decisions / Doctrine added this session
-- Batched MPS GEMM output is NOT M-invariant at the byte level → any variable-M path feeding a byte-stable cache must be per-row M=1 (locked 97 contract).
-- Generic dispatch backends (MLX graph / hand-rolled simple kernels / MPS) all land 40-190ms for a 6-layer dense M=8 drafter forward; verify-class fused kernels (~25µs/dispatch) are the only demonstrated regime meeting ≤15ms. Kernel fusion investment is the price of admission for small-model raw forwards on this engine.
-
-## Gotchas & Blockers (carried + new)
-- Workflow args serialization flake → hardcode args in script file, launch via {scriptPath} (workaround proven).
-- Bench N caps at ref spec_greedy length (refs/resident/* = 128).
-- Rate limits were 5h 96% / 7d 64% at PREVIOUS session end; this session ran driver-only (no devloops). Check /status before starting a kernel devloop.
-- SourceKit "No such module MLX" = LSP noise; xcodebuild is truth.
-- zsh: `===` in a compound command errors ("== not found") — quote or avoid.
+## Gotchas
+- Workflow args flake → hardcode in script file + {scriptPath}. Bench N caps at ref length (resident=128). SourceKit MLX noise. zsh `===` errors. Rate limits: check /status before devloops (this session ran driver-only).
 
 ## Pointers
-- swift/Sources/QwispCore/DFlashRawDrafter.swift (MPS drafter + prepare/encode/finish), DFlashDispatch.swift#draftFused, SeedlessFusedVerify.swift#stepArgmax (fused seam), TellRuntime.swift (fused-first wiring both loops).
-- Full measured trail: issue #98 comments (2026-07-19 ×2), PRs #109-#115.
-- Parked: #112 stable-prefix persist (user-approved design); QAD finetune recon (check z-lab training-code publication first, ~5min).
+- DFlashRawDrafter.swift (fmm16 kernel + prepare/encode/finish + gemmBench), DFlashDispatch.swift#draftFused, SeedlessFusedVerify.swift#stepArgmax seam, TellRuntime.swift fused-first wiring.
+- Cost-model discussion + ceiling table: issue #98 comment (round 4). PRs #109-#115.
+- Parked: #112 stable-prefix persist; QAD finetune recon (z-lab training code check, ~5min); batching #6.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,56 @@
+# HANDOFF: #98 A1 CLOSED-NEGATIVE (fused CB shipped, fusion hypothesis falsified) — PR #115 open; next: owner decision (fused drafter kernel devloop vs park #98)
+Date: 2026-07-19 | Status: DECISION-PENDING | Branch: claude/issue98-dflash-rawdrafter | Root: /Users/penta2himajin/repos/qwisp
+
+> STOP: Before trusting anything below, run the checks in "Verify First".
+> If any observation differs from the expected value, this handoff is stale —
+> the code is the truth, not this document. Report the mismatch before proceeding.
+
+## Verify First
+- `git branch --show-current` → `claude/issue98-dflash-rawdrafter`; `git status` → clean.
+- `git log --oneline -2` → `059699c` chore(profraw) on `a99afe3` probe(dflash) fused CB. main == `fadae32`.
+- PR #115 OPEN (ready) → merge on green review; RAWTESTS **98/98** (total=98 guard now), COMPTEST 33/33, TOKTEST 5/5, BENCHBATCH PASS — all verified this session on a fresh binary.
+- `brew services info qwisp | head -2` → Running: true (stop before ANY GPU run; start after).
+- Model artifacts unchanged: `~/.mtplx/models/Youssofal--Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16`, drafter `~/.mtplx/models/z-lab--Qwen3.6-35B-A3B-DFlash/`.
+
+## Next Action
+1. Merge PR #115 on green (default-OFF, correctness-neutral, all gates green).
+2. OWNER DECISION on #98: (a) fused drafter layer kernel devloop (verify-class Metal fusion; est. drafter ~10-16ms/block → code ~90-105 tok/s vs 82.7 = +10-25%; devloop-scale) or (b) PARK #98 at the seam+record and pick another workstream (default per earlier queue: batching #6; also parked: #112 stable-prefix persist = devloop-1-loop size, QAD finetune recon 5-min first step).
+
+## A1 Verdict (measured 2026-07-19, full record = issue #98 comment + commit a99afe3)
+- flag-off code 82.7 tok/s vs fused DFlash 32.2 (agentic 26.3 / longctx 44.3 / shortnl 15.0). Lossless 128/128 × 4 regimes with fusion ON.
+- FALSIFIED (do not re-propose): ① CPU-round-trip/CB-context as drafter cost (fusion bought ~2 tok/s; drafter slow even first-in-CB while verify section of SAME CB fast) ② GPU clock ramp (in-CB high-occupancy ballast ran slow itself +34ms, sped up nothing) ③ buffer provenance (Metal-owned copies = noCopy aliases, 39ms both) ④ MPS granularity (~0.5-1ms/encode; ≥44 calls/block ⇒ floor 25-45ms > ≤15ms bar).
+- Stage split (ctx=1): SDPA ≈2ms; lm_head ≈33-36ms and layers ≈20-24ms REGARDLESS of implementation (qmm4_tiled ≙ MPS f16; hand-rolled ≙ MPS) — dispatch-granularity-bound, not kernel-choice-bound.
+- KILLER ARITHMETIC: at drafter ~110ms/block even p=7/7 every block = 71 tok/s < 82.7 flag-off. Fused drafter kernel is PREREQUISITE to any dflash win, not an optimization.
+
+## What Shipped (branch, PR #115)
+- Fused draft+verify seam: `stepArgmax(draftPrologue:draftTokensBuf:)` additive (default nil = byte-identical, resident-only); drafter prologue → blit draft ids → M-row verify in ONE CB, one readback. `DFlashDispatch.draftFused`; fused-first in runSpecLoop + raw-spec bench loop (snapshot BEFORE fused step). `QWISP_DFLASH_NOFUSE=1` = split-path A/B.
+- `DFlashRawDrafter`: prepare()/encode(cb:)/finish() split; GEMMs = MPSMatrixMultiplication; lm_head = dequantized f16 (+0.6GB, resident-only); ctx path per-row M=1 GEMMs (batched MPS is NOT byte-M-invariant → would break locked 97); weights COPIED to Metal-owned buffers (noCopy obligation dropped); dflash_fmm_tiled kernel deleted (falsified).
+- Locked test 98 `dflash_fused_draft_verify`: fused ≡ split bit-equal (drafts/evals/KV/GDN). total=98.
+
+## Commands
+- build: `cd swift && xcodebuild build -scheme qwisp-poc -configuration Release -destination 'platform=macOS' -derivedDataPath ./.xcode-build-rel -skipPackagePluginValidation`
+- gates: `scripts/test_raw.sh` (98/98) / `scripts/test_completion.sh` 33/33 / `scripts/test_tokenizer.sh` 5/5 / `scripts/test_bench_batch.sh` PASS
+- bench: `QWISP_DFLASH=1 QWISP_GEN=128 QWISP_RUN=raw-spec QWISP_MTP_REF=refs/resident/code.safetensors swift/.xcode-build-rel/Build/Products/Release/qwisp-poc stream` (+`QWISP_DFLASH_TRACE=1` → [dflash-fused-time]/[dflash-trace]; `QWISP_DFLASH_NOFUSE=1` → split + [dflash-raw-time]; `QWISP_DFLASH_MLX=1` → MLX drafter)
+- drafter micro-bench: `QWISP_RUN=dflash-raw-bench` (back-to-back, synthetic V=8192 head, ~39ms steady)
+
+## Do Not Touch
+- `swift/Sources/QwispCore/SeedlessVerifyTests.swift`: WRITE-LOCKED (total=98 guard).
+- Frozen forward path: additive nil-guarded seams only (stepArgmax prologue params are the precedent-conform additive seam).
+- `refs/*.safetensors`: raw greedy only. `refs/resident/*` = N=128 G-D refs (exist locally).
+- Never two GPU processes (incl. brew service).
+
+## Decisions / Doctrine added this session
+- Batched MPS GEMM output is NOT M-invariant at the byte level → any variable-M path feeding a byte-stable cache must be per-row M=1 (locked 97 contract).
+- Generic dispatch backends (MLX graph / hand-rolled simple kernels / MPS) all land 40-190ms for a 6-layer dense M=8 drafter forward; verify-class fused kernels (~25µs/dispatch) are the only demonstrated regime meeting ≤15ms. Kernel fusion investment is the price of admission for small-model raw forwards on this engine.
+
+## Gotchas & Blockers (carried + new)
+- Workflow args serialization flake → hardcode args in script file, launch via {scriptPath} (workaround proven).
+- Bench N caps at ref spec_greedy length (refs/resident/* = 128).
+- Rate limits were 5h 96% / 7d 64% at PREVIOUS session end; this session ran driver-only (no devloops). Check /status before starting a kernel devloop.
+- SourceKit "No such module MLX" = LSP noise; xcodebuild is truth.
+- zsh: `===` in a compound command errors ("== not found") — quote or avoid.
+
+## Pointers
+- swift/Sources/QwispCore/DFlashRawDrafter.swift (MPS drafter + prepare/encode/finish), DFlashDispatch.swift#draftFused, SeedlessFusedVerify.swift#stepArgmax (fused seam), TellRuntime.swift (fused-first wiring both loops).
+- Full measured trail: issue #98 comments (2026-07-19 ×2), PRs #109-#115.
+- Parked: #112 stable-prefix persist (user-approved design); QAD finetune recon (check z-lab training-code publication first, ~5min).

--- a/swift/Sources/QwispCore/DFlashDispatch.swift
+++ b/swift/Sources/QwispCore/DFlashDispatch.swift
@@ -15,6 +15,11 @@ import Metal
 ///
 public final class DFlashDispatch {
     let drafter: DFlashDrafter
+    // #98 phase A1: raw-first draft path. nil ⇒ MLX-only (load/attach failure, or the
+    // caller never built one). QWISP_DFLASH_MLX=1 forces the MLX path even when raw is
+    // available (A/B measurement seam). Raw returns nil past its v1 ctx cap (4095 committed
+    // rows) or once attachTargetHead was never called — draft() falls back to MLX either way.
+    var raw: DFlashRawDrafter?
     var caches: [DFlashKVCache]
     let blockSize: Int                          // QWISP_DFLASH_BLOCK, default 8
     let maskId: Int32                           // drafter.config.maskTokenId
@@ -27,10 +32,11 @@ public final class DFlashDispatch {
     private(set) var pendingRows: Int = 0
     private(set) var ctxRowsFed: Int = 0        // total ctx rows in drafter cache
 
-    public init(drafter: DFlashDrafter, blockSize: Int,
+    public init(drafter: DFlashDrafter, raw: DFlashRawDrafter? = nil, blockSize: Int,
                 embedFn: @escaping ([Int32]) -> MLXArray?,
                 logitsArgmaxFn: @escaping (MLXArray) -> [Int]?) {
         self.drafter = drafter
+        self.raw = raw
         self.caches = drafter.makeCaches()
         self.blockSize = blockSize
         self.maskId = Int32(drafter.config.maskTokenId)
@@ -64,6 +70,16 @@ public final class DFlashDispatch {
     /// collapse to the same `pendingRows == 0` check.
     public func draft(u: Int) -> [Int]? {
         guard pendingRows > 0 else { return nil }
+        // Raw-first (#98 phase A1): try the one-CB raw forward before the MLX path. nil
+        // (attach missing, or v1 ctx-cap exceeded) falls through to MLX unchanged — pendingCtx
+        // is untouched until whichever path actually consumes it.
+        if let raw, !Tell.envFlag("QWISP_DFLASH_MLX"),
+           let ids = raw.forward(u: Int32(u), ctxRows: pendingCtx, ctxCount: pendingRows) {
+            ctxRowsFed += pendingRows
+            pendingCtx = []
+            pendingRows = 0
+            return ids
+        }
         let tokens: [Int32] = [Int32(u)] + Array(repeating: maskId, count: blockSize - 1)
         guard let embedded = embedFn(tokens) else { return nil }
         let noise = embedded.reshaped([1, blockSize, -1])
@@ -84,6 +100,7 @@ public final class DFlashDispatch {
     /// Fresh caches, clears pending/ctxRowsFed (new request/segment).
     public func reset() {
         caches = drafter.makeCaches()
+        raw?.reset()
         pendingCtx = []
         pendingRows = 0
         ctxRowsFed = 0

--- a/swift/Sources/QwispCore/DFlashDispatch.swift
+++ b/swift/Sources/QwispCore/DFlashDispatch.swift
@@ -97,6 +97,37 @@ public final class DFlashDispatch {
         return ids
     }
 
+    /// #98 A1 fused draft+verify: encodes the raw drafter as a prologue of the verify CB on
+    /// `fwd` (MUST be the same forward the spec loop verifies on — the fused step advances its
+    /// cache exactly like stepArgmax([u]+drafts)). ONE CB / ONE readback returns both the
+    /// draft ids and the verify argmax rows; the caller computes the accept prefix on CPU.
+    /// nil → nothing ran GPU-side (prepare is scratch-only); caller falls back to
+    /// draft()+stepArgmax unchanged.
+    public func draftFused(u: Int, fwd: SeedlessFusedVerify.SeedlessFusedForward)
+        -> (drafts: [Int], evals: [Int])? {
+        guard pendingRows > 0, let raw, !Tell.envFlag("QWISP_DFLASH_MLX"),
+              !Tell.envFlag("QWISP_DFLASH_NOFUSE"),   // A/B: force the split raw path
+              raw.prepare(u: Int32(u), ctxRows: pendingCtx, ctxCount: pendingRows)
+        else { return nil }
+        var toks = [Int32](repeating: 0, count: blockSize)  // rows 1.. GPU-overwritten by the blit
+        toks[0] = Int32(u)
+        let t0 = DispatchTime.now()
+        guard let evals = fwd.stepArgmax(toks, draftPrologue: { [raw] cb in raw.encode(cb: cb) },
+                                         draftTokensBuf: raw.tokenOutBuffer)
+        else { return nil }
+        if Tell.envFlag("QWISP_DFLASH_TRACE") {
+            let wallMs = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1e6
+            FileHandle.standardError.write(Data(String(
+                format: "[dflash-fused-time] gpu=%.2fms wall=%.2fms ctx+=%d\n",
+                SeedlessFusedVerify.SeedlessFusedForward.profLastGPUMs, wallMs, pendingRows).utf8))
+        }
+        let drafts = raw.finish()
+        ctxRowsFed += pendingRows
+        pendingCtx = []
+        pendingRows = 0
+        return (drafts, evals)
+    }
+
     /// Fresh caches, clears pending/ctxRowsFed (new request/segment).
     public func reset() {
         caches = drafter.makeCaches()

--- a/swift/Sources/QwispCore/DFlashRawDrafter.swift
+++ b/swift/Sources/QwispCore/DFlashRawDrafter.swift
@@ -1,0 +1,504 @@
+import Foundation
+import MLX
+import Metal
+
+// #98 DFlash phase A1 — raw-Metal drafter forward (spec: scratchpad/dflash-phaseA1-spec.md).
+//
+// ONE command buffer per block, following the RawMTPHead idiom (SeedlessFusedVerify.swift
+// ~5079 SeedlessMTPHead): persistent f16 MTLBuffer weights (noCopy — the cast MLXArrays are
+// retained for the drafter's lifetime), persistent per-layer KV MTLBuffers, everything else
+// reused from the frozen SeedlessFusedVerify/SeedlessMetalForward statics (fmm_rows,
+// rmsNormRows, ropeRows, embed_rows_q4, qmm4/qmmRows, argmax_rows, swiglu, resid_add,
+// write_kv_rows). The ONLY new Metal source is the drafter's own SDPA kernel (below) — the
+// drafter has no gate path and no partial-rotary rope, so the existing gated-attention prep
+// kernels (attn_q_prep_rows/attn_k_prep_rows) don't fit and the existing D=256-hardcoded
+// sdpa_rows kernel doesn't fit a runtime headDim — a small headDim-parametric kernel is
+// compiled here with its own makeLibrary (diag-kernel precedent).
+//
+// v1 scope (pinned): NO sliding eviction. ctxCap = slidingWindow - 1 for ALL layers; forward
+// returns nil once ctxLen+ctxCount would exceed it (caller falls back to the MLX drafter).
+
+public final class DFlashRawDrafter {
+    public let config: DFlashDrafterConfig
+
+    // ── Geometry (cached from config for terse call sites) ─────────────────
+    private let H: Int
+    private let numHeads: Int, numKV: Int, headDim: Int
+    private let mlpDim: Int
+    private let ctxFeatureDim: Int
+    private let ropeTheta: Float, eps: Float
+    private let blockSize: Int
+    private let ctxCap: Int                 // v1 cap: slidingWindow - 1, ALL layers
+
+    private let device: MTLDevice
+    private let queue: MTLCommandQueue
+
+    // ── Per-layer persistent weights + KV cache ─────────────────────────────
+    private struct Layer {
+        let qW: MTLBuffer, kW: MTLBuffer, vW: MTLBuffer, oW: MTLBuffer
+        let qNorm: MTLBuffer, kNorm: MTLBuffer
+        let inputLN: MTLBuffer, postLN: MTLBuffer
+        let gateW: MTLBuffer, upW: MTLBuffer, downW: MTLBuffer
+        let kCache: MTLBuffer, vCache: MTLBuffer   // [numKV, ctxCap, headDim] f16, persistent
+        let isSliding: Bool
+    }
+    private let layers: [Layer]
+
+    // ── Global drafter weights ──────────────────────────────────────────────
+    private let fcW: MTLBuffer            // [H, ctxFeatureDim]
+    private let hiddenNorm: MTLBuffer     // [H]
+    private let finalNorm: MTLBuffer      // [H]  (drafter's OWN final norm — not the target's)
+
+    // ── Target head (attached post-init; embed for noise, lm_head for logits) ──
+    private var embedWBuf: MTLBuffer?, embedSBuf: MTLBuffer?, embedBBuf: MTLBuffer?
+    private var lmWBuf: MTLBuffer?, lmSBuf: MTLBuffer?, lmBBuf: MTLBuffer?
+    private var vocab: Int = 0
+    private var logitsBuf: MTLBuffer?
+
+    // noCopy 寿命規約 (notes/03): mtlBuf(noCopy) の backing MLXArray を drafter と同寿命で保持。
+    private var retained: [MLXArray] = []
+
+    // ── Shared committed context length (v1: every layer advances together) ──
+    private var ctxLen: Int = 0
+    private var hasRun = false
+
+    // ── Scratch buffers, reused every forward() call ────────────────────────
+    private let tokBuf: MTLBuffer                  // [blockSize] int32
+    private let hBuf: MTLBuffer                    // [blockSize, H] evolving residual stream
+    private let anLNBuf: MTLBuffer                 // [blockSize, H] rmsNorm(inputLN) scratch
+    private let qRawBuf, qNormedBuf, qRotBuf: MTLBuffer          // [blockSize*numHeads, headDim]
+    private let pkRawBuf, pkNormedBuf, pkRotBuf: MTLBuffer       // [blockSize*numKV, headDim]
+    private let pvBuf: MTLBuffer                                // [blockSize*numKV, headDim]
+    private let attnOutBuf: MTLBuffer              // [blockSize*numHeads, headDim]
+    private let attnResBuf: MTLBuffer              // [blockSize, H]
+    private let mnBuf: MTLBuffer                   // [blockSize, H] post-attn norm
+    private let gateBuf, upBuf, actBuf: MTLBuffer   // [blockSize, mlpDim]
+    private let downBuf: MTLBuffer                 // [blockSize, H]
+    private let normedBuf: MTLBuffer               // [blockSize, H] final hidden (lastFinalHidden)
+    private let tokenOutBuf: MTLBuffer             // [blockSize] int32 argmax
+
+    private let ctxInputBuf: MTLBuffer             // [ctxCap, ctxFeatureDim]
+    private let fcOutBuf: MTLBuffer                // [ctxCap, H]
+    private let hCtxBuf: MTLBuffer                 // [ctxCap, H]
+    private let ckRawBuf, ckNormedBuf, ckRotBuf: MTLBuffer       // [ctxCap*numKV, headDim]
+    private let cvBuf: MTLBuffer                                // [ctxCap*numKV, headDim]
+
+    // ── init? ────────────────────────────────────────────────────────────────
+    public init?(config: DFlashDrafterConfig, weights: [String: MLXArray]) {
+        guard config.slidingWindow > 1, config.blockSize > 1, config.numHeads > 0,
+              config.numKVHeads > 0, config.headDim > 0
+        else { return nil }
+        guard let (dev, q) = SeedlessMetalForward.ensure() else { return nil }
+        guard SeedlessFusedVerify.ensureFmmPipeline(),
+              SeedlessFusedVerify.ensureRowsAuxPipelines(),
+              SeedlessMetalForward.ensureAuxPipelines(),
+              DFlashRawKernels.ensureSdpaPipeline(dev)
+        else { return nil }
+        SeedlessFusedVerify.ensureQmmPipeline()
+        guard SeedlessMetalForward._qmmPipeline != nil else { return nil }
+        // Force-compile the lazily-built rms(F16/F32) and rope pipelines (encode-only helpers
+        // force-unwrap them) — RawMTPHead init idiom, needed on a fresh process too.
+        let warmW = MLXArray.ones([8]).asType(.float16)
+        guard SeedlessMetalForward.rmsNormRows(warmW, warmW, M: 1, eps: 1e-6, D: 8) != nil,
+              SeedlessMetalForward.rmsNormRows(warmW, warmW, M: 1, eps: 1e-6, D: 8, promoteF32: true) != nil,
+              SeedlessMetalForward.ropeRows(MLXArray.zeros([1, 8]).asType(.float16),
+                                            headDim: 8, ropeDim: 8, base: 10000, startOffset: 0,
+                                            M: 1, numHeads: 1) != nil
+        else { return nil }
+
+        device = dev; queue = q
+        self.config = config
+        H = config.hiddenSize
+        numHeads = config.numHeads; numKV = config.numKVHeads; headDim = config.headDim
+        mlpDim = config.mlpDim; ctxFeatureDim = config.ctxFeatureDim
+        ropeTheta = config.ropeTheta; eps = config.rmsEps
+        blockSize = config.blockSize
+        ctxCap = config.slidingWindow - 1
+
+        func g(_ key: String) -> MLXArray? { weights[key]?.asType(.float16) }
+        var localRetained: [MLXArray] = []
+        func f16b(_ a: MLXArray) -> MTLBuffer? {
+            let c = a.asType(.float16); c.eval(); localRetained.append(c)
+            return SeedlessMetalForward.mtlBuf(c, dev)
+        }
+
+        guard let fcArr = g("fc.weight"), let hnArr = g("hidden_norm.weight"), let fnArr = g("norm.weight"),
+              let fcB = f16b(fcArr), let hnB = f16b(hnArr), let fnB = f16b(fnArr)
+        else { return nil }
+        fcW = fcB; hiddenNorm = hnB; finalNorm = fnB
+
+        let kvBytes = numKV * ctxCap * headDim * 2
+        var builtLayers: [Layer] = []
+        builtLayers.reserveCapacity(config.numLayers)
+        for i in 0 ..< config.numLayers {
+            let p = "layers.\(i)."
+            guard let qWArr = g(p + "self_attn.q_proj.weight"),
+                  let kWArr = g(p + "self_attn.k_proj.weight"),
+                  let vWArr = g(p + "self_attn.v_proj.weight"),
+                  let oWArr = g(p + "self_attn.o_proj.weight"),
+                  let qNArr = g(p + "self_attn.q_norm.weight"),
+                  let kNArr = g(p + "self_attn.k_norm.weight"),
+                  let gateArr = g(p + "mlp.gate_proj.weight"),
+                  let upArr = g(p + "mlp.up_proj.weight"),
+                  let downArr = g(p + "mlp.down_proj.weight"),
+                  let inLNArr = g(p + "input_layernorm.weight"),
+                  let postLNArr = g(p + "post_attention_layernorm.weight"),
+                  let qWB = f16b(qWArr), let kWB = f16b(kWArr), let vWB = f16b(vWArr), let oWB = f16b(oWArr),
+                  let qNB = f16b(qNArr), let kNB = f16b(kNArr),
+                  let gateB = f16b(gateArr), let upB = f16b(upArr), let downB = f16b(downArr),
+                  let inLNB = f16b(inLNArr), let postLNB = f16b(postLNArr),
+                  let kCache = dev.makeBuffer(length: kvBytes, options: .storageModeShared),
+                  let vCache = dev.makeBuffer(length: kvBytes, options: .storageModeShared)
+            else { return nil }
+            let isSliding = i < config.layerTypes.count ? config.layerTypes[i] : false
+            builtLayers.append(Layer(qW: qWB, kW: kWB, vW: vWB, oW: oWB, qNorm: qNB, kNorm: kNB,
+                                     inputLN: inLNB, postLN: postLNB, gateW: gateB, upW: upB, downW: downB,
+                                     kCache: kCache, vCache: vCache, isSliding: isSliding))
+        }
+        layers = builtLayers
+        retained = localRetained
+
+        // ── scratch buffers ──
+        func hb(_ n: Int) -> MTLBuffer? { dev.makeBuffer(length: n * 2, options: .storageModeShared) }
+        func ib(_ n: Int) -> MTLBuffer? { dev.makeBuffer(length: n * 4, options: .storageModeShared) }
+        let bs = blockSize, cc = ctxCap
+        guard let _tok = ib(bs),
+              let _h = hb(bs * H), let _anLN = hb(bs * H),
+              let _qRaw = hb(bs * numHeads * headDim), let _qN = hb(bs * numHeads * headDim), let _qR = hb(bs * numHeads * headDim),
+              let _pkRaw = hb(bs * numKV * headDim), let _pkN = hb(bs * numKV * headDim), let _pkR = hb(bs * numKV * headDim),
+              let _pv = hb(bs * numKV * headDim),
+              let _attnOut = hb(bs * numHeads * headDim), let _attnRes = hb(bs * H),
+              let _mn = hb(bs * H),
+              let _gate = hb(bs * mlpDim), let _up = hb(bs * mlpDim), let _act = hb(bs * mlpDim),
+              let _down = hb(bs * H), let _normed = hb(bs * H),
+              let _tokOut = ib(bs),
+              let _ctxIn = hb(cc * ctxFeatureDim), let _fcOut = hb(cc * H), let _hCtx = hb(cc * H),
+              let _ckRaw = hb(cc * numKV * headDim), let _ckN = hb(cc * numKV * headDim), let _ckR = hb(cc * numKV * headDim),
+              let _cv = hb(cc * numKV * headDim)
+        else { return nil }
+        tokBuf = _tok; hBuf = _h; anLNBuf = _anLN
+        qRawBuf = _qRaw; qNormedBuf = _qN; qRotBuf = _qR
+        pkRawBuf = _pkRaw; pkNormedBuf = _pkN; pkRotBuf = _pkR
+        pvBuf = _pv
+        attnOutBuf = _attnOut; attnResBuf = _attnRes
+        mnBuf = _mn
+        gateBuf = _gate; upBuf = _up; actBuf = _act
+        downBuf = _down; normedBuf = _normed
+        tokenOutBuf = _tokOut
+        ctxInputBuf = _ctxIn; fcOutBuf = _fcOut; hCtxBuf = _hCtx
+        ckRawBuf = _ckRaw; ckNormedBuf = _ckN; ckRotBuf = _ckR
+        cvBuf = _cv
+    }
+
+    // ── Target head attachment ──────────────────────────────────────────────
+    public func attachTargetHead(embedW: MLXArray, embedS: MLXArray, embedB: MLXArray,
+                                 lmW: MLXArray, lmS: MLXArray, lmB: MLXArray, vocab: Int) -> Bool {
+        func rawb(_ a: MLXArray) -> MTLBuffer? { a.eval(); retained.append(a); return SeedlessMetalForward.mtlBuf(a, device) }
+        func f16b(_ a: MLXArray) -> MTLBuffer? {
+            let c = a.asType(.float16); c.eval(); retained.append(c)
+            return SeedlessMetalForward.mtlBuf(c, device)
+        }
+        guard let ew = rawb(embedW), let es = f16b(embedS), let eb = f16b(embedB),
+              let lw = rawb(lmW), let ls = f16b(lmS), let lb = f16b(lmB),
+              let logits = device.makeBuffer(length: blockSize * vocab * 2, options: .storageModeShared)
+        else { return false }
+        embedWBuf = ew; embedSBuf = es; embedBBuf = eb
+        lmWBuf = lw; lmSBuf = ls; lmBBuf = lb
+        self.vocab = vocab
+        logitsBuf = logits
+        return true
+    }
+
+    // ── Private encode helpers for the two kernels not covered by an existing
+    //    "encode-only" static (embed noise into hBuf directly; final argmax). ──
+
+    private func encodeEmbedNoise(_ enc: MTLComputeCommandEncoder,
+                                  ew: MTLBuffer, es: MTLBuffer, eb: MTLBuffer) {
+        let p = SeedlessFusedVerify._embedRowsPipeline!
+        enc.setComputePipelineState(p)
+        enc.setBuffer(ew, offset: 0, index: 0); enc.setBuffer(es, offset: 0, index: 1)
+        enc.setBuffer(eb, offset: 0, index: 2); enc.setBuffer(tokBuf, offset: 0, index: 3)
+        enc.setBuffer(hBuf, offset: 0, index: 4)
+        var hh = UInt32(H), tt = UInt32(blockSize * H)
+        enc.setBytes(&hh, length: 4, index: 5); enc.setBytes(&tt, length: 4, index: 6)
+        enc.dispatchThreads(MTLSize(width: blockSize * H, height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: min(p.maxTotalThreadsPerThreadgroup, 256), height: 1, depth: 1))
+    }
+
+    private func encodeArgmax(_ enc: MTLComputeCommandEncoder, logits: MTLBuffer, V: Int) {
+        let p = SeedlessFusedVerify._argmaxRowsPipeline!
+        enc.setComputePipelineState(p)
+        enc.setBuffer(logits, offset: 0, index: 0); enc.setBuffer(tokenOutBuf, offset: 0, index: 1)
+        var vv = UInt32(V); enc.setBytes(&vv, length: 4, index: 2)
+        enc.dispatchThreadgroups(MTLSize(width: blockSize, height: 1, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+    }
+
+    // ── forward ──────────────────────────────────────────────────────────────
+    public func forward(u: Int32, ctxRows: [Float16], ctxCount: Int) -> [Int]? {
+        guard let ew = embedWBuf, let es = embedSBuf, let eb = embedBBuf,
+              let lw = lmWBuf, let ls = lmSBuf, let lb = lmBBuf, let logits = logitsBuf
+        else { return nil }   // attachTargetHead not called
+        guard ctxLen + ctxCount <= ctxCap else { return nil }   // v1 cap contract
+
+        // 1. noise tokens: [u] ++ [maskId × (blockSize-1)]
+        var toks = [Int32](repeating: Int32(config.maskTokenId), count: blockSize)
+        toks[0] = u
+        let tokPtr = tokBuf.contents().bindMemory(to: Int32.self, capacity: blockSize)
+        for i in 0 ..< blockSize { tokPtr[i] = toks[i] }
+
+        // 2. ctx rows upload (persistent scratch buffer, refreshed each call)
+        if ctxCount > 0 {
+            ctxRows.withUnsafeBytes { raw in
+                memcpy(ctxInputBuf.contents(), raw.baseAddress!, ctxCount * ctxFeatureDim * 2)
+            }
+        }
+
+        let cachedLen = ctxLen + ctxCount   // KV length valid after this call's ctx append
+        let scale = Float(pow(Double(headDim), -0.5))
+
+        let cb = queue.makeCommandBuffer()!
+        let enc = cb.makeComputeCommandEncoder()!
+
+        // noise embed → hBuf (residual stream init)
+        encodeEmbedNoise(enc, ew: ew, es: es, eb: eb)
+
+        // ctx feature path (computed ONCE, shared by every layer's k/v proj)
+        if ctxCount > 0 {
+            SeedlessFusedVerify.encodeFmmRows(enc, w: fcW, x: ctxInputBuf, out: fcOutBuf,
+                                              M: ctxCount, K: ctxFeatureDim, N: H)
+            SeedlessFusedVerify.encodeRmsNormRows(enc, x: fcOutBuf, w: hiddenNorm, out: hCtxBuf,
+                                                  rows: ctxCount, D: H, eps: eps)
+        }
+
+        for layer in layers {
+            // attn input norm (block rows only — ctx k/v project straight from hCtx, no inputLN)
+            SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: layer.inputLN, out: anLNBuf,
+                                                  rows: blockSize, D: H, eps: eps)
+            // q / propK / propV projections
+            DFlashRawKernels.encodeFmm(enc, w: layer.qW, x: anLNBuf, out: qRawBuf,
+                                       M: blockSize, K: H, N: numHeads * headDim)
+            DFlashRawKernels.encodeFmm(enc, w: layer.kW, x: anLNBuf, out: pkRawBuf,
+                                       M: blockSize, K: H, N: numKV * headDim)
+            DFlashRawKernels.encodeFmm(enc, w: layer.vW, x: anLNBuf, out: pvBuf,
+                                       M: blockSize, K: H, N: numKV * headDim)
+            // q/k rmsNorm (last-dim headDim, treating each (row,head) as an independent chunk)
+            SeedlessFusedVerify.encodeRmsNormRows(enc, x: qRawBuf, w: layer.qNorm, out: qNormedBuf,
+                                                  rows: blockSize * numHeads, D: headDim, eps: eps)
+            SeedlessFusedVerify.encodeRmsNormRows(enc, x: pkRawBuf, w: layer.kNorm, out: pkNormedBuf,
+                                                  rows: blockSize * numKV, D: headDim, eps: eps)
+            // FULL-headDim RoPE: q and propK at position cachedLen + row
+            SeedlessFusedVerify.encodeRopeRows(enc, x: qNormedBuf, out: qRotBuf,
+                                              headDim: headDim, ropeDim: headDim, base: ropeTheta,
+                                              startOffset: cachedLen, M: blockSize, numHeads: numHeads)
+            SeedlessFusedVerify.encodeRopeRows(enc, x: pkNormedBuf, out: pkRotBuf,
+                                              headDim: headDim, ropeDim: headDim, base: ropeTheta,
+                                              startOffset: cachedLen, M: blockSize, numHeads: numKV)
+
+            if ctxCount > 0 {
+                // ctx k/v from hCtx (this layer's own k/v proj — NOT re-normed by inputLN)
+                SeedlessFusedVerify.encodeFmmRows(enc, w: layer.kW, x: hCtxBuf, out: ckRawBuf,
+                                                  M: ctxCount, K: H, N: numKV * headDim)
+                SeedlessFusedVerify.encodeFmmRows(enc, w: layer.vW, x: hCtxBuf, out: cvBuf,
+                                                  M: ctxCount, K: H, N: numKV * headDim)
+                SeedlessFusedVerify.encodeRmsNormRows(enc, x: ckRawBuf, w: layer.kNorm, out: ckNormedBuf,
+                                                      rows: ctxCount * numKV, D: headDim, eps: eps)
+                // ctxK at position ctxLen(before this call) + row
+                SeedlessFusedVerify.encodeRopeRows(enc, x: ckNormedBuf, out: ckRotBuf,
+                                                  headDim: headDim, ropeDim: headDim, base: ropeTheta,
+                                                  startOffset: ctxLen, M: ctxCount, numHeads: numKV)
+                // commit ctx k/v into this layer's persistent KV cache at [ctxLen, ctxLen+ctxCount)
+                SeedlessFusedVerify.encodeWriteKVRows(enc, src: ckRotBuf, cache: layer.kCache,
+                                                      KV: numKV, D: headDim, maxLen: ctxCap, pos: ctxLen, M: ctxCount)
+                SeedlessFusedVerify.encodeWriteKVRows(enc, src: cvBuf, cache: layer.vCache,
+                                                      KV: numKV, D: headDim, maxLen: ctxCap, pos: ctxLen, M: ctxCount)
+            }
+
+            // SDPA: keys = cached[0..<cachedLen] ‖ propK[0..<blockSize]
+            //   sliding (causalOffset=true):  row r sees cachedLen + (r+1) keys
+            //   full    (causalOffset=false): every row sees cachedLen + blockSize keys (no mask)
+            DFlashRawKernels.encode(enc, q: qRotBuf, kCache: layer.kCache, vCache: layer.vCache,
+                                   propK: pkRotBuf, propV: pvBuf, out: attnOutBuf,
+                                   numHeads: numHeads, numKV: numKV, D: headDim,
+                                   cachedLen: cachedLen, ctxCap: ctxCap, M: blockSize,
+                                   scale: scale, causalOffset: layer.isSliding)
+
+            // o_proj — NO gate (unlike the target's attention)
+            SeedlessFusedVerify.encodeFmmRows(enc, w: layer.oW, x: attnOutBuf, out: attnResBuf,
+                                              M: blockSize, K: numHeads * headDim, N: H)
+            SeedlessFusedVerify.encodeResidAdd(enc, h: hBuf, r: attnResBuf, total: blockSize * H)
+
+            // MLP (swiglu)
+            SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: layer.postLN, out: mnBuf,
+                                                  rows: blockSize, D: H, eps: eps)
+            SeedlessFusedVerify.encodeFmmRows(enc, w: layer.gateW, x: mnBuf, out: gateBuf,
+                                              M: blockSize, K: H, N: mlpDim)
+            SeedlessFusedVerify.encodeFmmRows(enc, w: layer.upW, x: mnBuf, out: upBuf,
+                                              M: blockSize, K: H, N: mlpDim)
+            SeedlessFusedVerify.encodeSwiglu(enc, g: gateBuf, u: upBuf, h: actBuf, total: blockSize * mlpDim)
+            SeedlessFusedVerify.encodeFmmRows(enc, w: layer.downW, x: actBuf, out: downBuf,
+                                              M: blockSize, K: mlpDim, N: H)
+            SeedlessFusedVerify.encodeResidAdd(enc, h: hBuf, r: downBuf, total: blockSize * H)
+        }
+
+        // final rmsNorm (drafter's OWN norm — not the target's final norm)
+        SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: finalNorm, out: normedBuf,
+                                              rows: blockSize, D: H, eps: eps)
+        // target lm_head over ALL rows (row 0 discarded on readback — simpler than an x-offset
+        // qmm variant, at the cost of one extra row of compute).
+        SeedlessFusedVerify.encodeQmmRows(enc, w: lw, scales: ls, biases: lb, x: normedBuf, out: logits,
+                                          M: blockSize, K: H, N: vocab)
+        encodeArgmax(enc, logits: logits, V: vocab)
+
+        enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+
+        ctxLen += ctxCount
+        hasRun = true
+
+        let ptr = tokenOutBuf.contents().bindMemory(to: Int32.self, capacity: blockSize)
+        return (1 ..< blockSize).map { Int(ptr[$0]) }
+    }
+
+    // ── Rollback / reset (v1: no KV erase — tail rows are simply overwritten on next append) ──
+    public func trimTo(committed: Int) {
+        ctxLen = min(ctxLen, committed)
+    }
+
+    public func reset() {
+        ctxLen = 0
+    }
+
+    // ── Test-only accessor ──────────────────────────────────────────────────
+    public func lastFinalHidden() -> [Float16]? {
+        guard hasRun else { return nil }
+        let ptr = normedBuf.contents().bindMemory(to: Float16.self, capacity: blockSize * H)
+        return Array(UnsafeBufferPointer(start: ptr, count: blockSize * H))
+    }
+}
+
+// ── New Metal source: the drafter's own SDPA kernel ─────────────────────────
+// Not reusable from the frozen files: the existing `sdpa_rows` kernel hardcodes headDim=256
+// at compile time (drafter headDim is 16 in tests / 128 in production), and the drafter has
+// no gate path so the gated attn_q_prep_rows/attn_k_prep_rows kernels don't apply either.
+//
+// Occupancy fix (round 2, adversarial review g5): v1 dispatched one thread per (head,row) —
+// only numHeads*M threads total (256 in the real config), each a fully serial loop over up to
+// ~4095 cached keys. That starves the GPU (far below the thread count needed to fill it) and
+// measured 2.3x SLOWER than the MLX drafter it's meant to beat. Fix: one SIMD-group (32 lanes)
+// per (head,row) query instead of one thread — lanes split the key loop by stride-32 (same
+// idiom as GroupedMoEPoC/SeedlessFusedVerify's simd_sum row-reduction kernels already in this
+// codebase), each lane keeping its own partial online-softmax (max, sum, acc[D]), then a single
+// simd_max/simd_sum merge combines the 32 partials. Same total FLOPs, 32x more concurrent
+// threadgroups (numHeads*M threadgroups of 32 vs previously ceil(numHeads/32)*M groups), ~32x
+// less serial depth per lane. Key→lane assignment depends only on absolute key position, so the
+// two-call-vs-one-call byte-exact cache-consistency contract (locked test 97) is unaffected.
+private enum DFlashRawKernels {
+    nonisolated(unsafe) static var sdpaPipeline: MTLComputePipelineState?
+
+    static func ensureSdpaPipeline(_ device: MTLDevice) -> Bool {
+        if sdpaPipeline != nil { return true }
+        let src = """
+        #include <metal_stdlib>
+        using namespace metal;
+        // dflash_sdpa_rows: keys/values = cache[0..<cachedLen] ‖ prop[0..<propKeys(m)].
+        // causalOffset!=0: propKeys(m) = m+1 (causal-with-offset). causalOffset==0: propKeys(m) = M
+        // (no mask, bidirectional within the block). Cached keys are ALWAYS fully visible.
+        // One threadgroup == one simdgroup (32 lanes) == one (head, query-row) pair; lanes
+        // stride-partition the key loop, then merge via simd_max/simd_sum (online-softmax merge).
+        kernel void dflash_sdpa_rows(
+            device const half* q        [[buffer(0)]],   // [M*numHeads, D]
+            device const half* kCache   [[buffer(1)]],   // [numKV, ctxCap, D]
+            device const half* vCache   [[buffer(2)]],   // [numKV, ctxCap, D]
+            device const half* propK    [[buffer(3)]],   // [M*numKV, D]
+            device const half* propV    [[buffer(4)]],   // [M*numKV, D]
+            device half* out            [[buffer(5)]],   // [M*numHeads, D]
+            constant uint& numHeads     [[buffer(6)]],
+            constant uint& numKV        [[buffer(7)]],
+            constant uint& D            [[buffer(8)]],
+            constant uint& cachedLen    [[buffer(9)]],
+            constant uint& ctxCap       [[buffer(10)]],
+            constant uint& M            [[buffer(11)]],
+            constant float& scale       [[buffer(12)]],
+            constant uint& causalOffset [[buffer(13)]],
+            uint2 tgid    [[threadgroup_position_in_grid]],
+            uint  lane    [[thread_index_in_simdgroup]])
+        {
+            uint h = tgid.x, m = tgid.y;
+            uint gqa = numHeads / numKV;
+            uint kvh = h / gqa;
+            uint propKeys = (causalOffset != 0) ? (m + 1) : M;
+            uint totalKeys = cachedLen + propKeys;
+            constexpr uint MAXD = 256;
+            float acc[MAXD];
+            for (uint d = 0; d < D; d++) acc[d] = 0.0f;
+            float localMax = -INFINITY;
+            float localSum = 0.0f;
+            const device half* qrow = q + (m * numHeads + h) * D;
+            for (uint j = lane; j < totalKeys; j += 32) {
+                const device half* krow;
+                const device half* vrow;
+                if (j < cachedLen) {
+                    krow = kCache + (kvh * ctxCap + j) * D;
+                    vrow = vCache + (kvh * ctxCap + j) * D;
+                } else {
+                    uint pj = j - cachedLen;
+                    krow = propK + (pj * numKV + kvh) * D;
+                    vrow = propV + (pj * numKV + kvh) * D;
+                }
+                float score = 0.0f;
+                for (uint d = 0; d < D; d++) score += (float)qrow[d] * (float)krow[d];
+                score *= scale;
+                float newMax = max(localMax, score);
+                float factor = fast::exp(localMax - newMax);
+                float expScore = fast::exp(score - newMax);
+                localMax = newMax;
+                localSum = localSum * factor + expScore;
+                for (uint d = 0; d < D; d++) acc[d] = acc[d] * factor + expScore * (float)vrow[d];
+            }
+            // Merge the 32 lane-local online-softmax partials into one (single-level, since a
+            // simdgroup already spans all lanes assigned to this query).
+            float groupMax = simd_max(localMax);
+            float rescale = fast::exp(localMax - groupMax);
+            float groupSum = simd_sum(localSum * rescale);
+            device half* orow = out + (m * numHeads + h) * D;
+            for (uint d = 0; d < D; d++) {
+                float groupAcc = simd_sum(acc[d] * rescale);
+                if (lane == 0) orow[d] = (half)(groupSum > 0.0f ? (groupAcc / groupSum) : groupAcc);
+            }
+        }
+        """
+        do {
+            let lib = try device.makeLibrary(source: src, options: SeedlessMetalForward.mlxMatchCompileOpts())
+            sdpaPipeline = try device.makeComputePipelineState(function: lib.makeFunction(name: "dflash_sdpa_rows")!)
+        } catch { print("[dflash-raw-sdpa] compile: \(error)"); return false }
+        return sdpaPipeline != nil
+    }
+
+    static func encode(_ enc: MTLComputeCommandEncoder,
+                       q: MTLBuffer, kCache: MTLBuffer, vCache: MTLBuffer,
+                       propK: MTLBuffer, propV: MTLBuffer, out: MTLBuffer,
+                       numHeads: Int, numKV: Int, D: Int,
+                       cachedLen: Int, ctxCap: Int, M: Int,
+                       scale: Float, causalOffset: Bool) {
+        let p = sdpaPipeline!
+        enc.setComputePipelineState(p)
+        enc.setBuffer(q, offset: 0, index: 0)
+        enc.setBuffer(kCache, offset: 0, index: 1)
+        enc.setBuffer(vCache, offset: 0, index: 2)
+        enc.setBuffer(propK, offset: 0, index: 3)
+        enc.setBuffer(propV, offset: 0, index: 4)
+        enc.setBuffer(out, offset: 0, index: 5)
+        var nh = UInt32(numHeads), nkv = UInt32(numKV), dd = UInt32(D)
+        var cl = UInt32(cachedLen), cc = UInt32(ctxCap), mm = UInt32(M)
+        var sc = scale, co = UInt32(causalOffset ? 1 : 0)
+        enc.setBytes(&nh, length: 4, index: 6); enc.setBytes(&nkv, length: 4, index: 7)
+        enc.setBytes(&dd, length: 4, index: 8); enc.setBytes(&cl, length: 4, index: 9)
+        enc.setBytes(&cc, length: 4, index: 10); enc.setBytes(&mm, length: 4, index: 11)
+        enc.setBytes(&sc, length: 4, index: 12); enc.setBytes(&co, length: 4, index: 13)
+        // One threadgroup (== one simdgroup, 32 lanes) per (head, row) query — numHeads*M
+        // threadgroups total, vs the old dispatchThreads' ceil(numHeads/32)*M groups of 32
+        // serial-loop threads. See kernel comment above for the occupancy rationale.
+        enc.dispatchThreadgroups(MTLSize(width: numHeads, height: M, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 32, height: 1, depth: 1))
+    }
+}

--- a/swift/Sources/QwispCore/DFlashRawDrafter.swift
+++ b/swift/Sources/QwispCore/DFlashRawDrafter.swift
@@ -96,6 +96,16 @@ public final class DFlashRawDrafter {
         else { return nil }
         SeedlessFusedVerify.ensureQmmPipeline()
         guard SeedlessMetalForward._qmmPipeline != nil else { return nil }
+        // qmm4_tiled warm (attachHead idiom — the lm_head encode force-unwraps the pipeline;
+        // locked tests build this class standalone, so don't rely on suite ordering).
+        if SeedlessMetalForward._qmm4TiledPipeline == nil {
+            let x = MLXRandom.normal([1, 512]).asType(.float16)
+            let wf = MLXRandom.normal([8, 512]).asType(.float16)
+            let (wq, s, b) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine)
+            MLX.eval([x, wq, s, b!])
+            _ = SeedlessMetalForward.qmmTiled(x, wq, scales: s, biases: b!, M: 1, K: 512, N: 8)
+        }
+        guard SeedlessMetalForward._qmm4TiledPipeline != nil else { return nil }
         // Force-compile the lazily-built rms(F16/F32) and rope pipelines (encode-only helpers
         // force-unwrap them) — RawMTPHead init idiom, needed on a fresh process too.
         let warmW = MLXArray.ones([8]).asType(.float16)
@@ -257,31 +267,43 @@ public final class DFlashRawDrafter {
         let cachedLen = ctxLen + ctxCount   // KV length valid after this call's ctx append
         let scale = Float(pow(Double(headDim), -0.5))
 
-        let cb = queue.makeCommandBuffer()!
-        let enc = cb.makeComputeCommandEncoder()!
+        let trace = Tell.envFlag("QWISP_DFLASH_TRACE")
+        var cb = queue.makeCommandBuffer()!
+        var enc = cb.makeComputeCommandEncoder()!
+        var stamps: [(String, Double)] = []
+        // trace-only stage split (flag off = single CB, identical to production).
+        func split(_ label: String) {
+            guard trace else { return }
+            enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+            stamps.append((label, (cb.gpuEndTime - cb.gpuStartTime) * 1000.0))
+            cb = queue.makeCommandBuffer()!
+            enc = cb.makeComputeCommandEncoder()!
+        }
 
         // noise embed → hBuf (residual stream init)
         encodeEmbedNoise(enc, ew: ew, es: es, eb: eb)
 
         // ctx feature path (computed ONCE, shared by every layer's k/v proj)
         if ctxCount > 0 {
-            SeedlessFusedVerify.encodeFmmRows(enc, w: fcW, x: ctxInputBuf, out: fcOutBuf,
+            DFlashRawKernels.encodeFmmTiled(enc, w: fcW, x: ctxInputBuf, out: fcOutBuf,
                                               M: ctxCount, K: ctxFeatureDim, N: H)
             SeedlessFusedVerify.encodeRmsNormRows(enc, x: fcOutBuf, w: hiddenNorm, out: hCtxBuf,
                                                   rows: ctxCount, D: H, eps: eps)
         }
+
+        split("embed+ctx")
 
         for layer in layers {
             // attn input norm (block rows only — ctx k/v project straight from hCtx, no inputLN)
             SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: layer.inputLN, out: anLNBuf,
                                                   rows: blockSize, D: H, eps: eps)
             // q / propK / propV projections
-            DFlashRawKernels.encodeFmm(enc, w: layer.qW, x: anLNBuf, out: qRawBuf,
-                                       M: blockSize, K: H, N: numHeads * headDim)
-            DFlashRawKernels.encodeFmm(enc, w: layer.kW, x: anLNBuf, out: pkRawBuf,
-                                       M: blockSize, K: H, N: numKV * headDim)
-            DFlashRawKernels.encodeFmm(enc, w: layer.vW, x: anLNBuf, out: pvBuf,
-                                       M: blockSize, K: H, N: numKV * headDim)
+            DFlashRawKernels.encodeFmmTiled(enc, w: layer.qW, x: anLNBuf, out: qRawBuf,
+                                              M: blockSize, K: H, N: numHeads * headDim)
+            DFlashRawKernels.encodeFmmTiled(enc, w: layer.kW, x: anLNBuf, out: pkRawBuf,
+                                              M: blockSize, K: H, N: numKV * headDim)
+            DFlashRawKernels.encodeFmmTiled(enc, w: layer.vW, x: anLNBuf, out: pvBuf,
+                                              M: blockSize, K: H, N: numKV * headDim)
             // q/k rmsNorm (last-dim headDim, treating each (row,head) as an independent chunk)
             SeedlessFusedVerify.encodeRmsNormRows(enc, x: qRawBuf, w: layer.qNorm, out: qNormedBuf,
                                                   rows: blockSize * numHeads, D: headDim, eps: eps)
@@ -297,9 +319,9 @@ public final class DFlashRawDrafter {
 
             if ctxCount > 0 {
                 // ctx k/v from hCtx (this layer's own k/v proj — NOT re-normed by inputLN)
-                SeedlessFusedVerify.encodeFmmRows(enc, w: layer.kW, x: hCtxBuf, out: ckRawBuf,
+                DFlashRawKernels.encodeFmmTiled(enc, w: layer.kW, x: hCtxBuf, out: ckRawBuf,
                                                   M: ctxCount, K: H, N: numKV * headDim)
-                SeedlessFusedVerify.encodeFmmRows(enc, w: layer.vW, x: hCtxBuf, out: cvBuf,
+                DFlashRawKernels.encodeFmmTiled(enc, w: layer.vW, x: hCtxBuf, out: cvBuf,
                                                   M: ctxCount, K: H, N: numKV * headDim)
                 SeedlessFusedVerify.encodeRmsNormRows(enc, x: ckRawBuf, w: layer.kNorm, out: ckNormedBuf,
                                                       rows: ctxCount * numKV, D: headDim, eps: eps)
@@ -324,33 +346,59 @@ public final class DFlashRawDrafter {
                                    scale: scale, causalOffset: layer.isSliding)
 
             // o_proj — NO gate (unlike the target's attention)
-            SeedlessFusedVerify.encodeFmmRows(enc, w: layer.oW, x: attnOutBuf, out: attnResBuf,
+            DFlashRawKernels.encodeFmmTiled(enc, w: layer.oW, x: attnOutBuf, out: attnResBuf,
                                               M: blockSize, K: numHeads * headDim, N: H)
             SeedlessFusedVerify.encodeResidAdd(enc, h: hBuf, r: attnResBuf, total: blockSize * H)
 
             // MLP (swiglu)
             SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: layer.postLN, out: mnBuf,
                                                   rows: blockSize, D: H, eps: eps)
-            SeedlessFusedVerify.encodeFmmRows(enc, w: layer.gateW, x: mnBuf, out: gateBuf,
+            DFlashRawKernels.encodeFmmTiled(enc, w: layer.gateW, x: mnBuf, out: gateBuf,
                                               M: blockSize, K: H, N: mlpDim)
-            SeedlessFusedVerify.encodeFmmRows(enc, w: layer.upW, x: mnBuf, out: upBuf,
+            DFlashRawKernels.encodeFmmTiled(enc, w: layer.upW, x: mnBuf, out: upBuf,
                                               M: blockSize, K: H, N: mlpDim)
             SeedlessFusedVerify.encodeSwiglu(enc, g: gateBuf, u: upBuf, h: actBuf, total: blockSize * mlpDim)
-            SeedlessFusedVerify.encodeFmmRows(enc, w: layer.downW, x: actBuf, out: downBuf,
+            DFlashRawKernels.encodeFmmTiled(enc, w: layer.downW, x: actBuf, out: downBuf,
                                               M: blockSize, K: mlpDim, N: H)
             SeedlessFusedVerify.encodeResidAdd(enc, h: hBuf, r: downBuf, total: blockSize * H)
         }
+
+        split("layers")
 
         // final rmsNorm (drafter's OWN norm — not the target's final norm)
         SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: finalNorm, out: normedBuf,
                                               rows: blockSize, D: H, eps: eps)
         // target lm_head over ALL rows (row 0 discarded on readback — simpler than an x-offset
-        // qmm variant, at the cost of one extra row of compute).
-        SeedlessFusedVerify.encodeQmmRows(enc, w: lw, scales: ls, biases: lb, x: normedBuf, out: logits,
-                                          M: blockSize, K: H, N: vocab)
+        // qmm variant, at the cost of one extra row of compute). qmm4_tiled (threadgroup
+        // dequant shared across the M rows — same kernel stepArgmax uses for verify M>1):
+        // the per-row qmv (encodeQmmRows) re-reads+dequants the whole 4-bit lm_head PER ROW,
+        // ~8x the weight traffic at blockSize=8.
+        do {
+            let qp = SeedlessMetalForward._qmm4TiledPipeline!
+            enc.setComputePipelineState(qp)
+            enc.setBuffer(lw, offset: 0, index: 0); enc.setBuffer(ls, offset: 0, index: 1)
+            enc.setBuffer(lb, offset: 0, index: 2); enc.setBuffer(normedBuf, offset: 0, index: 3)
+            enc.setBuffer(logits, offset: 0, index: 4)
+            var kk = Int32(H), nn = Int32(vocab), mm = Int32(blockSize)
+            enc.setBytes(&kk, length: 4, index: 5); enc.setBytes(&nn, length: 4, index: 6)
+            enc.setBytes(&mm, length: 4, index: 7)
+            enc.dispatchThreadgroups(MTLSize(width: vocab, height: 1, depth: 1),
+                                     threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        }
+        split("lmhead")
         encodeArgmax(enc, logits: logits, V: vocab)
 
-        enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+        enc.endEncoding()
+        let t0 = DispatchTime.now()
+        cb.commit(); cb.waitUntilCompleted()
+        if trace {
+            let wallMs = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1e6
+            stamps.append(("head", (cb.gpuEndTime - cb.gpuStartTime) * 1000.0))
+            let parts = stamps.map { String(format: "%@=%.2fms", $0.0, $0.1) }.joined(separator: " ")
+            FileHandle.standardError.write(Data(String(
+                format: "[dflash-raw-time] %@ (tailWall=%.2fms) ctx=%d cached=%d\n",
+                parts, wallMs, ctxCount, cachedLen).utf8))
+        }
 
         ctxLen += ctxCount
         hasRun = true
@@ -374,6 +422,68 @@ public final class DFlashRawDrafter {
         let ptr = normedBuf.contents().bindMemory(to: Float16.self, capacity: blockSize * H)
         return Array(UnsafeBufferPointer(start: ptr, count: blockSize * H))
     }
+
+    // ── Steady-state micro-bench (QWISP_RUN=dflash-raw-bench): back-to-back forwards on the
+    //    real checkpoint + a synthetic 4-bit head, isolating drafter cost from decode-loop
+    //    interleaving (GPU clock-ramp diagnosis: cold/idle-gap CBs downclock ~10x). ──
+    public static func bench() -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let dir = ProcessInfo.processInfo.environment["QWISP_DFLASH_DIR"]
+            ?? "\(home)/.mtplx/models/z-lab--Qwen3.6-35B-A3B-DFlash"
+        guard let (cfg, weights) = Tell.loadDFlashConfigAndWeights(dir: URL(fileURLWithPath: dir)) else {
+            return "[dflash-raw-bench] weights load failed (\(dir))"
+        }
+        var cfg8 = cfg
+        cfg8.blockSize = 8
+        guard let raw = DFlashRawDrafter(config: cfg8, weights: weights) else {
+            return "[dflash-raw-bench] init failed"
+        }
+        // synthetic 4-bit head (test-91 idiom) — vocab shrunk: head cost measured separately below
+        let V = 8192
+        let ew = MLXRandom.normal([V, cfg.hiddenSize]).asType(.float16)
+        let (ewq, es, ebO) = MLX.quantized(ew, groupSize: 64, bits: 4, mode: .affine)
+        let lw = MLXRandom.normal([V, cfg.hiddenSize]).asType(.float16)
+        let (lwq, ls, lbO) = MLX.quantized(lw, groupSize: 64, bits: 4, mode: .affine)
+        guard let eBias = ebO, let lBias = lbO else { return "[dflash-raw-bench] quantize failed" }
+        MLX.eval([ewq, es, eBias, lwq, ls, lBias])
+        guard raw.attachTargetHead(embedW: ewq, embedS: es, embedB: eBias,
+                                   lmW: lwq, lmS: ls, lmB: lBias, vocab: V) else {
+            return "[dflash-raw-bench] attach failed"
+        }
+        let ctxRow = [Float16](repeating: Float16(0.01), count: 2 * cfg.ctxFeatureDim)
+        // GPU clock-pinning ballast: a heavy dense matmul immediately before each drafter
+        // forward. If the drafter collapses to a few ms with the ballast, the 20-50ms
+        // "cost" is the frequency governor idling on an all-low-occupancy workload — the
+        // production fix is then fusing the drafter into the verify CB, not more kernels.
+        let bm = 2048
+        let bA = MLXRandom.normal([bm, bm]).asType(.float16)
+        let bB = MLXRandom.normal([bm, bm]).asType(.float16)
+        MLX.eval([bA, bB])
+        var lines: [String] = ["[dflash-raw-bench] 30 back-to-back forwards (real drafter weights, synthetic head V=\(V))"]
+        for ballast in [false, true] {
+            var times: [Double] = []
+            for i in 0 ..< 30 {
+                if raw.ctxLen + 2 > raw.ctxCap { raw.reset() }
+                if ballast {
+                    let c = MLX.matmul(bA, bB)
+                    c.eval()
+                }
+                let t0 = DispatchTime.now()
+                guard raw.forward(u: 7, ctxRows: ctxRow, ctxCount: 2) != nil else {
+                    return "[dflash-raw-bench] forward nil at iter \(i)"
+                }
+                let ms = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1e6
+                times.append(ms)
+            }
+            let head = times.prefix(3).map { String(format: "%.2f", $0) }.joined(separator: ", ")
+            let tail = times.suffix(20)
+            let mean = tail.reduce(0, +) / Double(tail.count)
+            let mn = tail.min() ?? 0
+            lines.append(String(format: "  ballast=%@  first3: [%@] ms   steady(last20): mean=%.2fms min=%.2fms",
+                                ballast ? "ON " : "off", head, mean, mn))
+        }
+        return lines.joined(separator: "\n")
+    }
 }
 
 // ── New Metal source: the drafter's own SDPA kernel ─────────────────────────
@@ -394,12 +504,67 @@ public final class DFlashRawDrafter {
 // two-call-vs-one-call byte-exact cache-consistency contract (locked test 97) is unaffected.
 private enum DFlashRawKernels {
     nonisolated(unsafe) static var sdpaPipeline: MTLComputePipelineState?
+    nonisolated(unsafe) static var fmmTiledPipeline: MTLComputePipelineState?
 
     static func ensureSdpaPipeline(_ device: MTLDevice) -> Bool {
         if sdpaPipeline != nil { return true }
         let src = """
         #include <metal_stdlib>
         using namespace metal;
+        // dflash_fmm_tiled: out[M,N] = x[M,K] @ W[N,K]^T, all f16. One 256-thread threadgroup
+        // per output column n; the K-strided W-row read is coalesced and stays hot in cache
+        // across the M-loop, so W traffic is ~once per block instead of once per (row, col)
+        // thread. Replaces fmm_rows for the drafter: fmm_rows (one thread per (n,m), 16-wide
+        // groups, serial K) re-reads every W row M times at poor effective bandwidth — fine
+        // for the 1-layer M<=2 MTP head it was built for, catastrophic for 6 layers x M=8
+        // (measured 165-170ms GPU per block, ~10x the MLX drafter it was meant to beat).
+        kernel void dflash_fmm_tiled(
+            device const half* W   [[buffer(0)]],   // [N, K]
+            device const half* x   [[buffer(1)]],   // [M, K]
+            device half*       out [[buffer(2)]],   // [M, N]
+            constant int&      K   [[buffer(3)]],
+            constant int&      N   [[buffer(4)]],
+            constant int&      M   [[buffer(5)]],
+            uint n   [[threadgroup_position_in_grid]],
+            uint tid [[thread_index_in_threadgroup]],
+            uint tgs [[threads_per_threadgroup]])
+        {
+            // dq_tiled structure (GroupedMoEPoC denseBench, the measured-good dense shape):
+            // stage the W row into threadgroup memory in K-chunks (read from device ONCE),
+            // then each m-pass dots against TG memory — W re-reads are free, x passes are
+            // coalesced (per-m contiguous) and L2-hot (x is 32KB total). Two earlier
+            // variants measured bad: m-outer device re-reads (L1 thrash across TGs, ~20ms)
+            // and m-inner strided x (8 cache lines per k per thread, ~48ms).
+            constexpr int MAXM = 16;
+            constexpr int CHUNK = 2048;
+            threadgroup half ws[CHUNK];
+            threadgroup float red[256];
+            const device half* wrow = W + (size_t)n * (size_t)K;
+            float acc[MAXM];
+            for (int m = 0; m < M; m++) acc[m] = 0.0f;
+            for (int k0 = 0; k0 < K; k0 += CHUNK) {
+                int kc = min(CHUNK, K - k0);
+                for (int k = (int)tid; k < kc; k += (int)tgs) ws[k] = wrow[k0 + k];
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                for (int m = 0; m < M; m++) {
+                    const device half* xrow = x + (size_t)m * (size_t)K + k0;
+                    float p = 0.0f;
+                    for (int k = (int)tid; k < kc; k += (int)tgs)
+                        p += (float)xrow[k] * (float)ws[k];
+                    acc[m] += p;
+                }
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+            }
+            for (int m = 0; m < M; m++) {
+                red[tid] = acc[m]; threadgroup_barrier(mem_flags::mem_threadgroup);
+                for (uint s = tgs / 2; s > 0; s >>= 1) {
+                    if (tid < s) red[tid] += red[tid + s];
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+                }
+                if (tid == 0) out[m * N + (int)n] = (half)red[0];
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+            }
+        }
         // dflash_sdpa_rows: keys/values = cache[0..<cachedLen] ‖ prop[0..<propKeys(m)].
         // causalOffset!=0: propKeys(m) = m+1 (causal-with-offset). causalOffset==0: propKeys(m) = M
         // (no mask, bidirectional within the block). Cached keys are ALWAYS fully visible.
@@ -416,25 +581,37 @@ private enum DFlashRawKernels {
             constant uint& numKV        [[buffer(7)]],
             constant uint& D            [[buffer(8)]],
             constant uint& cachedLen    [[buffer(9)]],
-            constant uint& ctxCap       [[buffer(10)]],
+            constant uint& ctxCap      [[buffer(10)]],
             constant uint& M            [[buffer(11)]],
             constant float& scale       [[buffer(12)]],
             constant uint& causalOffset [[buffer(13)]],
             uint2 tgid    [[threadgroup_position_in_grid]],
             uint  lane    [[thread_index_in_simdgroup]])
         {
+            // Key-serial / D-parallel dataflow: keys are walked SERIALLY (deterministic order —
+            // locked test 97's two-call-vs-one-shot byte-exactness needs a key order that
+            // depends only on absolute position), the 32 lanes cooperate on each key: the
+            // q·k dot is a stride-32 partial + simd_sum broadcast, and the online-softmax
+            // accumulator lives DISTRIBUTED across lanes (D/32 floats each — registers, no
+            // spill). The previous lane-per-key variant kept a full acc[256] per lane, which
+            // spilled and ran slower than the MLX drafter it was meant to replace.
             uint h = tgid.x, m = tgid.y;
             uint gqa = numHeads / numKV;
             uint kvh = h / gqa;
             uint propKeys = (causalOffset != 0) ? (m + 1) : M;
             uint totalKeys = cachedLen + propKeys;
-            constexpr uint MAXD = 256;
-            float acc[MAXD];
-            for (uint d = 0; d < D; d++) acc[d] = 0.0f;
-            float localMax = -INFINITY;
-            float localSum = 0.0f;
+            constexpr uint MAXDL = 8;              // supports D up to 8*32 = 256
+            uint perLane = (D + 31) / 32;
             const device half* qrow = q + (m * numHeads + h) * D;
-            for (uint j = lane; j < totalKeys; j += 32) {
+            float qv[MAXDL];
+            float acc[MAXDL];
+            for (uint t = 0; t < perLane; t++) {
+                uint d = lane + t * 32;
+                qv[t] = (d < D) ? (float)qrow[d] : 0.0f;
+                acc[t] = 0.0f;
+            }
+            float runMax = -INFINITY, runSum = 0.0f;
+            for (uint j = 0; j < totalKeys; j++) {
                 const device half* krow;
                 const device half* vrow;
                 if (j < cachedLen) {
@@ -445,33 +622,54 @@ private enum DFlashRawKernels {
                     krow = propK + (pj * numKV + kvh) * D;
                     vrow = propV + (pj * numKV + kvh) * D;
                 }
-                float score = 0.0f;
-                for (uint d = 0; d < D; d++) score += (float)qrow[d] * (float)krow[d];
-                score *= scale;
-                float newMax = max(localMax, score);
-                float factor = fast::exp(localMax - newMax);
-                float expScore = fast::exp(score - newMax);
-                localMax = newMax;
-                localSum = localSum * factor + expScore;
-                for (uint d = 0; d < D; d++) acc[d] = acc[d] * factor + expScore * (float)vrow[d];
+                float part = 0.0f;
+                for (uint t = 0; t < perLane; t++) {
+                    uint d = lane + t * 32;
+                    if (d < D) part += qv[t] * (float)krow[d];
+                }
+                float score = simd_sum(part) * scale;   // broadcast: every lane holds the score
+                float newMax = max(runMax, score);
+                float factor = fast::exp(runMax - newMax);
+                float e = fast::exp(score - newMax);
+                runMax = newMax;
+                runSum = runSum * factor + e;
+                for (uint t = 0; t < perLane; t++) {
+                    uint d = lane + t * 32;
+                    if (d < D) acc[t] = acc[t] * factor + e * (float)vrow[d];
+                }
             }
-            // Merge the 32 lane-local online-softmax partials into one (single-level, since a
-            // simdgroup already spans all lanes assigned to this query).
-            float groupMax = simd_max(localMax);
-            float rescale = fast::exp(localMax - groupMax);
-            float groupSum = simd_sum(localSum * rescale);
             device half* orow = out + (m * numHeads + h) * D;
-            for (uint d = 0; d < D; d++) {
-                float groupAcc = simd_sum(acc[d] * rescale);
-                if (lane == 0) orow[d] = (half)(groupSum > 0.0f ? (groupAcc / groupSum) : groupAcc);
+            float inv = runSum > 0.0f ? (1.0f / runSum) : 1.0f;
+            for (uint t = 0; t < perLane; t++) {
+                uint d = lane + t * 32;
+                if (d < D) orow[d] = (half)(acc[t] * inv);
             }
         }
         """
         do {
             let lib = try device.makeLibrary(source: src, options: SeedlessMetalForward.mlxMatchCompileOpts())
             sdpaPipeline = try device.makeComputePipelineState(function: lib.makeFunction(name: "dflash_sdpa_rows")!)
+            fmmTiledPipeline = try device.makeComputePipelineState(function: lib.makeFunction(name: "dflash_fmm_tiled")!)
         } catch { print("[dflash-raw-sdpa] compile: \(error)"); return false }
-        return sdpaPipeline != nil
+        return sdpaPipeline != nil && fmmTiledPipeline != nil
+    }
+
+    /// Tiled f16 matmul: out[M,N] = x[M,K] @ W[N,K]^T. Drop-in for the drafter's projection/
+    /// MLP/fc sites (bandwidth-correct replacement for fmm_rows at M=blockSize x 6 layers).
+    static func encodeFmmTiled(_ enc: MTLComputeCommandEncoder,
+                               w: MTLBuffer, x: MTLBuffer, out: MTLBuffer,
+                               M: Int, K: Int, N: Int) {
+        let p = fmmTiledPipeline!
+        enc.setComputePipelineState(p)
+        enc.setBuffer(w, offset: 0, index: 0)
+        enc.setBuffer(x, offset: 0, index: 1)
+        enc.setBuffer(out, offset: 0, index: 2)
+        var kk = Int32(K), nn = Int32(N), mm = Int32(M)
+        enc.setBytes(&kk, length: 4, index: 3)
+        enc.setBytes(&nn, length: 4, index: 4)
+        enc.setBytes(&mm, length: 4, index: 5)
+        enc.dispatchThreadgroups(MTLSize(width: N, height: 1, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
     }
 
     static func encode(_ enc: MTLComputeCommandEncoder,

--- a/swift/Sources/QwispCore/DFlashRawDrafter.swift
+++ b/swift/Sources/QwispCore/DFlashRawDrafter.swift
@@ -1,24 +1,24 @@
 import Foundation
 import MLX
 import Metal
-import MetalPerformanceShaders
 
 // #98 DFlash phase A1 — raw-Metal drafter forward (spec: scratchpad/dflash-phaseA1-spec.md).
 //
 // ONE command buffer per block: persistent f16 MTLBuffer weights (COPIED into Metal-owned
 // buffers at init — no noCopy lifetime obligation), persistent per-layer KV MTLBuffers.
-// GEMMs (q/k/v/o, MLP, fc, lm_head) are MPSMatrixMultiplication — the hand-rolled
-// fmm/qmm4 kernels measured 75-100ms/block at drafter shapes (M=8, 6 thin layers; ~2-3ms
-// roofline), overhead-dominated across 3 kernel designs (#98 A1 record). Small ops reuse
+// GEMMs (q/k/v/o, MLP, fc, lm_head) use dflash_fmm16 (below) — a qmv_fast-derived f16
+// M-row kernel measured at 170-190GB/s on the large drafter shapes. Falsified earlier
+// (#98 A1 record, do not re-propose): fmm_rows/fmm_tiled hand kernels (35GB/s class),
+// qmm4_tiled here (barrier-tree, 33ms), MPSMatrixMultiplication (~0.5-1ms per encode =
+// granularity floor at ~44 calls/block). Small ops reuse
 // the frozen SeedlessFusedVerify/SeedlessMetalForward statics (rmsNormRows, ropeRows,
 // embed_rows_q4, argmax_rows, swiglu, resid_add, write_kv_rows). The ONLY new Metal source
 // is the drafter's own SDPA kernel (below) — the drafter has no gate path and no
 // partial-rotary rope, so the existing gated-attention prep kernels don't fit and the
 // existing D=256-hardcoded sdpa_rows kernel doesn't fit a runtime headDim.
 //
-// Fused draft+verify (#98 A1 round 3): prepare() → encode(cb:) → finish() lets the verify
-// CB carry the drafter as a prologue (MPS opens its own internal encoders, so the seam is
-// CB-level); forward() composes the three standalone.
+// Fused draft+verify (#98 A1): prepare() → encode(cb:) → finish() lets the verify CB
+// carry the drafter as a prologue; forward() composes the three standalone.
 //
 // v1 scope (pinned): NO sliding eviction. ctxCap = slidingWindow - 1 for ALL layers; forward
 // returns nil once ctxLen+ctxCount would exceed it (caller falls back to the MLX drafter).
@@ -55,20 +55,16 @@ public final class DFlashRawDrafter {
     private let finalNorm: MTLBuffer      // [H]  (drafter's OWN final norm — not the target's)
 
     // ── Target head (attached post-init; embed for noise, lm_head for logits) ──
-    // lm_head is DEQUANTIZED to f16 (V×H×2 ≈ 0.6GB for the real head): the drafter is
-    // resident-tier-only + opt-in, and the 4-bit qmm4_tiled path measured 33ms at drafter
-    // shapes (overhead-dominated) vs ~3ms roofline for an MPS f16 GEMM. Embed stays 4-bit
-    // (per-row gather is cheap).
+    // lm_head is DEQUANTIZED to f16 (V×H×2 ≈ 0.6GB for the real head; resident-tier-only
+    // + opt-in): the 4-bit qmm4_tiled path measured 33ms at drafter shapes, dflash_fmm16
+    // on the f16 head measured 3.2ms (192GB/s). Embed stays 4-bit (per-row gather is cheap).
     private var embedWBuf: MTLBuffer?, embedSBuf: MTLBuffer?, embedBBuf: MTLBuffer?
     private var lmF16Buf: MTLBuffer?
     private var vocab: Int = 0
     private var logitsBuf: MTLBuffer?
 
-    // ── MPS GEMM plumbing (#98 A1 round 3): the hand-rolled fmm/qmm kernels measured
-    // 75-100ms/block at drafter shapes (M=8, 6 thin layers) vs ~2-3ms roofline — the pinned
-    // fallback lever is MPSMatrixMultiplication, which encodes into the SAME command buffer
-    // (its own internal encoders), so the fused draft+verify CB structure is preserved.
-    private var mpsMulCache: [String: MPSMatrixMultiplication] = [:]
+    // ── Encoder plumbing for encode(cb:) (single compute encoder; the CB-level seam
+    // remains because the fused verify CB hands us the CB, not an encoder) ──
     private var _cb: MTLCommandBuffer?
     private var _enc: MTLComputeCommandEncoder?
     private func enc() -> MTLComputeCommandEncoder {
@@ -76,34 +72,6 @@ public final class DFlashRawDrafter {
         return _enc!
     }
     private func closeEnc() { _enc?.endEncoding(); _enc = nil }
-    private func mpsMat(_ buf: MTLBuffer, _ rows: Int, _ cols: Int, off: Int = 0) -> MPSMatrix {
-        MPSMatrix(buffer: buf, offset: off, descriptor: MPSMatrixDescriptor(
-            rows: rows, columns: cols, rowBytes: cols * 2, dataType: .float16))
-    }
-    /// out[M,N] = x[M,K] @ W[N,K]^T, all f16 (f32 accumulate inside MPS).
-    private func gemm(w: MTLBuffer, x: MTLBuffer, out: MTLBuffer, M: Int, K: Int, N: Int,
-                      xOff: Int = 0, outOff: Int = 0) {
-        closeEnc()
-        let key = "\(M)/\(K)/\(N)"
-        let mul: MPSMatrixMultiplication
-        if let m = mpsMulCache[key] { mul = m } else {
-            mul = MPSMatrixMultiplication(device: device, transposeLeft: false, transposeRight: true,
-                                          resultRows: M, resultColumns: N, interiorColumns: K,
-                                          alpha: 1.0, beta: 0.0)
-            mpsMulCache[key] = mul
-        }
-        mul.encode(commandBuffer: _cb!, leftMatrix: mpsMat(x, M, K, off: xOff),
-                   rightMatrix: mpsMat(w, N, K), resultMatrix: mpsMat(out, M, N, off: outOff))
-    }
-    /// ctx-path GEMM: one M=1 GEMM PER ROW. ctxCount varies call-to-call and batched MPS
-    /// output is not M-invariant at the byte level — but the drafter KV cache must be
-    /// byte-stable across call splits (two-call vs one-shot, locked test 97). Per-row M=1
-    /// makes every row an identical subproblem regardless of batching.
-    private func gemmPerRow(w: MTLBuffer, x: MTLBuffer, out: MTLBuffer, rows: Int, K: Int, N: Int) {
-        for r in 0 ..< rows {
-            gemm(w: w, x: x, out: out, M: 1, K: K, N: N, xOff: r * K * 2, outOff: r * N * 2)
-        }
-    }
 
     // ── Shared committed context length (v1: every layer advances together) ──
     private var ctxLen: Int = 0
@@ -268,7 +236,7 @@ public final class DFlashRawDrafter {
             return dst
         }
         func f16b(_ a: MLXArray) -> MTLBuffer? { copyb(a.asType(.float16)) }
-        // lm_head → dequantized f16 [V, H] for the MPS GEMM (see field comment).
+        // lm_head → dequantized f16 [V, H] for the dflash_fmm16 GEMM (see field comment).
         let lmF16 = MLX.dequantized(lmW, scales: lmS, biases: lmB,
                                     groupSize: 64, bits: 4, mode: .affine).asType(.float16)
         guard let ew = copyb(embedW), let es = f16b(embedS), let eb = f16b(embedB),
@@ -336,10 +304,9 @@ public final class DFlashRawDrafter {
     }
 
     /// GPU-side stage: encodes the whole drafter block (embed → ctx fc → layers → lm_head →
-    /// argmax → tokenOutBuf) into the caller's command buffer. GEMMs go through MPS (which
-    /// opens its own internal encoders — hence the CB-level seam, not an encoder-level one);
-    /// the small ops (norm/rope/SDPA/swiglu/residAdd/writeKV/argmax) use the existing raw
-    /// pipelines on interleaved compute encoders. Requires a successful prepare().
+    /// argmax → tokenOutBuf) into the caller's command buffer, on ONE compute encoder
+    /// (dflash_fmm16 GEMMs + the existing raw small-op pipelines). Requires a successful
+    /// prepare().
     public func encode(cb: MTLCommandBuffer) {
         guard pendingCount >= 0 else { return }
         let ctxCount = pendingCount
@@ -356,7 +323,8 @@ public final class DFlashRawDrafter {
 
         // ctx feature path (computed ONCE, shared by every layer's k/v proj)
         if ctxCount > 0 {
-            gemmPerRow(w: fcW, x: ctxInputBuf, out: fcOutBuf, rows: ctxCount, K: ctxFeatureDim, N: H)
+            DFlashRawKernels.encodeFmm16(enc(), w: fcW, x: ctxInputBuf, out: fcOutBuf,
+                                         M: ctxCount, K: ctxFeatureDim, N: H)
             SeedlessFusedVerify.encodeRmsNormRows(enc(), x: fcOutBuf, w: hiddenNorm, out: hCtxBuf,
                                                   rows: ctxCount, D: H, eps: eps)
         }
@@ -365,14 +333,19 @@ public final class DFlashRawDrafter {
             // attn input norm (block rows only — ctx k/v project straight from hCtx, no inputLN)
             SeedlessFusedVerify.encodeRmsNormRows(enc(), x: hBuf, w: layer.inputLN, out: anLNBuf,
                                                   rows: blockSize, D: H, eps: eps)
-            // q / propK / propV projections (+ ctx k/v from hCtx — grouped into ONE MPS run)
-            gemm(w: layer.qW, x: anLNBuf, out: qRawBuf, M: blockSize, K: H, N: numHeads * headDim)
-            gemm(w: layer.kW, x: anLNBuf, out: pkRawBuf, M: blockSize, K: H, N: numKV * headDim)
-            gemm(w: layer.vW, x: anLNBuf, out: pvBuf, M: blockSize, K: H, N: numKV * headDim)
+            // q / propK / propV projections
+            DFlashRawKernels.encodeFmm16(enc(), w: layer.qW, x: anLNBuf, out: qRawBuf,
+                                         M: blockSize, K: H, N: numHeads * headDim)
+            DFlashRawKernels.encodeFmm16(enc(), w: layer.kW, x: anLNBuf, out: pkRawBuf,
+                                         M: blockSize, K: H, N: numKV * headDim)
+            DFlashRawKernels.encodeFmm16(enc(), w: layer.vW, x: anLNBuf, out: pvBuf,
+                                         M: blockSize, K: H, N: numKV * headDim)
             if ctxCount > 0 {
                 // ctx k/v (this layer's own k/v proj — NOT re-normed by inputLN)
-                gemmPerRow(w: layer.kW, x: hCtxBuf, out: ckRawBuf, rows: ctxCount, K: H, N: numKV * headDim)
-                gemmPerRow(w: layer.vW, x: hCtxBuf, out: cvBuf, rows: ctxCount, K: H, N: numKV * headDim)
+                DFlashRawKernels.encodeFmm16(enc(), w: layer.kW, x: hCtxBuf, out: ckRawBuf,
+                                             M: ctxCount, K: H, N: numKV * headDim)
+                DFlashRawKernels.encodeFmm16(enc(), w: layer.vW, x: hCtxBuf, out: cvBuf,
+                                             M: ctxCount, K: H, N: numKV * headDim)
             }
             // q/k rmsNorm (last-dim headDim, treating each (row,head) as an independent chunk)
             SeedlessFusedVerify.encodeRmsNormRows(enc(), x: qRawBuf, w: layer.qNorm, out: qNormedBuf,
@@ -411,16 +384,20 @@ public final class DFlashRawDrafter {
                                    scale: scale, causalOffset: layer.isSliding)
 
             // o_proj — NO gate (unlike the target's attention)
-            gemm(w: layer.oW, x: attnOutBuf, out: attnResBuf, M: blockSize, K: numHeads * headDim, N: H)
+            DFlashRawKernels.encodeFmm16(enc(), w: layer.oW, x: attnOutBuf, out: attnResBuf,
+                                         M: blockSize, K: numHeads * headDim, N: H)
             SeedlessFusedVerify.encodeResidAdd(enc(), h: hBuf, r: attnResBuf, total: blockSize * H)
 
             // MLP (swiglu)
             SeedlessFusedVerify.encodeRmsNormRows(enc(), x: hBuf, w: layer.postLN, out: mnBuf,
                                                   rows: blockSize, D: H, eps: eps)
-            gemm(w: layer.gateW, x: mnBuf, out: gateBuf, M: blockSize, K: H, N: mlpDim)
-            gemm(w: layer.upW, x: mnBuf, out: upBuf, M: blockSize, K: H, N: mlpDim)
+            DFlashRawKernels.encodeFmm16(enc(), w: layer.gateW, x: mnBuf, out: gateBuf,
+                                         M: blockSize, K: H, N: mlpDim)
+            DFlashRawKernels.encodeFmm16(enc(), w: layer.upW, x: mnBuf, out: upBuf,
+                                         M: blockSize, K: H, N: mlpDim)
             SeedlessFusedVerify.encodeSwiglu(enc(), g: gateBuf, u: upBuf, h: actBuf, total: blockSize * mlpDim)
-            gemm(w: layer.downW, x: actBuf, out: downBuf, M: blockSize, K: mlpDim, N: H)
+            DFlashRawKernels.encodeFmm16(enc(), w: layer.downW, x: actBuf, out: downBuf,
+                                         M: blockSize, K: mlpDim, N: H)
             SeedlessFusedVerify.encodeResidAdd(enc(), h: hBuf, r: downBuf, total: blockSize * H)
         }
 
@@ -428,9 +405,10 @@ public final class DFlashRawDrafter {
         SeedlessFusedVerify.encodeRmsNormRows(enc(), x: hBuf, w: finalNorm, out: normedBuf,
                                               rows: blockSize, D: H, eps: eps)
         // target lm_head over ALL rows (row 0 discarded on readback — simpler than an x-offset
-        // variant, at the cost of one extra row of compute). f16 MPS GEMM on the dequantized
-        // head (see lmF16Buf comment).
-        gemm(w: lf, x: normedBuf, out: logits, M: blockSize, K: H, N: vocab)
+        // variant, at the cost of one extra row of compute). dflash_fmm16 on the dequantized
+        // f16 head (see lmF16Buf comment).
+        DFlashRawKernels.encodeFmm16(enc(), w: lf, x: normedBuf, out: logits,
+                                     M: blockSize, K: H, N: vocab)
         encodeArgmax(enc(), logits: logits, V: vocab)
     }
 
@@ -477,6 +455,124 @@ public final class DFlashRawDrafter {
         guard hasRun else { return nil }
         let ptr = normedBuf.contents().bindMemory(to: Float16.self, capacity: blockSize * H)
         return Array(UnsafeBufferPointer(start: ptr, count: blockSize * H))
+    }
+
+    // ── f16 GEMM kernel micro-bench (QWISP_RUN=dflash-gemm-bench): correctness (vs MLX
+    //    matmul, rel err) + effective bandwidth at the drafter's production shapes, measured
+    //    standalone BEFORE integration (measure-first doctrine). ──
+    public static func gemmBench() -> String {
+        guard let (dev, queue) = SeedlessMetalForward.ensure(),
+              DFlashRawKernels.ensureSdpaPipeline(dev) else { return "[dflash-gemm-bench] no device/pipeline" }
+        var lines: [String] = ["[dflash-gemm-bench] dflash_fmm16 y[M,N]=x[M,K]@W[N,K]^T (M=8)"]
+        let M = 8
+        for (k, n, tag) in [(2048, 2048, "q/o"), (2048, 256, "kv"), (2048, 9216, "gate/up"),
+                            (9216, 2048, "down"), (16384, 2048, "fc"), (2048, 151936, "lm_head")] {
+            let wA = MLXRandom.normal([n, k]).asType(.float16)
+            let xA = MLXRandom.normal([M, k]).asType(.float16)
+            MLX.eval([wA, xA])
+            guard let wSrc = SeedlessMetalForward.mtlBuf(wA, dev),
+                  let xSrc = SeedlessMetalForward.mtlBuf(xA, dev),
+                  let wB = dev.makeBuffer(length: wSrc.length, options: .storageModeShared),
+                  let xB = dev.makeBuffer(length: xSrc.length, options: .storageModeShared),
+                  let yB = dev.makeBuffer(length: M * n * 2, options: .storageModeShared)
+            else { return "[dflash-gemm-bench] buffers nil" }
+            memcpy(wB.contents(), wSrc.contents(), wSrc.length)
+            memcpy(xB.contents(), xSrc.contents(), xSrc.length)
+            // correctness vs MLX (f32 reference)
+            let cb0 = queue.makeCommandBuffer()!
+            let e0 = cb0.makeComputeCommandEncoder()!
+            DFlashRawKernels.encodeFmm16(e0, w: wB, x: xB, out: yB, M: M, K: k, N: n)
+            e0.endEncoding(); cb0.commit(); cb0.waitUntilCompleted()
+            let ref = MLX.matmul(xA.asType(.float32), wA.asType(.float32).transposed())
+            ref.eval()
+            let refArr = ref.asArray(Float.self)
+            let got = yB.contents().bindMemory(to: Float16.self, capacity: M * n)
+            var num: Float = 0, den: Float = 0
+            for i in 0 ..< M * n { let d = Float(got[i]) - refArr[i]; num += d * d; den += refArr[i] * refArr[i] }
+            let rel = den > 0 ? (num / den).squareRoot() : -1
+            // bandwidth: reps in one CB (same out buffer → hazard-serialized like the real chain)
+            let reps = 20
+            let cb = queue.makeCommandBuffer()!
+            let e = cb.makeComputeCommandEncoder()!
+            for _ in 0 ..< reps { DFlashRawKernels.encodeFmm16(e, w: wB, x: xB, out: yB, M: M, K: k, N: n) }
+            e.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+            let ms = (cb.gpuEndTime - cb.gpuStartTime) * 1000.0 / Double(reps)
+            let gbs = Double(n * k * 2) / (ms / 1000.0) / 1e9
+            lines.append(String(format: "  %-8@ K=%-5d N=%-6d  %.3fms  W-bw=%.0fGB/s  rel=%.2e",
+                                tag as NSString, k, n, ms, gbs, rel))
+        }
+        // ── dependent-chain calibration: y = x@W ping-pong (x↔y, N=K=2048) is a TRUE
+        // read-after-write chain — the reps loop above is write-after-write on one out
+        // buffer, which the driver may overlap. This row is the honest per-GEMM cost
+        // inside a dependent chain (what the drafter actually pays).
+        do {
+            let k = 2048, n = 2048
+            let wA = MLXRandom.normal([n, k]).asType(.float16)
+            let xA = MLXRandom.normal([M, k]).asType(.float16)
+            MLX.eval([wA, xA])
+            guard let wSrc = SeedlessMetalForward.mtlBuf(wA, dev),
+                  let xSrc = SeedlessMetalForward.mtlBuf(xA, dev),
+                  let wB = dev.makeBuffer(length: wSrc.length, options: .storageModeShared),
+                  let aB = dev.makeBuffer(length: M * k * 2, options: .storageModeShared),
+                  let bB = dev.makeBuffer(length: M * n * 2, options: .storageModeShared)
+            else { return lines.joined(separator: "\n") }
+            memcpy(wB.contents(), wSrc.contents(), wSrc.length)
+            memcpy(aB.contents(), xSrc.contents(), xSrc.length)
+            let reps = 40
+            let cb = queue.makeCommandBuffer()!
+            let e = cb.makeComputeCommandEncoder()!
+            for i in 0 ..< reps {
+                let (src, dst) = i % 2 == 0 ? (aB, bB) : (bB, aB)
+                DFlashRawKernels.encodeFmm16(e, w: wB, x: src, out: dst, M: M, K: k, N: n)
+            }
+            e.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+            let ms = (cb.gpuEndTime - cb.gpuStartTime) * 1000.0 / Double(reps)
+            lines.append(String(format: "  chain    K=2048 N=2048   %.3fms  W-bw=%.0fGB/s  (dependent ping-pong)",
+                                ms, Double(n * k * 2) / (ms / 1000.0) / 1e9))
+        }
+        // ── cold-W probe: cycle a 192MB weight set (exceeds SLC) so every GEMM reads W
+        // from DRAM, (a) 24 separate 8MB allocations (like the drafter's 61 per-tensor
+        // buffers), (b) ONE 192MB slab addressed by offset. Discriminates allocation
+        // granularity / mapping cost from pure DRAM streaming for the in-loop 3x tax.
+        do {
+            let k = 2048, n = 2048, count = 24
+            let wA = MLXRandom.normal([n, k]).asType(.float16)
+            MLX.eval([wA])
+            guard let wSrc = SeedlessMetalForward.mtlBuf(wA, dev),
+                  let aB = dev.makeBuffer(length: M * k * 2, options: .storageModeShared),
+                  let bB = dev.makeBuffer(length: M * n * 2, options: .storageModeShared),
+                  let slab = dev.makeBuffer(length: count * n * k * 2, options: .storageModeShared)
+            else { return lines.joined(separator: "\n") }
+            var seps: [MTLBuffer] = []
+            for i in 0 ..< count {
+                guard let b = dev.makeBuffer(length: n * k * 2, options: .storageModeShared)
+                else { return lines.joined(separator: "\n") }
+                memcpy(b.contents(), wSrc.contents(), n * k * 2)
+                memcpy(slab.contents() + i * n * k * 2, wSrc.contents(), n * k * 2)
+                seps.append(b)
+            }
+            let rounds = 5
+            for mode in ["separate", "slab"] {
+                let cb = queue.makeCommandBuffer()!
+                let e = cb.makeComputeCommandEncoder()!
+                for r in 0 ..< rounds {
+                    for i in 0 ..< count {
+                        let (src, dst) = (r * count + i) % 2 == 0 ? (aB, bB) : (bB, aB)
+                        if mode == "separate" {
+                            DFlashRawKernels.encodeFmm16(e, w: seps[i], x: src, out: dst, M: M, K: k, N: n)
+                        } else {
+                            DFlashRawKernels.encodeFmm16(e, w: slab, x: src, out: dst, M: M, K: k, N: n,
+                                                         wOff: i * n * k * 2)
+                        }
+                    }
+                }
+                e.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+                let ms = (cb.gpuEndTime - cb.gpuStartTime) * 1000.0 / Double(rounds * count)
+                lines.append(String(format: "  coldW-%@  K=2048 N=2048  %.3fms  W-bw=%.0fGB/s  (192MB set, DRAM-cold)",
+                                    mode as NSString, ms, Double(n * k * 2) / (ms / 1000.0) / 1e9))
+            }
+        }
+        return lines.joined(separator: "\n")
     }
 
     // ── Steady-state micro-bench (QWISP_RUN=dflash-raw-bench): back-to-back forwards on the
@@ -558,14 +654,86 @@ public final class DFlashRawDrafter {
 // threadgroups (numHeads*M threadgroups of 32 vs previously ceil(numHeads/32)*M groups), ~32x
 // less serial depth per lane. Key→lane assignment depends only on absolute key position, so the
 // two-call-vs-one-call byte-exact cache-consistency contract (locked test 97) is unaffected.
-private enum DFlashRawKernels {
+enum DFlashRawKernels {
     nonisolated(unsafe) static var sdpaPipeline: MTLComputePipelineState?
+    nonisolated(unsafe) static var fmm16Pipeline: MTLComputePipelineState?
 
     static func ensureSdpaPipeline(_ device: MTLDevice) -> Bool {
         if sdpaPipeline != nil { return true }
         let src = """
         #include <metal_stdlib>
         using namespace metal;
+        // dflash_fmm16: y[M,N] = x[M,K] @ W[N,K]^T, f16 in/out, f32 accumulate.
+        // qmv_fast-derived (#98 A1 round 4): 2 simdgroups per TG, ROWS=2 output rows per
+        // simdgroup, lanes stride K in 16-half chunks, simd_sum reduce — NO threadgroup
+        // memory, NO barriers (the barrier-tree qmm4_tiled shape measured 33ms at drafter
+        // context; qmv-class shapes are the engine's proven-fast family). W chunk registers
+        // are shared across the M-loop, so W is read ONCE total (the per-row qmv re-read
+        // and the fmm_rows re-read were the earlier falsified shapes). x is 32KB and stays
+        // SLC-hot.
+        // M-INVARIANCE (locked test 97 contract): each output element (m,n) accumulates in
+        // a fixed K-serial chunk order partitioned by lane only, then one simd_sum — the
+        // batch size M never enters any per-element order, so results are byte-stable
+        // across call splits BY CONSTRUCTION (ctx rows may batch freely).
+        // Constraints: N % 4 == 0; M <= 16 per dispatch (caller slices).
+        kernel void dflash_fmm16(
+            device const half* W [[buffer(0)]],    // [N, K]
+            device const half* x [[buffer(1)]],    // [M, K]
+            device half* y       [[buffer(2)]],    // [M, N]
+            constant int& K      [[buffer(3)]],
+            constant int& N      [[buffer(4)]],
+            constant int& M      [[buffer(5)]],
+            uint3 tid     [[threadgroup_position_in_grid]],
+            uint simd_gid [[simdgroup_index_in_threadgroup]],
+            uint simd_lid [[thread_index_in_simdgroup]])
+        {
+            constexpr int ROWS = 2;
+            constexpr int VPT  = 16;
+            constexpr int BLOCK = VPT * 32;        // 512 halfs of K per iteration
+            constexpr int MAXM = 16;
+            const int outRow = (int)tid.y * (2 * ROWS) + (int)simd_gid * ROWS;
+            const device half* w0 = W + (size_t)outRow * (size_t)K;
+            float acc[ROWS][MAXM];
+            for (int r = 0; r < ROWS; r++) for (int m = 0; m < MAXM; m++) acc[r][m] = 0.0f;
+            for (int k = 0; k < K; k += BLOCK) {
+                const int base = k + (int)simd_lid * VPT;
+                half wv[ROWS][VPT];
+                float xv[VPT];
+                if (base + VPT <= K) {              // fast path: whole 16-half chunk in range
+                    for (int r = 0; r < ROWS; r++) {
+                        const device half* wp = w0 + (size_t)r * (size_t)K + base;
+                        for (int i = 0; i < VPT; i++) wv[r][i] = wp[i];
+                    }
+                    for (int m = 0; m < M; m++) {
+                        const device half* xp = x + (size_t)m * (size_t)K + base;
+                        for (int i = 0; i < VPT; i++) xv[i] = xp[i];
+                        for (int r = 0; r < ROWS; r++) {
+                            float p = 0.0f;
+                            for (int i = 0; i < VPT; i++) p += xv[i] * (float)wv[r][i];
+                            acc[r][m] += p;
+                        }
+                    }
+                } else {                             // tail (test shapes: K=64/96/128)
+                    for (int r = 0; r < ROWS; r++)
+                        for (int i = 0; i < VPT; i++)
+                            wv[r][i] = (base + i < K) ? w0[(size_t)r * (size_t)K + base + i] : (half)0.0h;
+                    for (int m = 0; m < M; m++) {
+                        for (int i = 0; i < VPT; i++)
+                            xv[i] = (base + i < K) ? (float)x[(size_t)m * (size_t)K + base + i] : 0.0f;
+                        for (int r = 0; r < ROWS; r++) {
+                            float p = 0.0f;
+                            for (int i = 0; i < VPT; i++) p += xv[i] * (float)wv[r][i];
+                            acc[r][m] += p;
+                        }
+                    }
+                }
+            }
+            for (int r = 0; r < ROWS; r++)
+                for (int m = 0; m < M; m++) {
+                    float v = simd_sum(acc[r][m]);
+                    if (simd_lid == 0) y[(size_t)m * (size_t)N + outRow + r] = (half)v;
+                }
+        }
         // dflash_sdpa_rows: keys/values = cache[0..<cachedLen] ‖ prop[0..<propKeys(m)].
         // causalOffset!=0: propKeys(m) = m+1 (causal-with-offset). causalOffset==0: propKeys(m) = M
         // (no mask, bidirectional within the block). Cached keys are ALWAYS fully visible.
@@ -650,8 +818,32 @@ private enum DFlashRawKernels {
         do {
             let lib = try device.makeLibrary(source: src, options: SeedlessMetalForward.mlxMatchCompileOpts())
             sdpaPipeline = try device.makeComputePipelineState(function: lib.makeFunction(name: "dflash_sdpa_rows")!)
+            fmm16Pipeline = try device.makeComputePipelineState(function: lib.makeFunction(name: "dflash_fmm16")!)
         } catch { print("[dflash-raw-sdpa] compile: \(error)"); return false }
-        return sdpaPipeline != nil
+        return sdpaPipeline != nil && fmm16Pipeline != nil
+    }
+
+    /// f16 M-row GEMM: y[M,N] = x[M,K] @ W[N,K]^T. Slices M at 16 per dispatch (per-row
+    /// results are M-invariant, so slicing is byte-transparent). Requires N % 4 == 0.
+    static func encodeFmm16(_ enc: MTLComputeCommandEncoder,
+                            w: MTLBuffer, x: MTLBuffer, out: MTLBuffer,
+                            M: Int, K: Int, N: Int, wOff: Int = 0) {
+        let p = fmm16Pipeline!
+        var m0 = 0
+        while m0 < M {
+            let mc = min(16, M - m0)
+            enc.setComputePipelineState(p)
+            enc.setBuffer(w, offset: wOff, index: 0)
+            enc.setBuffer(x, offset: m0 * K * 2, index: 1)
+            enc.setBuffer(out, offset: m0 * N * 2, index: 2)
+            var kk = Int32(K), nn = Int32(N), mm = Int32(mc)
+            enc.setBytes(&kk, length: 4, index: 3)
+            enc.setBytes(&nn, length: 4, index: 4)
+            enc.setBytes(&mm, length: 4, index: 5)
+            enc.dispatchThreadgroups(MTLSize(width: 1, height: N / 4, depth: 1),
+                                     threadsPerThreadgroup: MTLSize(width: 32, height: 2, depth: 1))
+            m0 += mc
+        }
     }
 
     static func encode(_ enc: MTLComputeCommandEncoder,

--- a/swift/Sources/QwispCore/DFlashRawDrafter.swift
+++ b/swift/Sources/QwispCore/DFlashRawDrafter.swift
@@ -1,19 +1,24 @@
 import Foundation
 import MLX
 import Metal
+import MetalPerformanceShaders
 
 // #98 DFlash phase A1 — raw-Metal drafter forward (spec: scratchpad/dflash-phaseA1-spec.md).
 //
-// ONE command buffer per block, following the RawMTPHead idiom (SeedlessFusedVerify.swift
-// ~5079 SeedlessMTPHead): persistent f16 MTLBuffer weights (noCopy — the cast MLXArrays are
-// retained for the drafter's lifetime), persistent per-layer KV MTLBuffers, everything else
-// reused from the frozen SeedlessFusedVerify/SeedlessMetalForward statics (fmm_rows,
-// rmsNormRows, ropeRows, embed_rows_q4, qmm4/qmmRows, argmax_rows, swiglu, resid_add,
-// write_kv_rows). The ONLY new Metal source is the drafter's own SDPA kernel (below) — the
-// drafter has no gate path and no partial-rotary rope, so the existing gated-attention prep
-// kernels (attn_q_prep_rows/attn_k_prep_rows) don't fit and the existing D=256-hardcoded
-// sdpa_rows kernel doesn't fit a runtime headDim — a small headDim-parametric kernel is
-// compiled here with its own makeLibrary (diag-kernel precedent).
+// ONE command buffer per block: persistent f16 MTLBuffer weights (COPIED into Metal-owned
+// buffers at init — no noCopy lifetime obligation), persistent per-layer KV MTLBuffers.
+// GEMMs (q/k/v/o, MLP, fc, lm_head) are MPSMatrixMultiplication — the hand-rolled
+// fmm/qmm4 kernels measured 75-100ms/block at drafter shapes (M=8, 6 thin layers; ~2-3ms
+// roofline), overhead-dominated across 3 kernel designs (#98 A1 record). Small ops reuse
+// the frozen SeedlessFusedVerify/SeedlessMetalForward statics (rmsNormRows, ropeRows,
+// embed_rows_q4, argmax_rows, swiglu, resid_add, write_kv_rows). The ONLY new Metal source
+// is the drafter's own SDPA kernel (below) — the drafter has no gate path and no
+// partial-rotary rope, so the existing gated-attention prep kernels don't fit and the
+// existing D=256-hardcoded sdpa_rows kernel doesn't fit a runtime headDim.
+//
+// Fused draft+verify (#98 A1 round 3): prepare() → encode(cb:) → finish() lets the verify
+// CB carry the drafter as a prologue (MPS opens its own internal encoders, so the seam is
+// CB-level); forward() composes the three standalone.
 //
 // v1 scope (pinned): NO sliding eviction. ctxCap = slidingWindow - 1 for ALL layers; forward
 // returns nil once ctxLen+ctxCount would exceed it (caller falls back to the MLX drafter).
@@ -50,13 +55,55 @@ public final class DFlashRawDrafter {
     private let finalNorm: MTLBuffer      // [H]  (drafter's OWN final norm — not the target's)
 
     // ── Target head (attached post-init; embed for noise, lm_head for logits) ──
+    // lm_head is DEQUANTIZED to f16 (V×H×2 ≈ 0.6GB for the real head): the drafter is
+    // resident-tier-only + opt-in, and the 4-bit qmm4_tiled path measured 33ms at drafter
+    // shapes (overhead-dominated) vs ~3ms roofline for an MPS f16 GEMM. Embed stays 4-bit
+    // (per-row gather is cheap).
     private var embedWBuf: MTLBuffer?, embedSBuf: MTLBuffer?, embedBBuf: MTLBuffer?
-    private var lmWBuf: MTLBuffer?, lmSBuf: MTLBuffer?, lmBBuf: MTLBuffer?
+    private var lmF16Buf: MTLBuffer?
     private var vocab: Int = 0
     private var logitsBuf: MTLBuffer?
 
-    // noCopy 寿命規約 (notes/03): mtlBuf(noCopy) の backing MLXArray を drafter と同寿命で保持。
-    private var retained: [MLXArray] = []
+    // ── MPS GEMM plumbing (#98 A1 round 3): the hand-rolled fmm/qmm kernels measured
+    // 75-100ms/block at drafter shapes (M=8, 6 thin layers) vs ~2-3ms roofline — the pinned
+    // fallback lever is MPSMatrixMultiplication, which encodes into the SAME command buffer
+    // (its own internal encoders), so the fused draft+verify CB structure is preserved.
+    private var mpsMulCache: [String: MPSMatrixMultiplication] = [:]
+    private var _cb: MTLCommandBuffer?
+    private var _enc: MTLComputeCommandEncoder?
+    private func enc() -> MTLComputeCommandEncoder {
+        if _enc == nil { _enc = _cb!.makeComputeCommandEncoder()! }
+        return _enc!
+    }
+    private func closeEnc() { _enc?.endEncoding(); _enc = nil }
+    private func mpsMat(_ buf: MTLBuffer, _ rows: Int, _ cols: Int, off: Int = 0) -> MPSMatrix {
+        MPSMatrix(buffer: buf, offset: off, descriptor: MPSMatrixDescriptor(
+            rows: rows, columns: cols, rowBytes: cols * 2, dataType: .float16))
+    }
+    /// out[M,N] = x[M,K] @ W[N,K]^T, all f16 (f32 accumulate inside MPS).
+    private func gemm(w: MTLBuffer, x: MTLBuffer, out: MTLBuffer, M: Int, K: Int, N: Int,
+                      xOff: Int = 0, outOff: Int = 0) {
+        closeEnc()
+        let key = "\(M)/\(K)/\(N)"
+        let mul: MPSMatrixMultiplication
+        if let m = mpsMulCache[key] { mul = m } else {
+            mul = MPSMatrixMultiplication(device: device, transposeLeft: false, transposeRight: true,
+                                          resultRows: M, resultColumns: N, interiorColumns: K,
+                                          alpha: 1.0, beta: 0.0)
+            mpsMulCache[key] = mul
+        }
+        mul.encode(commandBuffer: _cb!, leftMatrix: mpsMat(x, M, K, off: xOff),
+                   rightMatrix: mpsMat(w, N, K), resultMatrix: mpsMat(out, M, N, off: outOff))
+    }
+    /// ctx-path GEMM: one M=1 GEMM PER ROW. ctxCount varies call-to-call and batched MPS
+    /// output is not M-invariant at the byte level — but the drafter KV cache must be
+    /// byte-stable across call splits (two-call vs one-shot, locked test 97). Per-row M=1
+    /// makes every row an identical subproblem regardless of batching.
+    private func gemmPerRow(w: MTLBuffer, x: MTLBuffer, out: MTLBuffer, rows: Int, K: Int, N: Int) {
+        for r in 0 ..< rows {
+            gemm(w: w, x: x, out: out, M: 1, K: K, N: N, xOff: r * K * 2, outOff: r * N * 2)
+        }
+    }
 
     // ── Shared committed context length (v1: every layer advances together) ──
     private var ctxLen: Int = 0
@@ -126,10 +173,18 @@ public final class DFlashRawDrafter {
         ctxCap = config.slidingWindow - 1
 
         func g(_ key: String) -> MLXArray? { weights[key]?.asType(.float16) }
-        var localRetained: [MLXArray] = []
+        // COPY into a Metal-owned buffer (not bytesNoCopy aliasing MLX memory): the drafter
+        // weights are touched only ~every 50ms for ~2ms — noCopy MLX-backed buffers measured
+        // ~17GB/s effective GPU read at these shapes (identical timings across 2 unrelated
+        // GEMM implementations = shared-resource bound), Metal-owned pages read at roofline.
+        // Copy also drops the noCopy lifetime obligation for these.
         func f16b(_ a: MLXArray) -> MTLBuffer? {
-            let c = a.asType(.float16); c.eval(); localRetained.append(c)
-            return SeedlessMetalForward.mtlBuf(c, dev)
+            let c = a.asType(.float16); c.eval()
+            guard let src = SeedlessMetalForward.mtlBuf(c, dev),
+                  let dst = dev.makeBuffer(length: src.length, options: .storageModeShared)
+            else { return nil }
+            memcpy(dst.contents(), src.contents(), src.length)
+            return dst
         }
 
         guard let fcArr = g("fc.weight"), let hnArr = g("hidden_norm.weight"), let fnArr = g("norm.weight"),
@@ -166,7 +221,6 @@ public final class DFlashRawDrafter {
                                      kCache: kCache, vCache: vCache, isSliding: isSliding))
         }
         layers = builtLayers
-        retained = localRetained
 
         // ── scratch buffers ──
         func hb(_ n: Int) -> MTLBuffer? { dev.makeBuffer(length: n * 2, options: .storageModeShared) }
@@ -203,17 +257,26 @@ public final class DFlashRawDrafter {
     // ── Target head attachment ──────────────────────────────────────────────
     public func attachTargetHead(embedW: MLXArray, embedS: MLXArray, embedB: MLXArray,
                                  lmW: MLXArray, lmS: MLXArray, lmB: MLXArray, vocab: Int) -> Bool {
-        func rawb(_ a: MLXArray) -> MTLBuffer? { a.eval(); retained.append(a); return SeedlessMetalForward.mtlBuf(a, device) }
-        func f16b(_ a: MLXArray) -> MTLBuffer? {
-            let c = a.asType(.float16); c.eval(); retained.append(c)
-            return SeedlessMetalForward.mtlBuf(c, device)
+        // COPY into Metal-owned buffers (same rationale as the init's f16b — the noCopy
+        // MLX-backed alias reads ~17GB/s at drafter access patterns).
+        func copyb(_ a: MLXArray) -> MTLBuffer? {
+            a.eval()
+            guard let src = SeedlessMetalForward.mtlBuf(a, device),
+                  let dst = device.makeBuffer(length: src.length, options: .storageModeShared)
+            else { return nil }
+            memcpy(dst.contents(), src.contents(), src.length)
+            return dst
         }
-        guard let ew = rawb(embedW), let es = f16b(embedS), let eb = f16b(embedB),
-              let lw = rawb(lmW), let ls = f16b(lmS), let lb = f16b(lmB),
+        func f16b(_ a: MLXArray) -> MTLBuffer? { copyb(a.asType(.float16)) }
+        // lm_head → dequantized f16 [V, H] for the MPS GEMM (see field comment).
+        let lmF16 = MLX.dequantized(lmW, scales: lmS, biases: lmB,
+                                    groupSize: 64, bits: 4, mode: .affine).asType(.float16)
+        guard let ew = copyb(embedW), let es = f16b(embedS), let eb = f16b(embedB),
+              let lf = f16b(lmF16),
               let logits = device.makeBuffer(length: blockSize * vocab * 2, options: .storageModeShared)
         else { return false }
         embedWBuf = ew; embedSBuf = es; embedBBuf = eb
-        lmWBuf = lw; lmSBuf = ls; lmBBuf = lb
+        lmF16Buf = lf
         self.vocab = vocab
         logitsBuf = logits
         return true
@@ -244,18 +307,23 @@ public final class DFlashRawDrafter {
                                  threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
     }
 
-    // ── forward ──────────────────────────────────────────────────────────────
-    public func forward(u: Int32, ctxRows: [Float16], ctxCount: Int) -> [Int]? {
-        guard let ew = embedWBuf, let es = embedSBuf, let eb = embedBBuf,
-              let lw = lmWBuf, let ls = lmSBuf, let lb = lmBBuf, let logits = logitsBuf
-        else { return nil }   // attachTargetHead not called
-        guard ctxLen + ctxCount <= ctxCap else { return nil }   // v1 cap contract
+    // ── forward, split into prepare / encode / finish ───────────────────────
+    // #98 A1 fused draft+verify: the verify CB encodes the drafter as a prologue
+    // (prepare → encode(callerEnc) → [caller commits] → finish). forward() composes the
+    // three on a private CB for the standalone path (tests / bench / dispatch fallback).
+
+    private var pendingCount = -1   // prepared ctxCount; -1 = no prepare() outstanding
+
+    /// CPU-side stage: attach + ctx-cap guards, token & ctx scratch upload. No GPU work,
+    /// no state advance — abandoning after prepare() (fused-step failure) is side-effect-free.
+    public func prepare(u: Int32, ctxRows: [Float16], ctxCount: Int) -> Bool {
+        guard embedWBuf != nil, logitsBuf != nil else { return false }   // attachTargetHead not called
+        guard ctxLen + ctxCount <= ctxCap else { return false }          // v1 cap contract
 
         // 1. noise tokens: [u] ++ [maskId × (blockSize-1)]
-        var toks = [Int32](repeating: Int32(config.maskTokenId), count: blockSize)
-        toks[0] = u
         let tokPtr = tokBuf.contents().bindMemory(to: Int32.self, capacity: blockSize)
-        for i in 0 ..< blockSize { tokPtr[i] = toks[i] }
+        tokPtr[0] = u
+        for i in 1 ..< blockSize { tokPtr[i] = Int32(config.maskTokenId) }
 
         // 2. ctx rows upload (persistent scratch buffer, refreshed each call)
         if ctxCount > 0 {
@@ -263,148 +331,136 @@ public final class DFlashRawDrafter {
                 memcpy(ctxInputBuf.contents(), raw.baseAddress!, ctxCount * ctxFeatureDim * 2)
             }
         }
+        pendingCount = ctxCount
+        return true
+    }
+
+    /// GPU-side stage: encodes the whole drafter block (embed → ctx fc → layers → lm_head →
+    /// argmax → tokenOutBuf) into the caller's command buffer. GEMMs go through MPS (which
+    /// opens its own internal encoders — hence the CB-level seam, not an encoder-level one);
+    /// the small ops (norm/rope/SDPA/swiglu/residAdd/writeKV/argmax) use the existing raw
+    /// pipelines on interleaved compute encoders. Requires a successful prepare().
+    public func encode(cb: MTLCommandBuffer) {
+        guard pendingCount >= 0 else { return }
+        let ctxCount = pendingCount
+        let ew = embedWBuf!, es = embedSBuf!, eb = embedBBuf!
+        let lf = lmF16Buf!, logits = logitsBuf!
 
         let cachedLen = ctxLen + ctxCount   // KV length valid after this call's ctx append
         let scale = Float(pow(Double(headDim), -0.5))
-
-        let trace = Tell.envFlag("QWISP_DFLASH_TRACE")
-        var cb = queue.makeCommandBuffer()!
-        var enc = cb.makeComputeCommandEncoder()!
-        var stamps: [(String, Double)] = []
-        // trace-only stage split (flag off = single CB, identical to production).
-        func split(_ label: String) {
-            guard trace else { return }
-            enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
-            stamps.append((label, (cb.gpuEndTime - cb.gpuStartTime) * 1000.0))
-            cb = queue.makeCommandBuffer()!
-            enc = cb.makeComputeCommandEncoder()!
-        }
+        _cb = cb
+        defer { closeEnc(); _cb = nil }
 
         // noise embed → hBuf (residual stream init)
-        encodeEmbedNoise(enc, ew: ew, es: es, eb: eb)
+        encodeEmbedNoise(enc(), ew: ew, es: es, eb: eb)
 
         // ctx feature path (computed ONCE, shared by every layer's k/v proj)
         if ctxCount > 0 {
-            DFlashRawKernels.encodeFmmTiled(enc, w: fcW, x: ctxInputBuf, out: fcOutBuf,
-                                              M: ctxCount, K: ctxFeatureDim, N: H)
-            SeedlessFusedVerify.encodeRmsNormRows(enc, x: fcOutBuf, w: hiddenNorm, out: hCtxBuf,
+            gemmPerRow(w: fcW, x: ctxInputBuf, out: fcOutBuf, rows: ctxCount, K: ctxFeatureDim, N: H)
+            SeedlessFusedVerify.encodeRmsNormRows(enc(), x: fcOutBuf, w: hiddenNorm, out: hCtxBuf,
                                                   rows: ctxCount, D: H, eps: eps)
         }
 
-        split("embed+ctx")
-
         for layer in layers {
             // attn input norm (block rows only — ctx k/v project straight from hCtx, no inputLN)
-            SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: layer.inputLN, out: anLNBuf,
+            SeedlessFusedVerify.encodeRmsNormRows(enc(), x: hBuf, w: layer.inputLN, out: anLNBuf,
                                                   rows: blockSize, D: H, eps: eps)
-            // q / propK / propV projections
-            DFlashRawKernels.encodeFmmTiled(enc, w: layer.qW, x: anLNBuf, out: qRawBuf,
-                                              M: blockSize, K: H, N: numHeads * headDim)
-            DFlashRawKernels.encodeFmmTiled(enc, w: layer.kW, x: anLNBuf, out: pkRawBuf,
-                                              M: blockSize, K: H, N: numKV * headDim)
-            DFlashRawKernels.encodeFmmTiled(enc, w: layer.vW, x: anLNBuf, out: pvBuf,
-                                              M: blockSize, K: H, N: numKV * headDim)
+            // q / propK / propV projections (+ ctx k/v from hCtx — grouped into ONE MPS run)
+            gemm(w: layer.qW, x: anLNBuf, out: qRawBuf, M: blockSize, K: H, N: numHeads * headDim)
+            gemm(w: layer.kW, x: anLNBuf, out: pkRawBuf, M: blockSize, K: H, N: numKV * headDim)
+            gemm(w: layer.vW, x: anLNBuf, out: pvBuf, M: blockSize, K: H, N: numKV * headDim)
+            if ctxCount > 0 {
+                // ctx k/v (this layer's own k/v proj — NOT re-normed by inputLN)
+                gemmPerRow(w: layer.kW, x: hCtxBuf, out: ckRawBuf, rows: ctxCount, K: H, N: numKV * headDim)
+                gemmPerRow(w: layer.vW, x: hCtxBuf, out: cvBuf, rows: ctxCount, K: H, N: numKV * headDim)
+            }
             // q/k rmsNorm (last-dim headDim, treating each (row,head) as an independent chunk)
-            SeedlessFusedVerify.encodeRmsNormRows(enc, x: qRawBuf, w: layer.qNorm, out: qNormedBuf,
+            SeedlessFusedVerify.encodeRmsNormRows(enc(), x: qRawBuf, w: layer.qNorm, out: qNormedBuf,
                                                   rows: blockSize * numHeads, D: headDim, eps: eps)
-            SeedlessFusedVerify.encodeRmsNormRows(enc, x: pkRawBuf, w: layer.kNorm, out: pkNormedBuf,
+            SeedlessFusedVerify.encodeRmsNormRows(enc(), x: pkRawBuf, w: layer.kNorm, out: pkNormedBuf,
                                                   rows: blockSize * numKV, D: headDim, eps: eps)
             // FULL-headDim RoPE: q and propK at position cachedLen + row
-            SeedlessFusedVerify.encodeRopeRows(enc, x: qNormedBuf, out: qRotBuf,
+            SeedlessFusedVerify.encodeRopeRows(enc(), x: qNormedBuf, out: qRotBuf,
                                               headDim: headDim, ropeDim: headDim, base: ropeTheta,
                                               startOffset: cachedLen, M: blockSize, numHeads: numHeads)
-            SeedlessFusedVerify.encodeRopeRows(enc, x: pkNormedBuf, out: pkRotBuf,
+            SeedlessFusedVerify.encodeRopeRows(enc(), x: pkNormedBuf, out: pkRotBuf,
                                               headDim: headDim, ropeDim: headDim, base: ropeTheta,
                                               startOffset: cachedLen, M: blockSize, numHeads: numKV)
 
             if ctxCount > 0 {
-                // ctx k/v from hCtx (this layer's own k/v proj — NOT re-normed by inputLN)
-                DFlashRawKernels.encodeFmmTiled(enc, w: layer.kW, x: hCtxBuf, out: ckRawBuf,
-                                                  M: ctxCount, K: H, N: numKV * headDim)
-                DFlashRawKernels.encodeFmmTiled(enc, w: layer.vW, x: hCtxBuf, out: cvBuf,
-                                                  M: ctxCount, K: H, N: numKV * headDim)
-                SeedlessFusedVerify.encodeRmsNormRows(enc, x: ckRawBuf, w: layer.kNorm, out: ckNormedBuf,
+                SeedlessFusedVerify.encodeRmsNormRows(enc(), x: ckRawBuf, w: layer.kNorm, out: ckNormedBuf,
                                                       rows: ctxCount * numKV, D: headDim, eps: eps)
                 // ctxK at position ctxLen(before this call) + row
-                SeedlessFusedVerify.encodeRopeRows(enc, x: ckNormedBuf, out: ckRotBuf,
+                SeedlessFusedVerify.encodeRopeRows(enc(), x: ckNormedBuf, out: ckRotBuf,
                                                   headDim: headDim, ropeDim: headDim, base: ropeTheta,
                                                   startOffset: ctxLen, M: ctxCount, numHeads: numKV)
                 // commit ctx k/v into this layer's persistent KV cache at [ctxLen, ctxLen+ctxCount)
-                SeedlessFusedVerify.encodeWriteKVRows(enc, src: ckRotBuf, cache: layer.kCache,
+                SeedlessFusedVerify.encodeWriteKVRows(enc(), src: ckRotBuf, cache: layer.kCache,
                                                       KV: numKV, D: headDim, maxLen: ctxCap, pos: ctxLen, M: ctxCount)
-                SeedlessFusedVerify.encodeWriteKVRows(enc, src: cvBuf, cache: layer.vCache,
+                SeedlessFusedVerify.encodeWriteKVRows(enc(), src: cvBuf, cache: layer.vCache,
                                                       KV: numKV, D: headDim, maxLen: ctxCap, pos: ctxLen, M: ctxCount)
             }
 
             // SDPA: keys = cached[0..<cachedLen] ‖ propK[0..<blockSize]
             //   sliding (causalOffset=true):  row r sees cachedLen + (r+1) keys
             //   full    (causalOffset=false): every row sees cachedLen + blockSize keys (no mask)
-            DFlashRawKernels.encode(enc, q: qRotBuf, kCache: layer.kCache, vCache: layer.vCache,
+            DFlashRawKernels.encode(enc(), q: qRotBuf, kCache: layer.kCache, vCache: layer.vCache,
                                    propK: pkRotBuf, propV: pvBuf, out: attnOutBuf,
                                    numHeads: numHeads, numKV: numKV, D: headDim,
                                    cachedLen: cachedLen, ctxCap: ctxCap, M: blockSize,
                                    scale: scale, causalOffset: layer.isSliding)
 
             // o_proj — NO gate (unlike the target's attention)
-            DFlashRawKernels.encodeFmmTiled(enc, w: layer.oW, x: attnOutBuf, out: attnResBuf,
-                                              M: blockSize, K: numHeads * headDim, N: H)
-            SeedlessFusedVerify.encodeResidAdd(enc, h: hBuf, r: attnResBuf, total: blockSize * H)
+            gemm(w: layer.oW, x: attnOutBuf, out: attnResBuf, M: blockSize, K: numHeads * headDim, N: H)
+            SeedlessFusedVerify.encodeResidAdd(enc(), h: hBuf, r: attnResBuf, total: blockSize * H)
 
             // MLP (swiglu)
-            SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: layer.postLN, out: mnBuf,
+            SeedlessFusedVerify.encodeRmsNormRows(enc(), x: hBuf, w: layer.postLN, out: mnBuf,
                                                   rows: blockSize, D: H, eps: eps)
-            DFlashRawKernels.encodeFmmTiled(enc, w: layer.gateW, x: mnBuf, out: gateBuf,
-                                              M: blockSize, K: H, N: mlpDim)
-            DFlashRawKernels.encodeFmmTiled(enc, w: layer.upW, x: mnBuf, out: upBuf,
-                                              M: blockSize, K: H, N: mlpDim)
-            SeedlessFusedVerify.encodeSwiglu(enc, g: gateBuf, u: upBuf, h: actBuf, total: blockSize * mlpDim)
-            DFlashRawKernels.encodeFmmTiled(enc, w: layer.downW, x: actBuf, out: downBuf,
-                                              M: blockSize, K: mlpDim, N: H)
-            SeedlessFusedVerify.encodeResidAdd(enc, h: hBuf, r: downBuf, total: blockSize * H)
+            gemm(w: layer.gateW, x: mnBuf, out: gateBuf, M: blockSize, K: H, N: mlpDim)
+            gemm(w: layer.upW, x: mnBuf, out: upBuf, M: blockSize, K: H, N: mlpDim)
+            SeedlessFusedVerify.encodeSwiglu(enc(), g: gateBuf, u: upBuf, h: actBuf, total: blockSize * mlpDim)
+            gemm(w: layer.downW, x: actBuf, out: downBuf, M: blockSize, K: mlpDim, N: H)
+            SeedlessFusedVerify.encodeResidAdd(enc(), h: hBuf, r: downBuf, total: blockSize * H)
         }
-
-        split("layers")
 
         // final rmsNorm (drafter's OWN norm — not the target's final norm)
-        SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: finalNorm, out: normedBuf,
+        SeedlessFusedVerify.encodeRmsNormRows(enc(), x: hBuf, w: finalNorm, out: normedBuf,
                                               rows: blockSize, D: H, eps: eps)
         // target lm_head over ALL rows (row 0 discarded on readback — simpler than an x-offset
-        // qmm variant, at the cost of one extra row of compute). qmm4_tiled (threadgroup
-        // dequant shared across the M rows — same kernel stepArgmax uses for verify M>1):
-        // the per-row qmv (encodeQmmRows) re-reads+dequants the whole 4-bit lm_head PER ROW,
-        // ~8x the weight traffic at blockSize=8.
-        do {
-            let qp = SeedlessMetalForward._qmm4TiledPipeline!
-            enc.setComputePipelineState(qp)
-            enc.setBuffer(lw, offset: 0, index: 0); enc.setBuffer(ls, offset: 0, index: 1)
-            enc.setBuffer(lb, offset: 0, index: 2); enc.setBuffer(normedBuf, offset: 0, index: 3)
-            enc.setBuffer(logits, offset: 0, index: 4)
-            var kk = Int32(H), nn = Int32(vocab), mm = Int32(blockSize)
-            enc.setBytes(&kk, length: 4, index: 5); enc.setBytes(&nn, length: 4, index: 6)
-            enc.setBytes(&mm, length: 4, index: 7)
-            enc.dispatchThreadgroups(MTLSize(width: vocab, height: 1, depth: 1),
-                                     threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
-        }
-        split("lmhead")
-        encodeArgmax(enc, logits: logits, V: vocab)
+        // variant, at the cost of one extra row of compute). f16 MPS GEMM on the dequantized
+        // head (see lmF16Buf comment).
+        gemm(w: lf, x: normedBuf, out: logits, M: blockSize, K: H, N: vocab)
+        encodeArgmax(enc(), logits: logits, V: vocab)
+    }
 
-        enc.endEncoding()
-        let t0 = DispatchTime.now()
-        cb.commit(); cb.waitUntilCompleted()
-        if trace {
-            let wallMs = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1e6
-            stamps.append(("head", (cb.gpuEndTime - cb.gpuStartTime) * 1000.0))
-            let parts = stamps.map { String(format: "%@=%.2fms", $0.0, $0.1) }.joined(separator: " ")
-            FileHandle.standardError.write(Data(String(
-                format: "[dflash-raw-time] %@ (tailWall=%.2fms) ctx=%d cached=%d\n",
-                parts, wallMs, ctxCount, cachedLen).utf8))
-        }
-
-        ctxLen += ctxCount
+    /// Post-completion stage: advances ctxLen and reads the draft token ids (rows 1..<block).
+    /// Call ONLY after the CB containing encode() has completed.
+    public func finish() -> [Int] {
+        ctxLen += max(0, pendingCount)
+        pendingCount = -1
         hasRun = true
-
         let ptr = tokenOutBuf.contents().bindMemory(to: Int32.self, capacity: blockSize)
         return (1 ..< blockSize).map { Int(ptr[$0]) }
+    }
+
+    /// Fused-CB seam: the drafter's argmax output ([blockSize] int32; row 0 = u's own argmax,
+    /// discarded) — blit source for the verify tokensIn.
+    public var tokenOutBuffer: MTLBuffer { tokenOutBuf }
+
+    /// Standalone forward (tests / bench / MLX-fallback dispatch path): private 1-CB compose
+    /// of prepare → encode → finish.
+    public func forward(u: Int32, ctxRows: [Float16], ctxCount: Int) -> [Int]? {
+        guard prepare(u: u, ctxRows: ctxRows, ctxCount: ctxCount) else { return nil }
+        let cb = queue.makeCommandBuffer()!
+        encode(cb: cb)
+        cb.commit(); cb.waitUntilCompleted()
+        if Tell.envFlag("QWISP_DFLASH_TRACE") {
+            FileHandle.standardError.write(Data(String(
+                format: "[dflash-raw-time] gpu=%.2fms ctx=%d cached=%d\n",
+                (cb.gpuEndTime - cb.gpuStartTime) * 1000.0, ctxCount, ctxLen + ctxCount).utf8))
+        }
+        return finish()
     }
 
     // ── Rollback / reset (v1: no KV erase — tail rows are simply overwritten on next append) ──
@@ -504,67 +560,12 @@ public final class DFlashRawDrafter {
 // two-call-vs-one-call byte-exact cache-consistency contract (locked test 97) is unaffected.
 private enum DFlashRawKernels {
     nonisolated(unsafe) static var sdpaPipeline: MTLComputePipelineState?
-    nonisolated(unsafe) static var fmmTiledPipeline: MTLComputePipelineState?
 
     static func ensureSdpaPipeline(_ device: MTLDevice) -> Bool {
         if sdpaPipeline != nil { return true }
         let src = """
         #include <metal_stdlib>
         using namespace metal;
-        // dflash_fmm_tiled: out[M,N] = x[M,K] @ W[N,K]^T, all f16. One 256-thread threadgroup
-        // per output column n; the K-strided W-row read is coalesced and stays hot in cache
-        // across the M-loop, so W traffic is ~once per block instead of once per (row, col)
-        // thread. Replaces fmm_rows for the drafter: fmm_rows (one thread per (n,m), 16-wide
-        // groups, serial K) re-reads every W row M times at poor effective bandwidth — fine
-        // for the 1-layer M<=2 MTP head it was built for, catastrophic for 6 layers x M=8
-        // (measured 165-170ms GPU per block, ~10x the MLX drafter it was meant to beat).
-        kernel void dflash_fmm_tiled(
-            device const half* W   [[buffer(0)]],   // [N, K]
-            device const half* x   [[buffer(1)]],   // [M, K]
-            device half*       out [[buffer(2)]],   // [M, N]
-            constant int&      K   [[buffer(3)]],
-            constant int&      N   [[buffer(4)]],
-            constant int&      M   [[buffer(5)]],
-            uint n   [[threadgroup_position_in_grid]],
-            uint tid [[thread_index_in_threadgroup]],
-            uint tgs [[threads_per_threadgroup]])
-        {
-            // dq_tiled structure (GroupedMoEPoC denseBench, the measured-good dense shape):
-            // stage the W row into threadgroup memory in K-chunks (read from device ONCE),
-            // then each m-pass dots against TG memory — W re-reads are free, x passes are
-            // coalesced (per-m contiguous) and L2-hot (x is 32KB total). Two earlier
-            // variants measured bad: m-outer device re-reads (L1 thrash across TGs, ~20ms)
-            // and m-inner strided x (8 cache lines per k per thread, ~48ms).
-            constexpr int MAXM = 16;
-            constexpr int CHUNK = 2048;
-            threadgroup half ws[CHUNK];
-            threadgroup float red[256];
-            const device half* wrow = W + (size_t)n * (size_t)K;
-            float acc[MAXM];
-            for (int m = 0; m < M; m++) acc[m] = 0.0f;
-            for (int k0 = 0; k0 < K; k0 += CHUNK) {
-                int kc = min(CHUNK, K - k0);
-                for (int k = (int)tid; k < kc; k += (int)tgs) ws[k] = wrow[k0 + k];
-                threadgroup_barrier(mem_flags::mem_threadgroup);
-                for (int m = 0; m < M; m++) {
-                    const device half* xrow = x + (size_t)m * (size_t)K + k0;
-                    float p = 0.0f;
-                    for (int k = (int)tid; k < kc; k += (int)tgs)
-                        p += (float)xrow[k] * (float)ws[k];
-                    acc[m] += p;
-                }
-                threadgroup_barrier(mem_flags::mem_threadgroup);
-            }
-            for (int m = 0; m < M; m++) {
-                red[tid] = acc[m]; threadgroup_barrier(mem_flags::mem_threadgroup);
-                for (uint s = tgs / 2; s > 0; s >>= 1) {
-                    if (tid < s) red[tid] += red[tid + s];
-                    threadgroup_barrier(mem_flags::mem_threadgroup);
-                }
-                if (tid == 0) out[m * N + (int)n] = (half)red[0];
-                threadgroup_barrier(mem_flags::mem_threadgroup);
-            }
-        }
         // dflash_sdpa_rows: keys/values = cache[0..<cachedLen] ‖ prop[0..<propKeys(m)].
         // causalOffset!=0: propKeys(m) = m+1 (causal-with-offset). causalOffset==0: propKeys(m) = M
         // (no mask, bidirectional within the block). Cached keys are ALWAYS fully visible.
@@ -649,27 +650,8 @@ private enum DFlashRawKernels {
         do {
             let lib = try device.makeLibrary(source: src, options: SeedlessMetalForward.mlxMatchCompileOpts())
             sdpaPipeline = try device.makeComputePipelineState(function: lib.makeFunction(name: "dflash_sdpa_rows")!)
-            fmmTiledPipeline = try device.makeComputePipelineState(function: lib.makeFunction(name: "dflash_fmm_tiled")!)
         } catch { print("[dflash-raw-sdpa] compile: \(error)"); return false }
-        return sdpaPipeline != nil && fmmTiledPipeline != nil
-    }
-
-    /// Tiled f16 matmul: out[M,N] = x[M,K] @ W[N,K]^T. Drop-in for the drafter's projection/
-    /// MLP/fc sites (bandwidth-correct replacement for fmm_rows at M=blockSize x 6 layers).
-    static func encodeFmmTiled(_ enc: MTLComputeCommandEncoder,
-                               w: MTLBuffer, x: MTLBuffer, out: MTLBuffer,
-                               M: Int, K: Int, N: Int) {
-        let p = fmmTiledPipeline!
-        enc.setComputePipelineState(p)
-        enc.setBuffer(w, offset: 0, index: 0)
-        enc.setBuffer(x, offset: 0, index: 1)
-        enc.setBuffer(out, offset: 0, index: 2)
-        var kk = Int32(K), nn = Int32(N), mm = Int32(M)
-        enc.setBytes(&kk, length: 4, index: 3)
-        enc.setBytes(&nn, length: 4, index: 4)
-        enc.setBytes(&mm, length: 4, index: 5)
-        enc.dispatchThreadgroups(MTLSize(width: N, height: 1, depth: 1),
-                                 threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        return sdpaPipeline != nil
     }
 
     static func encode(_ enc: MTLComputeCommandEncoder,

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -120,14 +120,33 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     private static func makeDFlash(engine: SeedlessEngine) -> DFlashDispatch? {
         let dir = ProcessInfo.processInfo.environment["QWISP_DFLASH_DIR"]
             ?? "\(FileManager.default.homeDirectoryForCurrentUser.path)/.mtplx/models/z-lab--Qwen3.6-35B-A3B-DFlash"
-        guard let drafter = DFlashDrafter.load(dir: URL(fileURLWithPath: dir)) else {
+        // #98 phase A1: Tell.loadDFlashConfigAndWeights (public-API-only re-derivation of what
+        // the frozen DFlashDrafter.load(dir:) does internally — needed here because both the
+        // MLX and raw drafters must share the identical weights dict).
+        guard let (cfg, weights) = Tell.loadDFlashConfigAndWeights(dir: URL(fileURLWithPath: dir)),
+              let drafter = DFlashDrafter(config: cfg, weights: weights)
+        else {
             FileHandle.standardError.write(Data(
                 "[qwisp] WARN: QWISP_DFLASH=1 but drafter load failed (\(dir)) — running without DFlash\n".utf8))
             return nil
         }
         let blockSize = Tell.envInt("QWISP_DFLASH_BLOCK", 8)
+        // Raw-first draft path (#98 phase A1): same weights, dispatch's own blockSize (may
+        // differ from the checkpoint's dflash_config.block_size). Load/attach failure → raw
+        // stays nil → DFlashDispatch.draft() runs MLX-only (warn once, not fatal).
+        var rawCfg = cfg
+        rawCfg.blockSize = blockSize
+        var raw = DFlashRawDrafter(config: rawCfg, weights: weights)
+        if let r = raw, !r.attachTargetHead(embedW: engine.embedW, embedS: engine.embedS, embedB: engine.embedB,
+                                            lmW: engine.lmW, lmS: engine.lmS, lmB: engine.lmB, vocab: engine.vocab) {
+            raw = nil
+        }
+        if raw == nil {
+            FileHandle.standardError.write(Data(
+                "[qwisp] WARN: DFlashRawDrafter init/attach failed — MLX-only drafter path\n".utf8))
+        }
         return DFlashDispatch(
-            drafter: drafter, blockSize: blockSize,
+            drafter: drafter, raw: raw, blockSize: blockSize,
             embedFn: { engine.embed(tokens: $0) },
             logitsArgmaxFn: { h in
                 // c_draft: ONE lazy-graph eval for embed+drafter+lm_head+argmax (see

--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -3684,8 +3684,18 @@ public enum SeedlessFusedVerify {
 
         /// 1-CB decode/verify step: token ids → 行毎 greedy argmax token ids。
         /// CB 1 本(resident/bolt)または multi-CB(strict)。readback は int32 [M] のみ(MLX op ゼロ)。
-        public func stepArgmax(_ tokens: [Int32]) -> [Int]? {
+        ///
+        /// #98 A1 fused draft+verify (additive seam, default nil = byte-identical): resident
+        /// のみ、drafter prologue を同一 CB の先頭に encode し、その argmax 出力
+        /// `draftTokensBuf` の rows 1..<M を blit で tokensIn rows 1..<M へ GPU-copy して
+        /// から通常の M 行 verify を走らせる(tokens の rows 1.. は placeholder)。draft と
+        /// verify の CPU 往復を 1 CB に畳む。prologue は CB を受ける(MPS が自前の encoder
+        /// を開くため encoder 単位では渡せない)。
+        public func stepArgmax(_ tokens: [Int32],
+                               draftPrologue: ((MTLCommandBuffer) -> Void)? = nil,
+                               draftTokensBuf: MTLBuffer? = nil) -> [Int]? {
             guard let hd = head, tokens.count <= maxM else { return nil }
+            if draftPrologue != nil, streamMode != .resident { return nil }   // fused seam: resident-only
             let M = tokens.count
             hd.tokensIn.contents().bindMemory(to: Int32.self, capacity: maxM).update(from: tokens, count: M)
 
@@ -3733,6 +3743,15 @@ public enum SeedlessFusedVerify {
             switch streamMode {
             case .resident:
                 let cb = queue.makeCommandBuffer()!
+                // #98 A1: drafter prologue + blit(draft argmax ids → tokensIn rows 1..<M)。
+                // encoder 境界の implicit barrier が embed の read を blit の後に順序付ける。
+                if let prologue = draftPrologue, let dt = draftTokensBuf, M > 1 {
+                    prologue(cb)
+                    let blit = cb.makeBlitCommandEncoder()!
+                    blit.copy(from: dt, sourceOffset: 4, to: hd.tokensIn, destinationOffset: 4,
+                              size: (M - 1) * 4)
+                    blit.endEncoding()
+                }
                 let enc = cb.makeComputeCommandEncoder()!
                 encodeEmbed(enc)
                 for (li, L) in layers.enumerated() { encodeLayer(enc, L, li: li, M: M) }

--- a/swift/Sources/QwispCore/SeedlessVerifyTests.swift
+++ b/swift/Sources/QwispCore/SeedlessVerifyTests.swift
@@ -90,7 +90,7 @@ public enum SeedlessVerifyTests {
         MLXRandom.seed(UInt64(42))
         var lines: [String] = []
         var passed = 0
-        let total = 97
+        let total = 98
 
         // Nested runner: records result and increments counter
         func run(_ name: String, body: () -> (Bool, String)) {
@@ -5953,6 +5953,129 @@ public enum SeedlessVerifyTests {
             guard hAfterCap.count == hTwoCall.count else { return (false, "post-cap count mismatch") }
             for i in 0..<hTwoCall.count where hAfterCap[i].bitPattern != hTwoCall[i].bitPattern {
                 return (false, "state poisoned after over-cap: mismatch @\(i)")
+            }
+            return (true, "ok")
+        }
+
+        // ── DFlash fused draft+verify (#98 A1 fused CB) locked test ───────
+        // WRITE-LOCKED (guarded by total = 98). Do not weaken/skip/delete.
+
+        // Test 98: dflash_fused_draft_verify
+        // The fused path (raw drafter encoded as a prologue of the verify CB + GPU blit of its
+        // argmax ids into tokensIn rows 1..<M) must be BIT-EQUAL to the split path
+        // (raw.forward → stepArgmax([u]+drafts)) in ALL of: draft ids, verify argmax rows,
+        // and post-step target cache state (KV lens/contents + GDN conv/rec state).
+        // Fixtures: test-47 2-layer mini verify engine (identical initial caches + shared
+        // head) × test-96 synthetic drafter (blockSize=4 → verify M=4=maxM).
+        run("dflash_fused_draft_verify") {
+            let V = 256
+            // ── verify mini-model (test-47 idiom: shared layer weights, per-engine cache copies)
+            let moe0 = stMkMoE(), moe1 = stMkMoE()
+            let gdnW = stMkGdnW(), attnW = stMkAttnW()
+            let iLN0 = MLXRandom.normal([stH]).asType(.float16)
+            let pLN0 = MLXRandom.normal([stH]).asType(.float16)
+            let iLN1 = MLXRandom.normal([stH]).asType(.float16)
+            let pLN1 = MLXRandom.normal([stH]).asType(.float16)
+            MLX.eval([iLN0, pLN0, iLN1, pLN1])
+            let specs = [
+                SeedlessVerifyForward.LayerSpec(isLinear: true,
+                    inputLN: iLN0, postLN: pLN0,
+                    gdn: gdnW, attn: nil, moe: moe0.w, moeE: stE, moeI: stI),
+                SeedlessVerifyForward.LayerSpec(isLinear: false,
+                    inputLN: iLN1, postLN: pLN1,
+                    gdn: nil, attn: attnW, moe: moe1.w, moeE: stE, moeI: stI),
+            ]
+            let cs = MLXRandom.normal([stCK - 1, stConvDim]).asType(.float16)
+            let rs = MLXRandom.normal([1, stHv, stDv, stDk]).asType(.float32)
+            let kc = MLXRandom.normal([stNkv, 8, stHd]).asType(.float16)
+            let vc = MLXRandom.normal([stNkv, 8, stHd]).asType(.float16)
+            MLX.eval([cs, rs, kc, vc])
+            func freshCaches() -> [SeedlessVerifyForward.LayerCaches] {
+                [SeedlessVerifyForward.LayerCaches(convState: cs, recState: rs),
+                 SeedlessVerifyForward.LayerCaches(kCache: kc, vCache: vc)]
+            }
+            let ewf = MLXRandom.normal([V, stH]).asType(.float16)
+            let (ewq, esc, ebiOpt) = MLX.quantized(ewf, groupSize: 64, bits: 4, mode: .affine)
+            let lwf = MLXRandom.normal([V, stH]).asType(.float16)
+            let (lwq, lsc, lbiOpt) = MLX.quantized(lwf, groupSize: 64, bits: 4, mode: .affine)
+            guard let ebi = ebiOpt, let lbi = lbiOpt else { return (false, "head biases nil") }
+            let fnW = MLXRandom.normal([stH]).asType(.float16)
+            MLX.eval([ewq, esc, ebi, lwq, lsc, lbi, fnW])
+            func mkEng() -> SeedlessFusedVerify.SeedlessFusedForward? {
+                guard let e = SeedlessFusedVerify.SeedlessFusedForward(
+                        layers: specs, caches: freshCaches(), maxM: 4, H: stH, maxSeqLen: 32),
+                      e.attachHead(embedW: ewq, embedS: esc, embedB: ebi,
+                                   lmW: lwq, lmS: lsc, lmB: lbi, fnW: fnW, vocab: V)
+                else { return nil }
+                return e
+            }
+
+            // ── drafter (test-96 idiom: blockSize=4 so verify M = 4 = maxM)
+            var cfg = dflashTestConfig()
+            cfg.blockSize = 4
+            let dW = dflashTestWeights(cfg)
+            let dH = cfg.hiddenSize, dV = cfg.vocabSize
+            let deF = MLXRandom.normal([dV, dH]).asType(.float16)
+            let (deq, des, debOpt) = MLX.quantized(deF, groupSize: 64, bits: 4, mode: .affine)
+            let dlF = MLXRandom.normal([dV, dH]).asType(.float16)
+            let (dlq, dls, dlbOpt) = MLX.quantized(dlF, groupSize: 64, bits: 4, mode: .affine)
+            guard let deb = debOpt, let dlb = dlbOpt else { return (false, "drafter head biases nil") }
+            MLX.eval([deq, des, deb, dlq, dls, dlb])
+            func mkRaw() -> DFlashRawDrafter? {
+                guard let d = DFlashRawDrafter(config: cfg, weights: dW),
+                      d.attachTargetHead(embedW: deq, embedS: des, embedB: deb,
+                                         lmW: dlq, lmS: dls, lmB: dlb, vocab: dV) else { return nil }
+                return d
+            }
+            let u: Int32 = 7
+            let ctx = MLXRandom.normal([3, cfg.ctxFeatureDim]).asType(.float16)
+            MLX.eval([ctx])
+            let ctxRows = ctx.reshaped([-1]).asArray(Float16.self)
+
+            // ── reference: split draft → verify
+            guard let engR = mkEng() else { return (false, "ref engine init/attach nil") }
+            guard let rawR = mkRaw() else { return (false, "ref drafter init/attach nil") }
+            guard let draftsR = rawR.forward(u: u, ctxRows: ctxRows, ctxCount: 3)
+            else { return (false, "ref raw forward nil") }
+            guard let evalsR = engR.stepArgmax([u] + draftsR.map { Int32($0) })
+            else { return (false, "ref stepArgmax nil") }
+
+            // ── fused: prologue + blit + verify in ONE CB
+            guard let engF = mkEng() else { return (false, "fused engine init/attach nil") }
+            guard let rawF = mkRaw() else { return (false, "fused drafter init/attach nil") }
+            guard rawF.prepare(u: u, ctxRows: ctxRows, ctxCount: 3)
+            else { return (false, "prepare failed (STUB)") }
+            var toks = [Int32](repeating: 0, count: cfg.blockSize)   // rows 1.. blit-overwritten
+            toks[0] = u
+            guard let evalsF = engF.stepArgmax(toks, draftPrologue: { rawF.encode(cb: $0) },
+                                               draftTokensBuf: rawF.tokenOutBuffer)
+            else { return (false, "fused stepArgmax nil (STUB)") }
+            let draftsF = rawF.finish()
+
+            // (a) draft ids bit-equal (deterministic kernels, identical weights/inputs).
+            if draftsF != draftsR { return (false, "drafts fused=\(draftsF) ref=\(draftsR)") }
+            // (b) verify argmax rows bit-equal — the blit really fed the draft ids.
+            if evalsF != evalsR { return (false, "evals fused=\(evalsF) ref=\(evalsR)") }
+            // (c) post-step target cache state bit-equal (test-47 idiom).
+            let snF = engF.snapshot(), snR = engR.snapshot()
+            for li in 0..<specs.count where snF.kvLens[li] != snR.kvLens[li] {
+                return (false, "kvLen layer=\(li) fused=\(snF.kvLens[li]) ref=\(snR.kvLens[li])")
+            }
+            let (kF, vF) = engF.readLayerCache(1)
+            let (kR, vR) = engR.readLayerCache(1)
+            for (nm, ca, cb) in [("kCache", kF, kR), ("vCache", vF, vR)] {
+                guard let aa = ca, let bb = cb else { return (false, "KV cache nil \(nm)") }
+                aa.eval(); bb.eval()
+                let (ok, d) = bitEqual(aa, bb)
+                if !ok { return (false, "\(nm): \(d)") }
+            }
+            let (cF, rF) = engF.readLayerCache(0)
+            let (cR, rR) = engR.readLayerCache(0)
+            for (nm, ca, cb) in [("convState", cF, cR), ("recState", rF, rR)] {
+                guard let aa = ca, let bb = cb else { return (false, "GDN state nil \(nm)") }
+                aa.eval(); bb.eval()
+                let (ok, d) = bitEqual(aa, bb)
+                if !ok { return (false, "\(nm): \(d)") }
             }
             return (true, "ok")
         }

--- a/swift/Sources/QwispCore/SeedlessVerifyTests.swift
+++ b/swift/Sources/QwispCore/SeedlessVerifyTests.swift
@@ -90,7 +90,7 @@ public enum SeedlessVerifyTests {
         MLXRandom.seed(UInt64(42))
         var lines: [String] = []
         var passed = 0
-        let total = 95
+        let total = 97
 
         // Nested runner: records result and increments counter
         func run(_ name: String, body: () -> (Bool, String)) {
@@ -5778,6 +5778,182 @@ public enum SeedlessVerifyTests {
             // (c) reset → fresh-instance state (draft → nil again).
             disp.reset()
             if disp.draft(u: 7) != nil { return (false, "post-reset draft should be nil") }
+            return (true, "ok")
+        }
+
+        // ── DFlash RAW drafter (#98 phase A1) locked tests ────────────────
+        // WRITE-LOCKED (guarded by total = 97). Do not weaken/skip/delete.
+
+        // Test 96: dflash_raw_vs_mlx
+        // The raw-Metal drafter forward must match the MLX drafter (DFlashDrafter) on the
+        // final-normed hidden. We compare HIDDEN, not token ids — argmax over near-tie f16
+        // logits can flip between kernel implementations. Both sides get byte-identical inputs:
+        //   • noise: tokens [u] ++ [maskId × (block-1)] embedded via the PRODUCTION embed_rows_q4
+        //     path (SeedlessFusedVerify.embedRowsRaw) over a synthetic 4-bit TARGET embed
+        //     fixture — the MLX side's noise IS that dequantised embed, so no input drift.
+        //   • ctx: the same synthetic [ctxCount, ctxFeatureDim] rows.
+        // block is reduced to 4 so that ctxCount(3)+block(4)=7 <= slidingWindow(8): the MLX
+        // drafter then takes the plain `.causal` branch (not the windowed-mask branch), which is
+        // exactly the raw path's causal-with-offset semantics — a like-for-like comparison.
+        // Asserts (a) Frobenius rel error < 2e-2 AND both hiddens non-zero; (b) reset + re-run →
+        // byte-identical hidden (raw bit-repro determinism).
+        run("dflash_raw_vs_mlx") {
+            var cfg = dflashTestConfig()
+            cfg.blockSize = 4
+            let weights = dflashTestWeights(cfg)
+            let H = cfg.hiddenSize, V = cfg.vocabSize, block = cfg.blockSize
+            let ctxCount = 3
+
+            // Synthetic 4-bit TARGET embed + lm_head fixtures (test-91 MLX.quantized idiom).
+            let embedF = MLXRandom.normal([V, H]).asType(.float16)
+            let (eq, es, ebOpt) = MLX.quantized(embedF, groupSize: 64, bits: 4, mode: .affine)
+            let lmF = MLXRandom.normal([V, H]).asType(.float16)
+            let (lq, ls, lbOpt) = MLX.quantized(lmF, groupSize: 64, bits: 4, mode: .affine)
+            guard let eb = ebOpt, let lb = lbOpt else { return (false, "quantize biases nil") }
+            MLX.eval([eq, es, eb, lq, ls, lb])
+
+            // Fixed inputs.
+            let u: Int32 = 7
+            let ctx2d = MLXRandom.normal([ctxCount, cfg.ctxFeatureDim]).asType(.float16)
+            MLX.eval([ctx2d])
+            let ctxRows = ctx2d.reshaped([-1]).asArray(Float16.self)
+            let ctxMLX  = ctx2d.reshaped([1, ctxCount, cfg.ctxFeatureDim])
+
+            // Build both drafters from IDENTICAL weights.
+            guard let raw = DFlashRawDrafter(config: cfg, weights: weights)
+            else { return (false, "DFlashRawDrafter init returned nil (STUB)") }
+            guard raw.attachTargetHead(embedW: eq, embedS: es, embedB: eb,
+                                       lmW: lq, lmS: ls, lmB: lb, vocab: V)
+            else { return (false, "attachTargetHead failed (STUB)") }
+            guard let mlx = DFlashDrafter(config: cfg, weights: weights)
+            else { return (false, "DFlashDrafter init returned nil") }
+
+            // Identical noise: production embed_rows_q4 over the synthetic target embed.
+            let tokens: [Int32] = [u] + Array(repeating: Int32(cfg.maskTokenId), count: block - 1)
+            guard let noiseRows = SeedlessFusedVerify.embedRowsRaw(tokens, w: eq, scales: es, biases: eb, H: H)
+            else { return (false, "embedRowsRaw nil") }
+            let noise = noiseRows.reshaped([1, block, H])
+            MLX.eval([noise])
+
+            // Raw forward (fresh state) → final-normed hidden [block, H].
+            _ = raw.forward(u: u, ctxRows: ctxRows, ctxCount: ctxCount)
+            guard let hRawFlat = raw.lastFinalHidden()
+            else { return (false, "lastFinalHidden nil (STUB)") }
+            guard hRawFlat.count == block * H
+            else { return (false, "raw hidden count \(hRawFlat.count) != \(block * H)") }
+
+            // MLX reference hidden [1, block, H] → [block, H].
+            let hMLX = mlx.forward(noise: noise, ctx: ctxMLX, caches: mlx.makeCaches())
+                .reshaped([block, H]).asType(.float32)
+            MLX.eval([hMLX])
+            let rawArr = MLXArray(hRawFlat, [block, H]).asType(.float32).asArray(Float.self)
+            let mlxArr = hMLX.asArray(Float.self)
+
+            // (a) both non-zero + Frobenius rel error < 2e-2.
+            var num: Float = 0, den: Float = 0
+            for i in 0..<mlxArr.count {
+                let d = rawArr[i] - mlxArr[i]
+                num += d * d
+                den += mlxArr[i] * mlxArr[i]
+            }
+            if den == 0 { return (false, "MLX hidden all-zero") }
+            if !rawArr.contains(where: { $0 != 0 }) { return (false, "raw hidden all-zero") }
+            let rel = (num / den).squareRoot()
+            if !(rel < 2e-2) { return (false, "rel error \(rel) >= 2e-2") }
+
+            // (b) reset + re-run same inputs → byte-identical hidden (bit-repro determinism).
+            raw.reset()
+            _ = raw.forward(u: u, ctxRows: ctxRows, ctxCount: ctxCount)
+            guard let hRaw2 = raw.lastFinalHidden() else { return (false, "second lastFinalHidden nil") }
+            guard hRaw2.count == hRawFlat.count else { return (false, "hidden count changed \(hRaw2.count)") }
+            for i in 0..<hRawFlat.count where hRaw2[i].bitPattern != hRawFlat[i].bitPattern {
+                return (false, "bit-repro mismatch @\(i) \(hRaw2[i]) vs \(hRawFlat[i])")
+            }
+            return (true, "ok")
+        }
+
+        // Test 97: dflash_raw_cache_consistency
+        // Raw-internal cache invariants (no MLX comparison — the raw path is self-referential):
+        // (a) two-call accumulation (ctx 3 rows then 2 rows) → final-normed hidden byte-equals a
+        //     fresh instance's single call over the 5 concatenated ctx rows (same invariant as
+        //     locked test 93, but byte-exact within the raw engine);
+        // (b) trimTo(3) rollback + replay the 2-row call → byte-identical to the pre-trim hidden;
+        // (c) ctxCap contract: with ctxLen at 5, a call whose ctxCount would push past
+        //     ctxCap = slidingWindow-1 = 7 returns nil, and the instance is unpoisoned (trim + a
+        //     legal replay still reproduces the pre-cap hidden byte-for-byte).
+        // block = 4 (raw path is causal-with-offset regardless of the MLX mask branch; total ctx
+        // stays <= ctxCap 7 in every legal call).
+        run("dflash_raw_cache_consistency") {
+            var cfg = dflashTestConfig()
+            cfg.blockSize = 4
+            let weights = dflashTestWeights(cfg)
+            let H = cfg.hiddenSize, V = cfg.vocabSize
+
+            // Target head fixture (needed for the noise embed inside forward).
+            let embedF = MLXRandom.normal([V, H]).asType(.float16)
+            let (eq, es, ebOpt) = MLX.quantized(embedF, groupSize: 64, bits: 4, mode: .affine)
+            let lmF = MLXRandom.normal([V, H]).asType(.float16)
+            let (lq, ls, lbOpt) = MLX.quantized(lmF, groupSize: 64, bits: 4, mode: .affine)
+            guard let eb = ebOpt, let lb = lbOpt else { return (false, "quantize biases nil") }
+            MLX.eval([eq, es, eb, lq, ls, lb])
+
+            let u: Int32 = 5
+            let ctx1 = MLXRandom.normal([3, cfg.ctxFeatureDim]).asType(.float16)
+            let ctx2 = MLXRandom.normal([2, cfg.ctxFeatureDim]).asType(.float16)
+            MLX.eval([ctx1, ctx2])
+            let r1 = ctx1.reshaped([-1]).asArray(Float16.self)
+            let r2 = ctx2.reshaped([-1]).asArray(Float16.self)
+            let rFull = MLX.concatenated([ctx1, ctx2], axis: 0).reshaped([-1]).asArray(Float16.self)
+
+            func mkRaw() -> DFlashRawDrafter? {
+                guard let d = DFlashRawDrafter(config: cfg, weights: weights) else { return nil }
+                guard d.attachTargetHead(embedW: eq, embedS: es, embedB: eb,
+                                         lmW: lq, lmS: ls, lmB: lb, vocab: V) else { return nil }
+                return d
+            }
+
+            // (a) two-call accumulation vs one-shot concatenated ctx → byte-exact hidden.
+            guard let dA = mkRaw() else { return (false, "DFlashRawDrafter init/attach nil (STUB)") }
+            _ = dA.forward(u: u, ctxRows: r1, ctxCount: 3)                 // primes ctxLen 0→3
+            guard dA.forward(u: u, ctxRows: r2, ctxCount: 2) != nil        // ctxLen 3→5
+            else { return (false, "second forward nil (STUB)") }
+            guard let hTwoCall = dA.lastFinalHidden() else { return (false, "lastFinalHidden nil (STUB)") }
+
+            guard let dB = mkRaw() else { return (false, "init/attach nil") }
+            guard dB.forward(u: u, ctxRows: rFull, ctxCount: 5) != nil
+            else { return (false, "one-shot forward nil") }
+            guard let hOneShot = dB.lastFinalHidden() else { return (false, "one-shot hidden nil") }
+            guard hTwoCall.count == hOneShot.count else { return (false, "hidden count mismatch") }
+            for i in 0..<hTwoCall.count where hTwoCall[i].bitPattern != hOneShot[i].bitPattern {
+                return (false, "two-call vs one-shot mismatch @\(i)")
+            }
+
+            // (b) trimTo rollback replay: from ctxLen 5 trim back to 3, re-run the 2-row call.
+            dA.trimTo(committed: 3)
+            guard dA.forward(u: u, ctxRows: r2, ctxCount: 2) != nil
+            else { return (false, "post-trim forward nil") }
+            guard let hReplay = dA.lastFinalHidden() else { return (false, "replay hidden nil") }
+            guard hReplay.count == hTwoCall.count else { return (false, "replay count mismatch") }
+            for i in 0..<hTwoCall.count where hReplay[i].bitPattern != hTwoCall[i].bitPattern {
+                return (false, "trim rollback replay mismatch @\(i)")
+            }
+
+            // (c) ctxCap contract: dA is at ctxLen 5; a 3-row call would reach 8 > ctxCap 7 → nil.
+            let cap3 = MLXRandom.normal([3, cfg.ctxFeatureDim]).asType(.float16)
+            MLX.eval([cap3])
+            let capRows = cap3.reshaped([-1]).asArray(Float16.self)
+            if dA.forward(u: u, ctxRows: capRows, ctxCount: 3) != nil {
+                return (false, "over-cap forward should return nil")
+            }
+            // state unpoisoned: trim to 3 and replay the legal 2-row call → still byte-equal.
+            dA.trimTo(committed: 3)
+            guard dA.forward(u: u, ctxRows: r2, ctxCount: 2) != nil
+            else { return (false, "post-cap forward nil") }
+            guard let hAfterCap = dA.lastFinalHidden() else { return (false, "post-cap hidden nil") }
+            guard hAfterCap.count == hTwoCall.count else { return (false, "post-cap count mismatch") }
+            for i in 0..<hTwoCall.count where hAfterCap[i].bitPattern != hTwoCall[i].bitPattern {
+                return (false, "state poisoned after over-cap: mismatch @\(i)")
+            }
             return (true, "ok")
         }
 

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -662,13 +662,24 @@ extension Tell {
             // #98 DFlash: only when SuffixSpec found nothing (draftless span) and not under A3
             // (dflash is inactive there — see dflashHarvest). Falls back to the old per-step
             // path on nil (cold start / any failure), unchanged behavior.
-            if drafts.isEmpty, !useA3, let dd = dflash, let ds = dd.draft(u: u), !ds.isEmpty {
-                drafts = ds
+            // #98 A1 fused-first: draft+verify in ONE CB on dflashFwd. Snapshot is taken
+            // BEFORE the fused step (the verify inside it advances the cache; the drafter
+            // itself never touches the target cache, so pre-draft == pre-verify state).
+            var fusedEvals: [Int]? = nil
+            var fusedSnap: Any? = nil
+            if drafts.isEmpty, !useA3, let dd = dflash {
+                if let fwd = dflashFwd {
+                    let s = backend.snapshot()
+                    if let r = dd.draftFused(u: u, fwd: fwd), !r.drafts.isEmpty {
+                        drafts = r.drafts; fusedEvals = r.evals; fusedSnap = s
+                    }
+                }
+                if fusedEvals == nil, let ds = dd.draft(u: u), !ds.isEmpty { drafts = ds }
             }
             let D      = drafts.count
             stSteps += 1; stDrafted += D; if D == 0 { stD0 += 1 }
 
-            var snap = backend.snapshot()
+            let snap = fusedSnap ?? backend.snapshot()
 
             if D == 0 {
                 // Chain path (mirrors the bench-engine block in `run`): only the non-A3 /
@@ -739,9 +750,15 @@ extension Tell {
                     }
                 }
             } else {
-                // Non-A3 path (unchanged)
-                let verifyTokens: [Int32] = [Int32(u)] + drafts.map { Int32($0) }
-                guard let evals = backend.stepArgmax(verifyTokens) else { return nil }
+                // Non-A3 path (unchanged; fused path already ran the verify in the draft CB)
+                let evals: [Int]
+                if let fe = fusedEvals {
+                    evals = fe
+                } else {
+                    let verifyTokens: [Int32] = [Int32(u)] + drafts.map { Int32($0) }
+                    guard let e = backend.stepArgmax(verifyTokens) else { return nil }
+                    evals = e
+                }
 
                 var p = 0
                 while p < D && drafts[p] == evals[p] { p += 1 }
@@ -1212,10 +1229,24 @@ extension Tell {
 
             // #98 DFlash: same slot as mtpDraftSpan above (dflash replaces it when active —
             // the two flags are mutually exclusive by construction, dflash takes priority).
+            // A1 fused-first: draft+verify in ONE CB (snapshot BEFORE — the fused verify
+            // advances the cache). Guards: mtpHead feeds pre-verify normed rows and rerank
+            // needs the verify tokens up-front — both fall back to the split path.
             var dflashDrafted = false
-            if D == 0, let dd = dflash, !useA3, let ds = dd.draft(u: u), !ds.isEmpty {
-                drafts = ds; D = drafts.count
-                dflashDrafted = true
+            var fusedEvals: [Int]? = nil
+            var fusedSnap: Any? = nil
+            if D == 0, let dd = dflash, !useA3 {
+                if mtpHead == nil, !_useRerank, let fwd = _residentFwd {
+                    let s = backend.snapshot()
+                    if let r = dd.draftFused(u: u, fwd: fwd), !r.drafts.isEmpty {
+                        drafts = r.drafts; D = drafts.count; dflashDrafted = true
+                        fusedEvals = r.evals; fusedSnap = s
+                    }
+                }
+                if !dflashDrafted, let ds = dd.draft(u: u), !ds.isEmpty {
+                    drafts = ds; D = drafts.count
+                    dflashDrafted = true
+                }
             }
 
             // ★ MTP-D1 (Step 5): u はこの step で必ず commit される → pair (h_prev, u) を
@@ -1234,7 +1265,8 @@ extension Tell {
             }
 
             // Snapshot before the batched verify (backend-specific representation).
-            var snap = backend.snapshot()
+            // Fused dflash step: the verify already ran → use the pre-fused snapshot.
+            let snap = fusedSnap ?? backend.snapshot()
 
             if D == 0 {
                 // No draft available
@@ -1333,11 +1365,17 @@ extension Tell {
                     }
                 }
             } else {
-                // ── Non-A3 path (unchanged) ──────────────────────────────
-                let verifyTokens: [Int32] = [Int32(u)] + drafts.map { Int32($0) }
-                if _useRerank { _reuseVerifyToks = verifyTokens.map { Int($0) } }
-                guard let evals = backend.stepArgmax(verifyTokens)
-                else { return "[raw-spec] ERROR: verify step nil" }
+                // ── Non-A3 path (unchanged; fused path already ran the verify) ──
+                let evals: [Int]
+                if let fe = fusedEvals {
+                    evals = fe
+                } else {
+                    let verifyTokens: [Int32] = [Int32(u)] + drafts.map { Int32($0) }
+                    if _useRerank { _reuseVerifyToks = verifyTokens.map { Int($0) } }
+                    guard let e = backend.stepArgmax(verifyTokens)
+                    else { return "[raw-spec] ERROR: verify step nil" }
+                    evals = e
+                }
 
                 var p = 0
                 while p < D && drafts[p] == evals[p] { p += 1 }

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -16,6 +16,25 @@ import MLXFast
 /// QWISP_DUMP_TOKENS=1     — print PROMPT_TOKENS / OUT_TOKENS lines (bench correctness axis)
 extension Tell {
 
+    /// #98 phase A1: config.json + safetensors load, mirroring DFlashDrafter.load(dir:)'s
+    /// internals (that frozen helper doesn't expose the parsed config/weights, and both the
+    /// MLX and raw drafters need to share the identical weights dict). Public-API-only —
+    /// does not touch DFlashDrafter.swift.
+    static func loadDFlashConfigAndWeights(dir: URL) -> (DFlashDrafterConfig, [String: MLXArray])? {
+        guard let cfg = try? DFlashDrafterConfig.load(configJSON: dir.appendingPathComponent("config.json")),
+              let entries = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
+        else { return nil }
+        var weights: [String: MLXArray] = [:]
+        for url in entries where url.pathExtension == "safetensors" {
+            guard let m = try? loadArrays(url: url) else { return nil }
+            for (k, v) in m {
+                let stripped = k.hasPrefix("model.") ? String(k.dropFirst("model.".count)) : k
+                weights[stripped] = v
+            }
+        }
+        return (cfg, weights)
+    }
+
     /// notes/14 TODO-2: bolt の rolling re-calib R と async refresh chunk B を workload 名で
     /// 実証済み最適値へ切り替える opt-in preset(QWISP_BOLT_WORKLOAD)。純関数。
     /// 明示 env(QWISP_BOLT_RECALIB_R/QWISP_BOLT_REFRESH_B)が常にこの preset を上書きする。
@@ -1077,10 +1096,21 @@ extension Tell {
         if Tell.envFlag("QWISP_DFLASH"), let fwd = _residentFwd, fwd.streamMode == .resident, !useA3 {
             let dir = ProcessInfo.processInfo.environment["QWISP_DFLASH_DIR"]
                 ?? "\(FileManager.default.homeDirectoryForCurrentUser.path)/.mtplx/models/z-lab--Qwen3.6-35B-A3B-DFlash"
-            if let drafter = DFlashDrafter.load(dir: URL(fileURLWithPath: dir)) {
+            // #98 phase A1: load config+weights once (public-API-only re-derivation of what
+            // DFlashDrafter.load(dir:) does internally — that frozen helper doesn't expose
+            // them, and both the MLX and raw drafters need to share the same weights dict).
+            if let (cfg, weights) = Tell.loadDFlashConfigAndWeights(dir: URL(fileURLWithPath: dir)),
+               let drafter = DFlashDrafter(config: cfg, weights: weights) {
                 let blockSize = Tell.envInt("QWISP_DFLASH_BLOCK", 8)
+                var rawCfg = cfg
+                rawCfg.blockSize = blockSize
+                var raw = DFlashRawDrafter(config: rawCfg, weights: weights)
+                if let r = raw, !r.attachTargetHead(embedW: engine.embedW, embedS: engine.embedS, embedB: engine.embedB,
+                                                    lmW: engine.lmW, lmS: engine.lmS, lmB: engine.lmB, vocab: engine.vocab) {
+                    raw = nil
+                }
                 let dd = DFlashDispatch(
-                    drafter: drafter, blockSize: blockSize,
+                    drafter: drafter, raw: raw, blockSize: blockSize,
                     embedFn: { engine.embed(tokens: $0) },
                     logitsArgmaxFn: { h in
                         // c_draft: ONE lazy-graph eval for embed+drafter+lm_head+argmax —
@@ -1093,7 +1123,7 @@ extension Tell {
                     })
                 _ = fwd.attachTap(layerIds: drafter.config.targetLayerIds)
                 dflash = dd
-                print("[raw-spec] DFlash dispatch active (block=\(blockSize))")
+                print("[raw-spec] DFlash dispatch active (block=\(blockSize), raw=\(raw != nil))")
             } else {
                 print("[raw-spec] WARN: QWISP_DFLASH=1 but drafter load failed (\(dir)) — running without DFlash")
             }

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -40,6 +40,7 @@ if CommandLine.arguments.contains("stream") {
         ("gqmm2-bench", { _, _ in SeedlessMetalForward.gqmm2Bench() }),   // notes/18 W1 speed sim
         ("dflash-parity", { _, _ in DFlashParityProbe.run() }),           // #98 phase 2b oracle parity
         ("dflash-raw-bench", { _, _ in DFlashRawDrafter.bench() }),       // #98 A1 c_draft micro-bench
+        ("dflash-gemm-bench", { _, _ in DFlashRawDrafter.gemmBench() }),  // #98 A1 f16 GEMM kernel probe
     ]
     if let name = env["QWISP_RUN"] {
         if let r = runners.first(where: { $0.0 == name }) {

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -39,6 +39,7 @@ if CommandLine.arguments.contains("stream") {
         ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),
         ("gqmm2-bench", { _, _ in SeedlessMetalForward.gqmm2Bench() }),   // notes/18 W1 speed sim
         ("dflash-parity", { _, _ in DFlashParityProbe.run() }),           // #98 phase 2b oracle parity
+        ("dflash-raw-bench", { _, _ in DFlashRawDrafter.bench() }),       // #98 A1 c_draft micro-bench
     ]
     if let name = env["QWISP_RUN"] {
         if let r = runners.first(where: { $0.0 == name }) {


### PR DESCRIPTION
## Summary
#98 A1 raw-drafter workstream: the fused draft+verify CB seam, the `dflash_fmm16` drafter GEMM kernel, locked test 98, and the full falsification/attribution record. Refs #98 (verdict comments: [round 3](https://github.com/penta2himajin/qwisp/issues/98#issuecomment-5015893936), [round 4](https://github.com/penta2himajin/qwisp/issues/98#issuecomment-5016033277)). Default OFF unchanged — correctness-neutral.

- **Fused seam**: `stepArgmax` gains additive `draftPrologue`/`draftTokensBuf` (default nil = byte-identical); drafter encoded at the head of the resident verify CB, draft ids blit-copied into `tokensIn` rows 1..<M, ONE readback. `DFlashDispatch.draftFused` + fused-first wiring in both spec loops; `QWISP_DFLASH_NOFUSE=1` A/B seam.
- **`dflash_fmm16`**: qmv_fast-derived f16 M-row GEMM (simd_sum, no barriers, W read once; per-element accumulation independent of M ⇒ locked-97 byte contract holds for any ctx batching). Drafter CB: 110-190ms (MPS) → **13.4ms** in-loop. lm_head = dequantized f16 (+0.6GB, resident-tier-only) at 191GB/s.
- **Probes**: `QWISP_RUN=dflash-gemm-bench` (kernel correctness + bandwidth incl. dependent-chain and cold-set rows).
- Locked test 98: fused ≡ split bit-equal (draft ids, verify rows, KV/GDN state).

## Verdict (measured, N=128 resident)
code 52.9 / agentic 50.8 / longctx 58.9 / shortnl 27.9 vs flag-off 82.7 / 76.0 / 90.5 / 81.9 — **DFlash stays opt-in**. Attribution closed: no mystery tax; remaining cost = verify r_8≈3.2 + partial-reject rebuild (term omitted from the original projection). The binding constraint moved from the drafter to ACCEPT (cold-start ctx) — prefill-ctx bootstrap is the next go/no-go gate (issue comment has the corrected cost model).

## Gates
- RAWTESTS **98/98**, BENCHBATCHTEST PASS, COMPTEST 33/33, TOKTEST 5/5
- Lossless with fusion ON: OUT_TOKENS 128/128 byte-identical × 4 regimes (both rounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)