### PR TITLE
test(tools): OpenCode parallel-agent reproduction — capture proxy + replay harness, first measured verdict

### DIFF
--- a/tools/opencode-repro/README.md
+++ b/tools/opencode-repro/README.md
@@ -1,0 +1,42 @@
+# OpenCode parallel-agent reproduction
+
+Faithfully reproduce the request pattern OpenCode emits when it fans out **parallel sub-agents**
+(`task(background=true)` → N independent streaming completions), then measure qwisp's two paths
+against it:
+
+- **serialize (default)** — bit-identity to the single-stream strict reference, no batching speedup.
+- **batch (`QWISP_BATCH`)** — throughput, but the MLX-greedy path (see below) may diverge from strict.
+
+## 1. Capture ground truth (needs a running qwisp server)
+
+```bash
+# terminal A: capturing proxy in front of the server
+CAPTURE=./oc-capture.jsonl node tools/opencode-repro/capture_proxy.mjs   # :8081 → :8080
+```
+
+Point OpenCode's qwisp provider `baseURL` at `http://127.0.0.1:8081/v1` (temporarily), then run a
+task that fans out parallel sub-agents. Every request lands in `oc-capture.jsonl` with the full
+body, arrival timing, and in-flight concurrency.
+
+## 2. Replay + compare (needs the server; GPU)
+
+```bash
+R=tools/opencode-repro/replay_concurrent.mjs
+# reference: one request at a time against the default (serialize) server
+node $R run oc-capture.jsonl 127.0.0.1:8080 serial     ref-serial.json     --greedy
+# reproduce the fan-out load against the default server (serialize path)
+node $R run oc-capture.jsonl 127.0.0.1:8080 concurrent cc-serialize.json   --greedy
+# ...and against a server started with QWISP_BATCH=<N> (batch path)
+node $R run oc-capture.jsonl 127.0.0.1:8080 concurrent cc-batch.json       --greedy
+
+node $R diff ref-serial.json cc-serialize.json   # expect: all streams identical, speedup ~1x
+node $R diff ref-serial.json cc-batch.json        # measures batch divergence % + throughput speedup
+```
+
+`diff` reports how many streams are byte-identical to the serial reference and the wall-clock
+speedup. The batch run's divergence count is the empirical answer to "does continuous batching
+lose bit-exactness, and how often" on real OpenCode traffic (not just in theory).
+
+Notes: the wire carries text deltas, not token ids, so identity is compared on concatenated text
+(a strong proxy for a token flip). `--greedy` forces temperature 0 so the comparison is
+deterministic even if OpenCode sampled. No dependencies — Node built-in `http` only.

