### PR TITLE
feat(dflash): prefill-ctx bootstrap — accept lever for #98 A1

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,58 +1,57 @@
-# HANDOFF: #98 A1 drafter SOLVED (fmm16, 13.4ms) but aggregate still loses — corrected economics: next go/no-go = prefill-ctx bootstrap (accept lever). PR #115 open
-Date: 2026-07-19 | Status: DECISION-PENDING | Branch: claude/issue98-dflash-rawdrafter | Root: /Users/penta2himajin/repos/qwisp
+# HANDOFF: #98 A1 = NO-GO vs flag-off chain (bootstrap gate resolved). PR #115 MERGED, PR #116 (bootstrap) OPEN. Decision: merge #116 + park A1 + move to batching #6
+Date: 2026-07-19 | Status: DECISION-PENDING (recommend park) | Branch: claude/issue98-dflash-bootstrap | Root: /Users/penta2himajin/repos/qwisp
 
 > STOP: Before trusting anything below, run the checks in "Verify First".
 > If any observation differs from the expected value, this handoff is stale —
 > the code is the truth, not this document. Report the mismatch before proceeding.
 
 ## Verify First
-- `git branch --show-current` → `claude/issue98-dflash-rawdrafter`; `git status` → clean.
-- `git log --oneline -1` → `2d120fe` feat(dflash) dflash_fmm16. main == `fadae32`.
-- PR #115 OPEN (ready, title mentions fmm16); gates verified this session: RAWTESTS **98/98**, BENCHBATCH PASS, COMPTEST 33/33, TOKTEST 5/5.
-- `brew services info qwisp | head -2` → Running: true (STOP before ANY GPU run; check `ps aux | grep -E "qwisp serve|qwisp-poc"` first — user asked for a GPU-process check before every GPU run).
+- `git branch --show-current` → `claude/issue98-dflash-bootstrap`; `git status` → clean.
+- `git log --oneline -1` → `bc37cef` feat(dflash) prefill-ctx bootstrap. main == `1ca80a1` (PR #115 merged).
+- PR #115 (fmm16 + fused CB) MERGED. PR #116 (bootstrap) OPEN — recommend merge (correctness-neutral accept lever).
+- Gates verified this session: RAWTESTS **98/98**, BENCHBATCH PASS, COMPTEST 33/33, TOKTEST 5/5.
+- **GPU rule (user instruction): `ps aux | grep -E "qwisp serve|qwisp-poc|mlx"` before EVERY GPU run; stop brew service first; if a proc is running, monitor don't collide.** `brew services info qwisp` → Running true at handoff.
 
-## Current Numbers (N=128 resident, M1 Max 64GB)
-- fused DFlash: code **52.9** / agentic 50.8 / longctx 58.9 / shortnl 27.9 — all 128/128 lossless.
-- flag-off: 82.7 / 76.0 / 90.5 / 81.9. DFlash loses on aggregate in every regime.
-- drafter CB in-loop 13.4ms (c_draft ≈ 1.1×F, F=12.1ms); standalone 7ms; kernel probe: lm_head 622MB f16 3.25ms/191GB/s, dependent chain 0.055ms/GEMM.
+## THE VERDICT: A1 is structurally NO-GO vs flag-off chain (M=1 greedy)
+Drafter is fully solved (fmm16, 13.4ms/block) AND bootstrap landed (accept lever works), yet DFlash loses to flag-off in EVERY regime. This is NOT a tuning gap — it's the batch-1 latency physics:
+- flag-off `chainedStepArgmax` ≈ 12.1ms/tok (M=1 forwards already near the batch-1 floor; chain amortizes dispatch over K greedy tokens). Very strong baseline on the d0≈90% draftless span.
+- DFlash block=8: verify M=8 = r_8·F ≈ 3.2·12.1 = 39ms → 9.75ms/tok at accept=4, + drafter 13.4/T + reject-rebuild ⇒ ~16ms/tok.
+- Break-even needs T>~5 AND drafter≤7ms AND no rebuild — a stack only longctx's tail approaches. block=4 doesn't rescue (r_4=2.0, fewer tok/block, same class).
+- Same physics as [[seedless-vs-suffixspec-nogo]] / batch-1 wall: **speculation wins at compute-bound M>1, NOT M=1 greedy where chain is cheap.**
 
-## THE CORRECTED COST MODEL (memorize this; the old projection was wrong)
-cost/tok = (c_draft + r_8 + P_rej·r_(p̄+1) + cpu) / T, in units of F=12.1ms.
-- r_8 ≈ 3.2 (verify M=8 = 38.7ms — round-3 economics misread this as ~12ms).
-- P_rej·r_(p̄+1) ≈ 19.4ms/block at code (partial-reject rebuild; OMITTED from the
-  original #98 projection "95-105 tok/s" — that number was wrong).
-- Aggregate code T=4.19 ⇒ even c_draft=0 loses (62ms > 50.7 parity). Measured 52.9 fits the model.
-- Steady tail (ctx>60) T≈6 ⇒ parity..+8% now; ~+15% at c_draft 0.5.
-⇒ THE DRAFTER IS NO LONGER THE BOTTLENECK. Binding constraints: cold-start ctx (aggregate T) and the structural r_8+rebuild cost.
+## Measured (paired A/B, N=128 resident, service stopped)
+| regime | boot=0 | boot=1 | accept/step | flag-off |
+|---|---|---|---|---|
+| code | 56.8 | 62.5 | 3.19→4.00 | 82.7 |
+| agentic | 54.5 | 62.7 | 3.59→4.54 | 76.0 |
+| longctx | 65.5 | 62.6 | 4.78→5.33 | 90.5 |
+| shortnl | 28.6 | 26.7 | 1.02→0.95 | 81.9 |
+(longctx regresses under bootstrap: one-time full-prompt ctx feed > accept gain at long prompt. shortnl non-transfer.)
+Finding: accept ramp is POSITION/content-dependent, not ctx-size alone (ctx=95 block 1 still gives p=2,1,0,0 then climbs).
 
-## Next Action (owner picked "kernel" branch this session; now a new fork)
-1. Merge PR #115 on green (still valid: default-OFF, all gates green, big kernel + record).
-2. NEXT GO/NO-GO: **prefill-ctx bootstrap prototype** — feed prompt-derived ctx rows to the drafter at block 1 so aggregate T reaches the steady 5.6-6. Ceiling if it works: code ~75-90 / longctx ~85-100 vs 82.7/90.5 ⇒ win only if aggregate T ≥ ~5.5. If bootstrap fails → #98 parks as "shipped opt-in, default OFF, loses on aggregate".
-3. Secondary (only if bootstrap greens): drafter polish 13.4→~7ms (fuse small ops, argmax tune) = +3-4 tok/s class; hysteresis dispatch (shortnl auto-off) before any default-ON talk.
-4. Probably NO-GO (check before attempting): rebuild-avoidance via partial GDN rewind — needs per-row GDN state snapshots (same physics as spec-gdn-incompat).
+## Recommended Next Action (owner call — this is a workstream-park decision)
+1. **Merge PR #116** — bootstrap is a genuine correctness-neutral accept improvement; bank it for any future DFlash-favorable regime.
+2. **Park #98 A1**: shipped opt-in (`QWISP_DFLASH=1` + `QWISP_DFLASH_BOOTSTRAP=1`), default OFF. Infrastructure (fmm16 kernel, fused draft+verify CB, tap, bootstrap) is solid and reusable; the limiter is the M=1 chain baseline being too strong.
+3. **Move to batching #6** — the M>1 continuous-batching regime is where block-drafting economics actually favor speculation (verify M amortized across requests), and where this machinery pays off. See memory [[issue6-batching-validated]].
+4. Unexplored DFlash-favorable angle if #98 is ever revived: slower device tier (8GB streaming, single forwards IO-bound → flips the economics). v1 is resident-scoped; would be a separate measurement.
 
-## What Shipped This Session (branch, PR #115; commits a99afe3 + 2d120fe)
-- Fused draft+verify seam (stepArgmax additive draftPrologue/draftTokensBuf; DFlashDispatch.draftFused; QWISP_DFLASH_NOFUSE A/B; locked test 98; total=98).
-- dflash_fmm16 kernel (qmv-class f16 M-row GEMM, M-invariant by construction ⇒ ctx batching legal under locked-97; MPS deleted; ONE encoder).
-- lm_head dequant f16 (+0.6GB resident-only); drafter weights copied to Metal-owned buffers.
-- Probes: QWISP_RUN=dflash-gemm-bench (kernel bw), dflash-raw-bench (forward), QWISP_DFLASH_TRACE ([dflash-fused-time]/[dflash-raw-time]/[dflash-trace]).
+## What Shipped (all on branch history; PRs #109-#116)
+- #109-#114: tap, MLX drafter, parity, dispatch, c_draft probe (merged).
+- #115 (merged): fused draft+verify CB seam (stepArgmax additive draftPrologue/draftTokensBuf), dflash_fmm16 kernel (qmv-class f16 M-row GEMM, M-invariant by construction), lm_head dequant f16, locked test 98 (total=98).
+- #116 (open): prefill-ctx bootstrap (forwardRowsHybrid encodeTap seam + Tell.prefill onChunk + QWISP_DFLASH_BOOTSTRAP wiring).
 
-## Falsified / Closed (do not re-propose — full trail in #98 comments 2026-07-19 ×3)
-- CPU-round-trip/CB-context as drafter cost; GPU clock ramp (2nd kill); buffer provenance (noCopy vs copied); allocation granularity (slab vs separate); memory pressure (91% free); MPS granularity (~0.5-1ms/encode); fmm_rows/fmm_tiled kernel shapes (35GB/s class); qmm4_tiled barrier-tree at drafter shapes (33ms); per-row `.item()`; MLX drafter as shipping path; block=16; sliding ring-buffer v1.
-- "Mystery in-loop tax": NEVER EXISTED — it was kernel bandwidth + MPS overhead + misreading r_8 as 12ms.
+## Falsified / Closed (do not re-propose — full trail: #98 comments 2026-07-19 ×4)
+CPU-round-trip/CB-context; GPU clock ramp (×2); buffer provenance; allocation granularity; memory pressure; MPS granularity; fmm_rows/fmm_tiled (35GB/s); qmm4_tiled barrier-tree (33ms); per-row .item(); MLX drafter as ship path; block=16; sliding ring v1. "Mystery in-loop tax" NEVER existed (= kernel bw + MPS + misreading r_8 as 12ms). NEW: bootstrap accept lever REAL but insufficient; A1 vs flag-off = structural NO-GO (batch-1 physics).
 
 ## Commands
 - build: `cd swift && xcodebuild build -scheme qwisp-poc -configuration Release -destination 'platform=macOS' -derivedDataPath ./.xcode-build-rel -skipPackagePluginValidation`
 - gates: scripts/test_raw.sh (98/98) / test_completion.sh 33/33 / test_tokenizer.sh 5/5 / test_bench_batch.sh PASS
-- bench: `QWISP_DFLASH=1 QWISP_GEN=128 QWISP_RUN=raw-spec QWISP_MTP_REF=refs/resident/{code,agentic,longctx,shortnl}.safetensors .../qwisp-poc stream`
+- A/B bench: `env QWISP_DFLASH=1 [QWISP_DFLASH_BOOTSTRAP=1] QWISP_GEN=128 QWISP_RUN=raw-spec QWISP_MTP_REF=refs/resident/{code,agentic,longctx,shortnl}.safetensors .../qwisp-poc stream` (flag-off = drop QWISP_DFLASH). Probes: dflash-gemm-bench, dflash-raw-bench, QWISP_DFLASH_TRACE.
 
 ## Do Not Touch
-- SeedlessVerifyTests.swift WRITE-LOCKED (total=98). Frozen forward path: additive nil-guarded seams only. refs/* raw-greedy only. Never two GPU processes; ps-check before every GPU run (user instruction this session).
-
-## Gotchas
-- Workflow args flake → hardcode in script file + {scriptPath}. Bench N caps at ref length (resident=128). SourceKit MLX noise. zsh `===` errors. Rate limits: check /status before devloops (this session ran driver-only).
+- SeedlessVerifyTests.swift WRITE-LOCKED (total=98). Frozen forward path: additive nil-guarded seams only. refs/* raw-greedy only. Never two GPU processes; ps-check before every GPU run.
 
 ## Pointers
-- DFlashRawDrafter.swift (fmm16 kernel + prepare/encode/finish + gemmBench), DFlashDispatch.swift#draftFused, SeedlessFusedVerify.swift#stepArgmax seam, TellRuntime.swift fused-first wiring.
-- Cost-model discussion + ceiling table: issue #98 comment (round 4). PRs #109-#115.
-- Parked: #112 stable-prefix persist; QAD finetune recon (z-lab training code check, ~5min); batching #6.
+- DFlashRawDrafter.swift (fmm16 + prepare/encode/finish), DFlashDispatch.swift#draftFused, SeedlessFusedVerify.swift#stepArgmax seam + forwardRowsHybrid tap, TellRuntime.swift prefill onChunk + both loop wirings.
+- Verdict + cost model: issue #98 comments (rounds 3-4 + bootstrap gate). PRs #109-#116.
+- Parked also: #112 stable-prefix persist (user-approved design); QAD finetune recon (z-lab training-code check ~5min).

--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -4161,6 +4161,10 @@ public enum SeedlessFusedVerify {
                                                       M: M, E: L.E, I: L.I, Ktop: L.Ktop, H: H)
                     SeedlessFusedVerify.encodeResidAdd(enc(), h: hBuf, r: moeOut, total: M * H)
                 }
+                // #98 DFlash bootstrap: same nil-guarded tap seam as encodeLayer/runStrictLayers
+                // (copy-out only — the hybrid token stream is untouched). tapBuf nil => no-op,
+                // so the canonical hybrid prefill stays byte-identical when DFlash is off.
+                encodeTap(enc(), li: li, M: M)
             }
             if let fw = finalNormW {
                 SeedlessFusedVerify.encodeRmsNormRows(enc(), x: hBuf, w: fw, out: normed, rows: M, D: H, eps: eps)

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -527,7 +527,11 @@ extension Tell {
     /// loop's pre-verify feed once u is known (KV-read draft discipline, notes/17).
     static func prefill(promptIds: [Int32], backend: SpecBackend,
                         mtpHead: SeedlessFusedVerify.SeedlessMTPHead? = nil,
-                        mtpFwd: SeedlessFusedVerify.SeedlessFusedForward? = nil) -> MLXArray? {
+                        mtpFwd: SeedlessFusedVerify.SeedlessFusedForward? = nil,
+                        // #98 DFlash prefill-ctx bootstrap: called after each chunk forward
+                        // with that chunk's row count (the per-forward tapBuf holds exactly
+                        // those rows at that moment). nil (default) = byte-identical.
+                        onChunk: ((Int) -> Void)? = nil) -> MLXArray? {
         let pLen = promptIds.count
         guard pLen > 0 else { return nil }
         // Steel-prefill hybrid: larger chunks (steel wins grow with M); decode/verify unaffected.
@@ -540,6 +544,7 @@ extension Tell {
             let end = Swift.min(pos + chunkSize, pLen)
             let chunk = Array(promptIds[pos ..< end])
             guard let normed = fwdFn(chunk) else { return nil }
+            onChunk?(chunk.count)
             if let head = mtpHead, let fwd = mtpFwd {
                 // Non-final chunk: k pairs (last row pairs with the next chunk's head
                 // token). Final chunk: k-1 pairs (h_last has no committed successor yet).
@@ -620,7 +625,22 @@ extension Tell {
         // prefixCache: when the backend's cache already holds a prefix of `promptIds`, pass the
         // remaining suffix as prefillTokens (forward appends it at the cache's current position).
         // `hist` still uses the full promptIds so SuffixSpec drafting is unchanged (speed preserved).
-        guard let lastNormed = prefill(promptIds: prefillTokens ?? promptIds, backend: backend) else { return nil }
+        // #98 DFlash prefill-ctx bootstrap (QWISP_DFLASH_BOOTSTRAP=1, opt-in): harvest each
+        // prefill chunk's tap rows into the drafter ctx so block 1 already sees the prompt
+        // features (kills the cold-start accept ramp). Prompt longer than the raw ctx cap →
+        // draft falls back to the MLX drafter (windowed mask) — unchanged v1 contract.
+        // With a restored prefix-cache, only the re-prefilled suffix is harvested (cached
+        // rows never ran a tapped forward) — degraded ctx, still lossless.
+        let dflashBoot: ((Int) -> Void)? = {
+            guard Tell.envFlag("QWISP_DFLASH_BOOTSTRAP"), !useA3, let dd = dflash,
+                  let fwd = dflashFwd, fwd.tapBuf != nil else { return nil }
+            return { rows in
+                guard let tb = fwd.tapBuf else { return }
+                dd.appendCtx(tapBuf: tb, maxM: fwd.maxM, rows: rows)
+            }
+        }()
+        guard let lastNormed = prefill(promptIds: prefillTokens ?? promptIds, backend: backend,
+                                       onChunk: dflashBoot) else { return nil }
         guard let lg0 = engine.logits(lastNormed, M: 1) else { return nil }
         MLX.eval([lg0])
         var u = MLX.argMax(lg0[0], axis: -1).item(Int.self)
@@ -1166,8 +1186,19 @@ extension Tell {
 
         // ── PREFILL ───────────────────────────────────────────────────────
         // (mtpHead non-nil → prompt pairs ingested into head KV per chunk, Step 5)
+        // #98 DFlash prefill-ctx bootstrap (QWISP_DFLASH_BOOTSTRAP=1, opt-in): mirrors the
+        // runSpecLoop seam — harvest each prefill chunk's tap rows into the drafter ctx.
+        let dflashBoot: ((Int) -> Void)? = {
+            guard Tell.envFlag("QWISP_DFLASH_BOOTSTRAP"), !useA3, let dd = dflash,
+                  let fwd = _residentFwd, fwd.tapBuf != nil else { return nil }
+            return { rows in
+                guard let tb = fwd.tapBuf else { return }
+                dd.appendCtx(tapBuf: tb, maxM: fwd.maxM, rows: rows)
+            }
+        }()
         guard let lastNormed = prefill(promptIds: promptIds, backend: backend,
-                                       mtpHead: mtpHead, mtpFwd: _residentFwd)
+                                       mtpHead: mtpHead, mtpFwd: _residentFwd,
+                                       onChunk: dflashBoot)
         else { return "[raw-spec] ERROR: prefill returned nil" }
 
         // First token: argmax of logits at the last prompt position.


### PR DESCRIPTION
## Summary
#98 DFlash prefill-ctx bootstrap: harvest each prefill chunk's tap rows into the drafter ctx so block 1 already sees the prompt features, instead of cold-starting from committed rows only. Opt-in `QWISP_DFLASH_BOOTSTRAP=1`; default OFF = byte-identical. Refs #98.

Three additive nil-guarded seams:
- `forwardRowsHybrid`: `encodeTap` after the post-MoE residAdd (same seam as `encodeLayer`/`runStrictLayers`; copy-out only — the canonical hybrid prefill token stream is untouched).
- `Tell.prefill`: `onChunk` callback (nil default = byte-identical).
- `runSpecLoop` + raw-spec bench loop: opt-in wiring.

## Measured (paired A/B, N=128 resident, service stopped)
| regime | boot=0 | boot=1 | accept/step |
|---|---|---|---|
| code | 56.8 | **62.5** | 3.19 → 4.00 |
| agentic | 54.5 | **62.7** | 3.59 → 4.54 |
| longctx | 65.5 | 62.6 | 4.78 → 5.33 (one-time full-prompt ctx feed eats the gain) |
| shortnl | 28.6 | 26.7 | 1.02 → 0.95 (non-transfer, known) |

All 128/128 lossless. RAWTESTS 98/98, BENCHBATCH/COMP/TOK green.

## Finding
With ctx=95 from block 1, early-block accept is STILL low (p=2,1,0,0 then climbs) — the accept ramp is **position/content-dependent, not ctx-size alone**. Bootstrap closes most of the aggregate-vs-tail gap (T 4.19→5.00 vs tail ~5.6-5.9) but not all. vs flag-off (82.7/76.0/90.5/81.9), DFlash still loses on aggregate — **remains opt-in**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)