### PR TITLE
feat(server): RAM-tier prefix cache — keep interleaved conversations warm (#117)

### DIFF
--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -211,6 +211,14 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     private var prefixEmptySnap: Any?                       // fullSnapshot of the fresh arena, for reset
     private var arenaContent: [Int32] = []                  // tokens currently prefilled into the arena (one path)
     private var prefixSlots: [(len: Int, snap: Any)] = []   // restore points along arenaContent, sorted by len
+    // #117 RAM tier: whole-conversation states (persistentState blobs, path-independent) so
+    // interleaved conversations don't thrash the single-arena path above. LRU by byte budget;
+    // default 2GB resident / OFF streaming (wired-memory pressure — see PR #70).
+    private var prefixRAM = PrefixRAMStore()
+    public private(set) var prefixRAMHits = 0               // gate observability, mirrors PrefixPersist.restoreHits
+    func prefixRAMBudget(isStreaming: Bool) -> Int {
+        Swift.max(0, Tell.envInt("QWISP_PREFIX_RAM_MB", isStreaming ? 0 : 2048)) * 1_048_576
+    }
 
     /// Read `text_config.max_position_embeddings` from the checkpoint's config.json.
     /// Falls back to 32768 if absent — a sane bound that still lets any real chat reach EOS.
@@ -550,7 +558,25 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                 // of re-prefilling it. Boundaries past the divergence point are stale → drop them.
                 let lcp = SeedlessBackend.commonPrefixLen(content, self.arenaContent)
                 var restoreLen = self.prefixSlots.last(where: { $0.len <= lcp })?.len ?? 0
-                if restoreLen > 0, let s = self.prefixSlots.last(where: { $0.len == restoreLen })?.snap {
+                // #117 RAM tier: another conversation's stored state whose prefix beats the
+                // in-path restore point by more than a restore is worth (~512 tok of prefill).
+                self.prefixRAM.budget = self.prefixRAMBudget(isStreaming: cfg.isStreaming)
+                if let hit = self.prefixRAM.bestMatch(content: content), hit.tokens.count > restoreLen + 512 {
+                    if backend.restorePersistentState?(hit.state) == true {
+                        self.arenaContent = hit.tokens
+                        self.prefixSlots = []
+                        if let snap = backend.fullSnapshot?() {
+                            self.prefixSlots = [(len: hit.tokens.count, snap: snap)]
+                        }
+                        restoreLen = hit.tokens.count
+                        self.prefixRAMHits += 1
+                    } else {
+                        // A failed restore may have half-written the arena — the in-path
+                        // state is dead; fall back to a cold prefill from the empty state.
+                        self.arenaContent = []; self.prefixSlots = []; restoreLen = 0
+                        if let e = self.prefixEmptySnap { backend.fullRestore?(e) }
+                    }
+                } else if restoreLen > 0, let s = self.prefixSlots.last(where: { $0.len == restoreLen })?.snap {
                     backend.fullRestore?(s)
                 } else if PrefixPersist.enabled,
                           let hit = PrefixPersist.bestMatch(modelDir: self.modelDir, content: content),
@@ -589,10 +615,15 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                 // #89 (opt-in): persist the content-boundary state for cross-process reuse.
                 // The state is exactly at the boundary here (gen-suffix prefill comes next);
                 // persistentState() is a CPU copy of shared buffers, the file write is async.
-                if PrefixPersist.enabled, let blob = backend.persistentState?() {
-                    let model = self.modelDir
-                    DispatchQueue.global(qos: .utility).async {
-                        PrefixPersist.save(modelDir: model, tokens: content, state: blob)
+                if self.prefixRAM.budget > 0 || PrefixPersist.enabled,
+                   let blob = backend.persistentState?() {
+                    // #117: RAM tier keeps this conversation warm across arena-path switches.
+                    if self.prefixRAM.budget > 0 { self.prefixRAM.save(tokens: content, state: blob) }
+                    if PrefixPersist.enabled {
+                        let model = self.modelDir
+                        DispatchQueue.global(qos: .utility).async {
+                            PrefixPersist.save(modelDir: model, tokens: content, state: blob)
+                        }
                     }
                 }
 
@@ -624,6 +655,7 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     public func resetPrefixCache() {
         prefixBackend = nil; prefixFwd = nil; prefixProviders = nil; prefixArenaLen = 0; prefixEmptySnap = nil
         arenaContent = []; prefixSlots = []
+        prefixRAM.removeAll()   // #117: "restart" semantics — only the DISK store (#89) survives
     }
 
     // Cap resident snapshots (~60MB each) at prefixMaxSlots, evicting the densest neighbour so a coarse

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -12,6 +12,103 @@ import MLX
 // tail = the generation prompt + generated tokens that the next request rewinds past, B = the new
 // content appended in the next request.
 extension Tell {
+    // Long-context decay probe (#117 follow-up): the production log shows prefill chunk rate
+    // decaying 348→66 tok/s over 0→40K and decode collapsing 45→7 tok/s at 48K. This isolates
+    // WHY, per stage, using forwardRowsProfiled (exact per-encoder GPU ms bucketed GDN/attn/MoE).
+    // One long prefill builds the context; at checkpoints it also runs M=1 forwards (= decode
+    // step cost at that context). If attn ms scales ~linearly with position while GDN/MoE stay
+    // flat, the driver is full-attention O(N) reads (fundamental; only the 10 full-attn layers
+    // grow) — not a fixable constant. Env: QWISP_DECAY_MAX (default 49152).
+    public static func longContextDecayProbe(modelDir: String) -> String {
+        guard let store = try? WeightStore(modelDir: modelDir) else { return "[decay] load fail\nDECAY done" }
+        store.residentAll()
+        let engine = SeedlessEngine.build(store: store)
+        let maxCtx = Tell.envInt("QWISP_DECAY_MAX", 49152)
+        let chunk = 1024
+        guard let (fwd, _) = engine.makeFused(maxM: chunk + 8, maxSeqLen: maxCtx + 128) else {
+            return "[decay] makeFused nil\nDECAY done"
+        }
+        let checkpoints = [4096, 8192, 16384, 32768, 49152].filter { $0 <= maxCtx }
+        var lines = ["[decay] maxCtx=\(maxCtx) chunk=\(chunk) resident/fused — per-stage GPU ms (exact)",
+                     "  ── prefill: per-chunk stage ms by context position ──",
+                     "     posStart   attn_ms   gdn_ms   moe_ms   chunk_ms   tok/s"]
+        func tok(_ n: Int, _ salt: Int) -> [Int32] { (0..<n).map { Int32((($0 &* 7 &+ salt) % 5000) + 100) } }
+        let prompt = tok(maxCtx, 13)
+        var pos = 0
+        let sampleAt = Set([0, 1024, 2048, 4096, 8192, 16384, 24576, 32768, 40960, 47104])
+        var decodeRows: [String] = []
+        while pos < maxCtx {
+            let end = Swift.min(pos + chunk, maxCtx)
+            let x = engine.embed(tokens: Array(prompt[pos ..< end]))
+            guard let t = fwd.forwardRowsProfiled(x, M: end - pos) else { break }
+            if sampleAt.contains(pos) {
+                let cm = t.gdn + t.attn + t.moe
+                lines.append(String(format: "     %8d  %8.2f %8.2f %8.2f  %8.2f  %6.0f",
+                                    pos, t.attn, t.gdn, t.moe, cm, Double(end - pos) / (cm / 1000)))
+            }
+            pos = end
+            // Decode-step cost (M=1) at this context depth — average 5, skip warmup.
+            if checkpoints.contains(pos) {
+                var a = 0.0, g = 0.0, m = 0.0; let reps = 6
+                for r in 0..<reps {
+                    let x1 = engine.embed(tokens: [prompt[pos % maxCtx]])
+                    guard let t1 = fwd.forwardRowsProfiled(x1, M: 1) else { break }
+                    if r > 0 { a += t1.attn; g += t1.gdn; m += t1.moe }   // drop rep 0 (warmup)
+                }
+                let n = Double(reps - 1); let step = (a + g + m) / n
+                decodeRows.append(String(format: "     %8d  %8.3f %8.3f %8.3f  %8.3f  %6.1f",
+                                         pos, a/n, g/n, m/n, step, 1000.0 / step))
+            }
+        }
+        lines.append("  ── decode (M=1) step stage ms by context length ──")
+        lines.append("     context    attn_ms   gdn_ms   moe_ms   step_ms   tok/s")
+        lines.append(contentsOf: decodeRows)
+        return lines.joined(separator: "\n") + "\nDECAY done"
+    }
+
+    // Spec-verify width probe (#117 follow-up): the decay probe showed the RAW M=1 forward at
+    // 49K is ~36 tok/s, yet the production log's spec-decode collapses to 6-7 tok/s there. The
+    // suspect is the verify forward: full-attention is O(M·N), so a K-token draft costs ~K× the
+    // attention of a single row at that context. This prefills to QWISP_SPEC_CTX (default 32768)
+    // then sweeps M (verify width) measuring per-stage forward ms. If attn ms scales ~linearly
+    // with M while GDN/MoE stay flat, long drafts are counterproductive at long context and the
+    // fix is a context-aware draft-length cap (spec loop, additive, lossless). Measure-first.
+    public static func specWidthProbe(modelDir: String) -> String {
+        guard let store = try? WeightStore(modelDir: modelDir) else { return "[spec-width] load fail\nSPECWIDTH done" }
+        store.residentAll()
+        let engine = SeedlessEngine.build(store: store)
+        let ctx = Tell.envInt("QWISP_SPEC_CTX", 32768)
+        let maxM = 32
+        guard let (fwd, _) = engine.makeFused(maxM: maxM, maxSeqLen: ctx + maxM + 8) else {
+            return "[spec-width] makeFused nil\nSPECWIDTH done"
+        }
+        func tok(_ n: Int, _ salt: Int) -> [Int32] { (0..<n).map { Int32((($0 &* 7 &+ salt) % 5000) + 100) } }
+        // Prefill to `ctx` in chunks of 1024 (build the KV context).
+        let pre = tok(ctx, 13); var pos = 0
+        while pos < ctx {
+            let end = Swift.min(pos + 1024, ctx)
+            _ = fwd.forwardRowsProfiled(engine.embed(tokens: Array(pre[pos ..< end])), M: end - pos)
+            pos = end
+        }
+        var lines = ["[spec-width] ctx=\(ctx) resident/fused — forward stage ms by verify width M",
+                     "     M    attn_ms   gdn_ms   moe_ms   step_ms  attn/M   (draft cost model)"]
+        // Sweep M; each M runs a few reps (dropping warmup). forwardRowsProfiled appends to KV,
+        // but we only need the timing — the small KV growth (a few hundred rows total) is noise
+        // against a 32K context.
+        for M in [1, 2, 4, 8, 16] {
+            var a = 0.0, g = 0.0, m = 0.0; let reps = 5
+            for r in 0..<reps {
+                let x = engine.embed(tokens: tok(M, 100 + r))
+                guard let t = fwd.forwardRowsProfiled(x, M: M) else { break }
+                if r > 0 { a += t.attn; g += t.gdn; m += t.moe }
+            }
+            let n = Double(reps - 1)
+            lines.append(String(format: "  %4d  %8.3f %8.3f %8.3f %8.3f %8.3f",
+                                M, a/n, g/n, m/n, (a+g+m)/n, (a/n)/Double(M)))
+        }
+        return lines.joined(separator: "\n") + "\nSPECWIDTH done"
+    }
+
     // Prefill throughput probe: measures tok/s prefilling a fixed prompt at several chunk sizes.
     // If larger chunks are much faster → per-forward overhead dominates (raise the chunk).
     // If flat → per-token compute is the limit (kernel-level work). Measure-before-implement.

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -237,6 +237,60 @@ extension Tell {
         return lines.joined(separator: "\n")
     }
 
+    // #117 gate: PREFIXE2E for the RAM tier. Interleaved conversations — A cold, B cold
+    // (unrelated → replaces A's arena path), then A extended: the third request must
+    // restore A's whole-conversation state from the RAM store (prefixRAMHits asserts the
+    // restore actually fired) and stream byte-identical to the cache-off path. A fourth
+    // request extends the third: the in-path slot now ties the RAM entry, so the gain
+    // guard (>512 tok) must keep the cheap in-path restore (hits stays 1).
+    public static func prefixRAME2E(modelDir: String) -> String {
+        let ec = Tell.envInt("QWISP_PREFIX_E2E_C", 0)
+        let tier: SeedlessTier = ec > 0 ? .streaming(c: ec) : .auto
+        guard let backend = try? SeedlessBackend(modelDir: modelDir, tier: tier) else { return "[prefix-ram-e2e] load fail\nPREFIXRAME2E FAIL" }
+        if ec > 0 { backend.losslessForced = true }
+        setenv("QWISP_PREFIX_RAM_MB", "512", 1)      // force the tier ON (streaming defaults OFF)
+        defer { unsetenv("QWISP_PREFIX_RAM_MB") }
+
+        func toks(_ n: Int, _ salt: Int) -> [Int] { (0..<n).map { (($0 &* 7 &+ salt) % 5000) + 100 } }
+        let cA = toks(700, 1)                        // conv A (700 > the 512-tok gain guard)
+        let cB = toks(700, 2)                        // conv B, no shared prefix
+        let cA2 = cA + toks(40, 3)                   // A continues after the switch
+        let cA3 = cA2 + toks(40, 4)                  // A continues in-path (RAM must NOT fire)
+        func req(_ content: [Int]) -> (prompt: [Int], cl: Int) { (content + toks(8, 777), content.count) }
+        let reqs = [req(cA), req(cB), req(cA2), req(cA3)]
+        let maxTok = 24
+
+        final class Box: @unchecked Sendable { var v: [Int] = [] }
+        func gen(_ p: [Int], _ cl: Int) -> [Int] {
+            let box = Box()
+            let sem = DispatchSemaphore(value: 0)
+            let stream = backend.generate(p, options: GenerateOptions(maxTokens: maxTok, promptContentLen: cl))
+            Task { for await t in stream { box.v.append(t) }; sem.signal() }
+            sem.wait()
+            return box.v
+        }
+
+        backend.prefixCacheForced = false
+        let ref = reqs.map { gen($0.prompt, $0.cl) }
+        backend.prefixCacheForced = true
+        backend.resetPrefixCache()
+        var hitsAfter: [Int] = []
+        let got = reqs.map { r in let g = gen(r.prompt, r.cl); hitsAfter.append(backend.prefixRAMHits); return g }
+
+        var lines = ["[prefix-ram-e2e] A cold / B cold / A-extend (RAM restore) / A-extend (in-path), maxTok=\(maxTok), tier=\(ec > 0 ? "streaming C=\(ec)" : "resident")"]
+        var pass = true
+        let labels = ["R1 A cold    ", "R2 B switch  ", "R3 A ram-hit ", "R4 A in-path "]
+        let wantHits = [0, 0, 1, 1]
+        for i in 0..<reqs.count {
+            let ok = ref[i] == got[i] && hitsAfter[i] == wantHits[i]
+            pass = pass && ok
+            lines.append("  \(labels[i])  ref=\(ref[i].count)tok  cached=\(got[i].count)tok  ramHits=\(hitsAfter[i]) (want \(wantHits[i]))  \(ok ? "IDENTICAL ✅" : "DIVERGE ❌")")
+            if ref[i] != got[i] { lines.append("    ref   : \(ref[i].prefix(12))"); lines.append("    cached: \(got[i].prefix(12))") }
+        }
+        lines.append("PREFIXRAME2E \(pass ? "PASS" : "FAIL")")
+        return lines.joined(separator: "\n")
+    }
+
     // #76 gate (bolt side): bolt-mode decode with the in-RAM prompt-prefix blob
     // (QWISP_BOLT_PREFIX) vs without must be byte-identical. Two INDEPENDENT backends
     // (own BoltServe, own arena) are fed the same request sequence so per-process calib

--- a/swift/Sources/QwispCore/PrefixPersist.swift
+++ b/swift/Sources/QwispCore/PrefixPersist.swift
@@ -157,3 +157,75 @@ public enum PrefixPersist {
         return checks
     }
 }
+
+// RAM tier for the cross-request prefix cache (issue #117): interleaved conversations
+// (OpenCode title-gen / tabs / sub-sessions) thrash the single-path in-arena cache — every
+// switch re-prefills everything past the shared harness prefix (measured reuse 4–52%,
+// TTFT up to 7 min on a 49K prompt). This store keeps whole-conversation decode states
+// (SeedlessFusedForward.persistentStateData blobs — path-independent, unlike FullSnapshot's
+// KV-length-only restore points) in RAM, keyed by token content, LRU-evicted by byte
+// budget. No disk writes — the SSD-wear objection that keeps #89 opt-in does not apply.
+public struct PrefixRAMStore {
+    public var budget: Int                                    // bytes; 0 = disabled
+    // MRU-first; an entry ≈ 24KB/token (attention KV used slice + GDN state).
+    var entries: [(tokens: [Int32], state: Data)] = []
+    public init(budget: Int = 0) { self.budget = budget }
+    var bytes: Int { entries.reduce(0) { $0 + $1.state.count } }
+
+    /// Store one content-boundary state. Entries that are a prefix of `tokens` (earlier
+    /// turns of the same conversation, or the same key) are superseded and dropped.
+    public mutating func save(tokens: [Int32], state: Data) {
+        guard budget > 0, !tokens.isEmpty, state.count <= budget else { return }
+        entries.removeAll { $0.tokens.count <= tokens.count
+            && Array(tokens[0 ..< $0.tokens.count]) == $0.tokens }
+        entries.insert((tokens, state), at: 0)
+        while bytes > budget { entries.removeLast() }
+    }
+
+    /// The stored entry whose token sequence is the LONGEST prefix of `content`; touches LRU.
+    public mutating func bestMatch(content: [Int32]) -> (tokens: [Int32], state: Data)? {
+        var best = -1
+        for i in entries.indices
+        where entries[i].tokens.count <= content.count
+            && (best < 0 || entries[i].tokens.count > entries[best].tokens.count)
+            && Array(content[0 ..< entries[i].tokens.count]) == entries[i].tokens {
+            best = i
+        }
+        guard best >= 0 else { return nil }
+        let e = entries.remove(at: best)
+        entries.insert(e, at: 0)
+        return e
+    }
+
+    public mutating func removeAll() { entries.removeAll() }
+
+    /// Pure self-check (no GPU): longest match, supersede, LRU byte eviction, budget gates.
+    public static func selfCheck() -> [(String, Bool)] {
+        func blob(_ n: Int, _ b: UInt8) -> Data { Data(repeating: b, count: n) }
+        var s = PrefixRAMStore(budget: 1000)
+        let a: [Int32] = [1, 2, 3, 4], a2: [Int32] = [1, 2, 3, 4, 5, 6], b: [Int32] = [9, 8, 7]
+        s.save(tokens: a, state: blob(100, 1))
+        s.save(tokens: b, state: blob(100, 2))
+        s.save(tokens: a2, state: blob(100, 3))                   // supersedes a
+        var checks: [(String, Bool)] = [
+            ("supersede_prefix", s.entries.count == 2),
+            ("longest_prefix", s.bestMatch(content: a2 + [7])?.state == blob(100, 3)),
+            ("miss_after_supersede", s.bestMatch(content: [1, 2, 3, 4, 99]) == nil),
+            ("unrelated_kept", s.bestMatch(content: b + [0])?.state == blob(100, 2)),
+            ("miss_diverge", s.bestMatch(content: [42]) == nil),
+        ]
+        var l = PrefixRAMStore(budget: 250)
+        l.save(tokens: [1], state: blob(100, 1))
+        l.save(tokens: [2], state: blob(100, 2))
+        _ = l.bestMatch(content: [1])                             // touch [1] → MRU
+        l.save(tokens: [3], state: blob(100, 3))                  // 300 > 250 → evict LRU = [2]
+        checks.append(("lru_evict_touched_kept", l.bestMatch(content: [2]) == nil && l.bestMatch(content: [1]) != nil))
+        var d = PrefixRAMStore(budget: 0)
+        d.save(tokens: [1], state: blob(10, 1))
+        checks.append(("disabled_budget0", d.bestMatch(content: [1]) == nil))
+        var o = PrefixRAMStore(budget: 100)
+        o.save(tokens: [1], state: blob(200, 1))                  // entry larger than the whole budget
+        checks.append(("oversize_skip", o.bestMatch(content: [1]) == nil))
+        return checks
+    }
+}

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -38,6 +38,8 @@ if CommandLine.arguments.contains("stream") {
         ("seqmt-m", { md, _ in Tell.seqMTScalingProbe(modelDir: md) }),             // #90 Step 0 probe
         ("prefix-cache-speed", { md, _ in Tell.prefixCacheSpeedProbe(modelDir: md) }),
         ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),
+        ("long-context-decay", { md, _ in Tell.longContextDecayProbe(modelDir: md) }), // #117 follow-up profiling
+        ("spec-width", { md, _ in Tell.specWidthProbe(modelDir: md) }),             // #117 verify-width scaling
         ("gqmm2-bench", { _, _ in SeedlessMetalForward.gqmm2Bench() }),   // notes/18 W1 speed sim
         ("dflash-parity", { _, _ in DFlashParityProbe.run() }),           // #98 phase 2b oracle parity
         ("dflash-raw-bench", { _, _ in DFlashRawDrafter.bench() }),       // #98 A1 c_draft micro-bench

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -33,6 +33,7 @@ if CommandLine.arguments.contains("stream") {
         ("hybrid-prefill-bench", { md, _ in Tell.hybridPrefillBench(modelDir: md) }),
         ("prefix-cache-e2e", { md, _ in Tell.prefixCacheE2E(modelDir: md) }),
         ("prefix-persist-e2e", { md, _ in Tell.prefixPersistE2E(modelDir: md) }),   // #89 restart gate
+        ("prefix-ram-e2e", { md, _ in Tell.prefixRAME2E(modelDir: md) }),           // #117 RAM-tier gate
         ("prefix-bolt-e2e", { md, _ in Tell.prefixBoltE2E(modelDir: md) }),         // #76 bolt-side gate
         ("seqmt-m", { md, _ in Tell.seqMTScalingProbe(modelDir: md) }),             // #90 Step 0 probe
         ("prefix-cache-speed", { md, _ in Tell.prefixCacheSpeedProbe(modelDir: md) }),

--- a/swift/Sources/qwisp/Selftest.swift
+++ b/swift/Sources/qwisp/Selftest.swift
@@ -95,6 +95,9 @@ func runCompletionSelftest(modelDir: String) async -> String {
     // prefix-cache disk persistence (issue #89; pure tmp-dir store checks, no GPU).
     for (name, ok) in PrefixPersist.selfCheck() { check("prefixpersist_\(name)", ok) }
 
+    // prefix-cache RAM tier (issue #117; pure keyed-store checks, no GPU).
+    for (name, ok) in PrefixRAMStore.selfCheck() { check("prefixram_\(name)", ok) }
+
     // continuous-batching scheduler (issue #6; pure logic over a scripted fake engine).
     for (name, ok) in ContinuousScheduler.selfCheck() { check("batch_\(name)", ok) }
 


### PR DESCRIPTION
Closes #117

## Problem (production-measured)

Interleaved conversations (OpenCode title-gen / tabs / sub-sessions) thrash the single-path in-arena prefix cache. Reuse estimated from the production log (`ttft × prefill_rate`, 2026-07-19, brew service, default config):

| situation | reuse | TTFT |
|---|---|---|
| same conversation, next turn | **97%** | 2.3s |
| after a conversation switch (~10K) | 37-52% (shared harness prefix only) | 13-25s |
| 26K conversation, +624 tok after a switch | 15% | **127s** |
| 48-49K conversation | 4% | **6-7 min** |

The stable ~4K reused tokens on every switch = the shared OpenCode system+tools prefix (multi-slot stride snapshots doing their job). Everything conversation-specific is re-prefilled on every switch. This is the real "qwisp feels slow in OpenCode" complaint (batching was ruled out — no concurrency in the log at all).

## Root cause

`generateCached` keeps ONE arena path (`arenaContent` + `prefixSlots`). A slot is a `FullSnapshot` = KV **lengths** + GDN copy — valid only while arena positions ≤ len still hold that path's KV. A new conversation overwrites the arena past the LCP, correctly dropping the old slots. Single path is a design constraint of the cheap snapshot, not a bug.

## Fix: RAM tier (reuses #89 machinery)

`persistentStateData()` already produces a **path-independent** full-state blob (KV used slice + GDN, plain CPU memcpy) restorable into any large-enough arena (~0.5s class). #89 keeps these on disk, opt-in for SSD wear — RAM has no wear.

- `PrefixRAMStore`: in-RAM keyed collection, LRU by **byte budget** (`QWISP_PREFIX_RAM_MB`, default 2GB resident / **OFF on streaming tiers** — wired-memory pressure, PR #70). ~24KB/token ⇒ ~250MB per 10K-token conversation.
- `generateCached` restores the longest stored prefix when it beats the in-path restore point by **>512 tokens** (a restore is not worth less prefill than that); earlier turns of the same conversation are superseded on save; failed restore → cold fallback.
- Save at the content boundary (same site as #89, one blob generation shared between RAM + disk tiers).
- `resetPrefixCache` clears the RAM store too (restart semantics — only the #89 disk store survives; keeps the #89 gate intact).

This is the **multi-path** prefix cache in swap form: the arena is the active path's working set, the RAM store is the index + eviction backing for the others. (A zero-copy paged-KV variant would require rewriting the frozen attention kernels — deferred until measurement shows the ~0.5s swap is insufficient.)

Expected on the measured traffic: switch TTFT 13-127s → ~1-3s; 48K cases → seconds once warm.

## Gates (all green)

- RAWTESTS **98/98**
- COMPTEST **41/41** (8 new pure `PrefixRAMStore` store checks)
- BENCHBATCHTEST PASS, TOKTEST 5/5
- New `prefix-ram-e2e` lossless gate (A cold / B switch / A RAM-restore / A in-path; byte-compare vs cache-off + `ramHits` assertions): **PASS** resident + **PASS** streaming C=64
- Regressions: `prefix-persist-e2e` (#89) PASS, `prefix-cache-e2e` (#76) PASS

## Out of scope (same log, separate axis, needs GPU profiling)

- Prefill chunk rate decays 348 → 66 tok/s over 0 → 40K context.
- Decode collapses to 6-7 tok/s at 48K (vs 40-50 at ≤10K).

🤖 Generated with [Claude Code](https://claude.com/claude-code)