--- a/tools/opencode-repro/capture_proxy.mjs
+++ b/tools/opencode-repro/capture_proxy.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// OpenCode → qwisp capturing reverse proxy (issue: OpenCode parallel-agent reproduction).
+//
+// Sits between OpenCode and the qwisp server so we capture the EXACT wire requests OpenCode
+// emits when it fans out parallel sub-agents — ground truth for a deterministic replay harness.
+// Streams (SSE) pass through untouched via pipe; nothing is buffered on the response side, so
+// OpenCode's token streaming and timing are unaffected. Each request is logged as one JSONL
+// line with the full body (for replay) plus timing + concurrency (in-flight count at arrival).
+//
+// Usage:  PORT=8081 UPSTREAM=127.0.0.1:8080 CAPTURE=./oc-capture.jsonl node capture_proxy.mjs
+// Point OpenCode's qwisp provider baseURL at http://127.0.0.1:8081/v1 and run a fan-out task.
+//
+// ponytail: built-in http only, no deps. Bodies are buffered request-side (chat JSON, not huge);
+// responses stream. Upgrade path if a body ever exceeds memory: spill to a sidecar file by id.
+import http from "node:http";
+import fs from "node:fs";
+
+const PORT = parseInt(process.env.PORT ?? "8081", 10);
+const [UP_HOST, UP_PORT] = (process.env.UPSTREAM ?? "127.0.0.1:8080").split(":");
+const CAPTURE = process.env.CAPTURE ?? "./oc-capture.jsonl";
+const out = fs.createWriteStream(CAPTURE, { flags: "a" });
+const t0 = process.hrtime.bigint();
+const ms = () => Number(process.hrtime.bigint() - t0) / 1e6;
+
+let seq = 0;
+let inflight = 0;
+
+const server = http.createServer((req, res) => {
+  const id = ++seq;
+  const tArrival = ms();
+  inflight++;
+  const inflightAtArrival = inflight;
+
+  const chunks = [];
+  req.on("data", (c) => chunks.push(c));
+  req.on("end", () => {
+    const body = Buffer.concat(chunks);
+    const upReq = http.request(
+      { host: UP_HOST, port: UP_PORT, method: req.method, path: req.url, headers: req.headers },
+      (upRes) => {
+        let tFirstByte = null;
+        let respBytes = 0;
+        let sseEvents = 0;
+        res.writeHead(upRes.statusCode ?? 502, upRes.headers);
+        upRes.on("data", (c) => {
+          if (tFirstByte === null) tFirstByte = ms();
+          respBytes += c.length;
+          // Count SSE "data:" frames to sanity-check streaming shape (not parsed).
+          for (let i = 0; i < c.length - 4; i++) {
+            if (c[i] === 0x64 && c[i + 1] === 0x61 && c[i + 2] === 0x74 && c[i + 3] === 0x61 && c[i + 4] === 0x3a) sseEvents++;
+          }
+        });
+        upRes.pipe(res); // stream through, no buffering
+        upRes.on("end", () => {
+          inflight--;
+          let parsed = null;
+          try {
+            const j = JSON.parse(body.toString("utf8"));
+            parsed = {
+              model: j.model,
+              stream: j.stream,
+              n: j.n ?? null,
+              parallel_tool_calls: j.parallel_tool_calls ?? null,
+              messages: Array.isArray(j.messages) ? j.messages.length : null,
+              tools: Array.isArray(j.tools) ? j.tools.length : null,
+              lastRole: Array.isArray(j.messages) && j.messages.length ? j.messages[j.messages.length - 1].role : null,
+              approxPromptChars: body.length,
+            };
+          } catch {}
+          out.write(JSON.stringify({
+            id, method: req.method, path: req.url,
+            tArrival, tFirstByte, tDone: ms(),
+            inflightAtArrival, status: upRes.statusCode,
+            respBytes, sseEvents, parsed,
+            body: body.toString("utf8"),   // full body for replay
+          }) + "\n");
+          console.error(`#${id} ${req.method} ${req.url} inflight=${inflightAtArrival} ttfb=${tFirstByte === null ? "-" : (tFirstByte - tArrival).toFixed(0)}ms sse=${sseEvents} ${upRes.statusCode}`);
+        });
+      }
+    );
+    upReq.on("error", (e) => { inflight--; res.writeHead(502); res.end(String(e)); });
+    upReq.end(body);
+  });
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.error(`[capture] :${PORT} → ${UP_HOST}:${UP_PORT}  capture=${CAPTURE}`);
+});

--- a/tools/opencode-repro/replay_concurrent.mjs
+++ b/tools/opencode-repro/replay_concurrent.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Deterministic replay of a captured OpenCode trace against a qwisp server (issue: parallel-agent
+// reproduction). Fires the captured request bodies either CONCURRENTLY at their recorded relative
+// arrival times (reproducing OpenCode's fan-out load) or SERIALLY one-at-a-time (the bit-identity
+// reference). Collects each request's streamed text + timing. A separate `diff` compares two runs
+// token-for-text to quantify how often the batch path diverges from the serial/strict reference.
+//
+// Usage:
+//   node replay_concurrent.mjs run <capture.jsonl> <host:port> <concurrent|serial> <out.json> [--greedy]
+//   node replay_concurrent.mjs diff <ref.json> <cmp.json>
+//
+// --greedy overrides temperature/top_p to force the greedy path (so the identity comparison is
+// meaningful even if OpenCode sampled). Compares streamed text (the wire has no token ids); text
+// divergence is a strong proxy for a token flip. ponytail: built-in http only.
+import http from "node:http";
+import fs from "node:fs";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function fire(hostport, body, greedy) {
+  const [host, port] = hostport.split(":");
+  let req;
+  try { req = JSON.parse(body); } catch { return Promise.resolve({ ok: false, text: "", err: "bad-body" }); }
+  req.stream = true;
+  if (greedy) { req.temperature = 0; delete req.top_p; delete req.top_k; }
+  const payload = Buffer.from(JSON.stringify(req));
+  const t0 = Date.now();
+  return new Promise((resolve) => {
+    const r = http.request({ host, port, method: "POST", path: "/v1/chat/completions",
+      headers: { "content-type": "application/json", "content-length": payload.length, authorization: "Bearer sk-noauth" } },
+      (res) => {
+        let text = "", ttft = null, buf = "";
+        res.on("data", (c) => {
+          if (ttft === null) ttft = Date.now() - t0;
+          buf += c.toString("utf8");
+          let nl;
+          while ((nl = buf.indexOf("\n")) >= 0) {
+            const line = buf.slice(0, nl).trim(); buf = buf.slice(nl + 1);
+            if (!line.startsWith("data:")) continue;
+            const d = line.slice(5).trim();
+            if (d === "[DONE]") continue;
+            try { const j = JSON.parse(d); const delta = j.choices?.[0]?.delta?.content; if (delta) text += delta; } catch {}
+          }
+        });
+        res.on("end", () => resolve({ ok: true, text, ttft, wall: Date.now() - t0, status: res.statusCode }));
+      });
+    r.on("error", (e) => resolve({ ok: false, text: "", err: String(e) }));
+    r.end(payload);
+  });
+}
+
+async function run(capPath, hostport, mode, outPath, greedy) {
+  const recs = fs.readFileSync(capPath, "utf8").trim().split("\n").map((l) => JSON.parse(l))
+    .filter((r) => r.method === "POST" && r.path.includes("chat/completions"));
+  recs.sort((a, b) => a.tArrival - b.tArrival);
+  console.error(`[replay] ${recs.length} completions, mode=${mode}, target=${hostport}, greedy=${!!greedy}`);
+  const results = {};
+  const wall0 = Date.now();
+  if (mode === "concurrent") {
+    const base = recs[0].tArrival;
+    await Promise.all(recs.map(async (r) => {
+      await sleep(Math.max(0, r.tArrival - base));   // reproduce arrival timing
+      const t = Date.now() - wall0;
+      const res = await fire(hostport, r.body, greedy);
+      results[r.id] = { ...res, tStart: t, inflightAtArrival: r.inflightAtArrival };
+      console.error(`  #${r.id} done ttft=${res.ttft ?? "-"}ms wall=${res.wall ?? "-"}ms len=${res.text.length}`);
+    }));
+  } else {
+    for (const r of recs) {
+      const res = await fire(hostport, r.body, greedy);   // one at a time = reference
+      results[r.id] = { ...res, inflightAtArrival: 1 };
+      console.error(`  #${r.id} done ttft=${res.ttft ?? "-"}ms wall=${res.wall ?? "-"}ms len=${res.text.length}`);
+    }
+  }
+  const totalWall = Date.now() - wall0;
+  const genChars = Object.values(results).reduce((s, r) => s + (r.text?.length ?? 0), 0);
+  fs.writeFileSync(outPath, JSON.stringify({ mode, hostport, greedy: !!greedy, totalWall, genChars, results }, null, 2));
+  console.error(`[replay] totalWall=${totalWall}ms genChars=${genChars} → ${outPath}`);
+}
+
+function diff(refPath, cmpPath) {
+  const ref = JSON.parse(fs.readFileSync(refPath, "utf8"));
+  const cmp = JSON.parse(fs.readFileSync(cmpPath, "utf8"));
+  let ids = 0, identical = 0, diverged = [];
+  for (const id of Object.keys(ref.results)) {
+    const a = ref.results[id]?.text, b = cmp.results[id]?.text;
+    if (a == null || b == null) continue;
+    ids++;
+    if (a === b) identical++;
+    else {
+      let i = 0; while (i < a.length && i < b.length && a[i] === b[i]) i++;
+      diverged.push({ id, divergeAtChar: i, refLen: a.length, cmpLen: b.length,
+                      refTail: a.slice(i, i + 40), cmpTail: b.slice(i, i + 40) });
+    }
+  }
+  console.log(`identity: ${identical}/${ids} streams byte-identical`);
+  console.log(`throughput: ref totalWall=${ref.totalWall}ms  cmp totalWall=${cmp.totalWall}ms  speedup=${(ref.totalWall / cmp.totalWall).toFixed(2)}x`);
+  for (const d of diverged) console.log(`  #${d.id} diverges @char ${d.divergeAtChar} (ref ${d.refLen} / cmp ${d.cmpLen})\n    ref: …${JSON.stringify(d.refTail)}\n    cmp: …${JSON.stringify(d.cmpTail)}`);
+}
+
+const [, , cmd, ...a] = process.argv;
+if (cmd === "run") await run(a[0], a[1], a[2], a[3], a.includes("--greedy"));
+else if (cmd === "diff") diff(a[0], a[1]);
+else { console.error("usage: run <cap.jsonl> <host:port> <concurrent|serial> <out.json> [--greedy]  |  diff <ref.json> <cmp.json>"); process.exit(1); }


### PR DESCRIPTION
## What

Faithful reproduction of OpenCode's **parallel sub-agent fan-out** against qwisp, per the B-track prerequisite: prove we can reproduce the exact behavior before any batching work. Capture proxy (real wire ground truth) + deterministic concurrent/serial replay + identity/throughput diff. Node built-in http only, no deps.

## Reproduction fidelity (proved live)

Ran real OpenCode 1.18.3 headless against qwisp through the proxy with a 3-subagent fan-out task. Captured trace: title-gen ∥ main turn, then **3 subagent streams arriving simultaneously** (identical 12.8K-char system prefix, same 29K-char prompt shape, inflight peak 3), then the coordinator turn. All requests greedy (no temperature).

Replaying the trace reproduced the live TTFB ladder almost exactly (live 0.38/16.1/20.8s → replay 0.36/15.9/20.5s) — the harness is faithful.

## First measured verdict on the two server paths (real OpenCode traffic, 64GB resident)

| path | identity vs strict serial ref | total wall | note |
|---|---|---|---|
| serialize (default) | **6/6 byte-identical** | 72.3s (1.01x) | AsyncLock ladder; prefix cache absorbs the shared-prefix fan-out (repeat TTFT ~0.2-0.4s) |
| `QWISP_BATCH=4` | **3/6 diverge** (haiku text visibly differs) | **190.6s (0.38x — 2.6x SLOWER)** | uniform TTFT ~0.3s, but MLX-greedy path: no SuffixSpec, no prefix cache → every request re-prefills ~9K tokens |

Two conclusions the source-reading phase could not give:

1. **Bit-exactness loss of the batch path is now measured, not theoretical**: 3/6 real streams flip (e.g. "wakes sleeping seeds" → "awakens life"). Root cause split: the batch backend is the MLX f16 op-graph (not the Seedless strict engine) — divergence exists batch-or-not; batch shape variance adds nondeterminism on top.
2. **On real OpenCode fan-out shapes, batching as shipped LOSES 2.6x to serialize+prefix-cache**, because agentic prompts are prefill-dominated with heavy shared prefixes: the batch path lacks both SuffixSpec and the prefix cache, so its uniform-TTFT benefit is swamped by N× full re-prefill. Batching only pays where decode dominates or prefixes are cold-unique.

Implication for the B-track fork: the actionable lever for parallel sub-agents is **prefix-cache-aware admission (share the prefill) — not the current batch path**; spec-in-batch would additionally need prefix reuse to beat serialize at all on this traffic. Relates to #117 (the RAM tier is what made serialize's fan-out TTFT ~0.3s) and the closed #6.

Repro recipe in `tools/opencode-repro/README.md`. Captured trace (contains prompts) deliberately not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)