### PR TITLE
feat(spec): mechanical speculation gate — fix long-context decode collapse (#119)

### DIFF
--- a/swift/Sources/QwispCore/Tell.swift
+++ b/swift/Sources/QwispCore/Tell.swift
@@ -30,6 +30,53 @@ public enum Tell {
     /// per process (env-in-loop is 18.8µs, fusion doctrine).
     static let suffixMinMatch = Swift.max(1, Tell.envInt("QWISP_SUFFIX_MINMATCH", 4))
 
+    // ── #119: mechanical speculation gate ────────────────────────────────────────
+    // A draft attempt runs the f32 strict verify, whose cost is ~linear in context
+    // (measured 288ms/attempt @14K → 878ms @48K), while a chain step costs 17→29ms.
+    // Break-even is ~17 accepted tokens/attempt @14K, ~30 @48K; low-accept agentic
+    // regimes deliver 4-5 — every attempt is a net loss and decode collapses (issue
+    // #119: 6-7 tok/s at 48K; gate off/on measured 18.8 → 38 tok/s). The gate is
+    // mechanical (rolling measured accept, no prediction): suspend drafting when the
+    // rolling mean accepted-per-attempt is below a ctx-scaled threshold, re-probe
+    // after specGateReprobe emitted tokens. The window is NOT cleared on suspension,
+    // so a still-bad regime re-suspends after a single probe attempt. Greedy chain is
+    // the reference path — gating changes speed only, the token stream is unchanged.
+    // QWISP_SPEC_GATE=0 opts out (always draft, pre-#119 behavior).
+    static let specGateWindow = 8
+    static var specGateEnabled: Bool { envInt("QWISP_SPEC_GATE", 1) != 0 }
+    static var specGateReprobe: Int { Swift.max(8, envInt("QWISP_SPEC_REPROBE", 256)) }
+    /// Conservative floor of the measured break-even curve (errs toward keeping spec on).
+    static func specGateThreshold(histLen: Int) -> Int { 4 + histLen / 3000 }
+    /// Evidence needed before suspending shrinks as context grows: an attempt's waste is
+    /// ctx-linear (~900ms @48K) while a false suspension costs only one re-probe span, so
+    /// at long ctx a single sub-threshold attempt suffices; short ctx demands a full window.
+    static func specGateWindowNeeded(histLen: Int) -> Int { Swift.max(1, specGateWindow - histLen / 6000) }
+    static func specGateShouldSuspend(window: [Int], histLen: Int) -> Bool {
+        window.count >= specGateWindowNeeded(histLen: histLen)
+            && window.reduce(0, +) < specGateThreshold(histLen: histLen) * window.count
+    }
+
+    /// Pure self-check (no GPU) for the gate arithmetic.
+    public static func specGateSelfCheck() -> [(String, Bool)] {
+        let bad = Array(repeating: 4, count: specGateWindow)      // 4 acc/attempt
+        let good = Array(repeating: 20, count: specGateWindow)
+        return [
+            ("threshold_short", specGateThreshold(histLen: 2000) == 4),
+            ("threshold_14k", specGateThreshold(histLen: 14000) == 8),
+            ("threshold_48k", specGateThreshold(histLen: 48000) == 20),
+            ("window_short_full", specGateWindowNeeded(histLen: 0) == 8),
+            ("window_14k", specGateWindowNeeded(histLen: 14000) == 6),
+            ("window_48k_single", specGateWindowNeeded(histLen: 48000) == 1),
+            ("suspend_one_bad_long", specGateShouldSuspend(window: [4], histLen: 48000)),
+            ("suspend_bad_long", specGateShouldSuspend(window: bad, histLen: 48000)),
+            ("keep_good_long", !specGateShouldSuspend(window: good, histLen: 48000)),
+            ("keep_one_good_long", !specGateShouldSuspend(window: [24], histLen: 48000)),
+            ("keep_bad_short", !specGateShouldSuspend(window: bad, histLen: 0)),   // 4 ≥ threshold 4
+            ("no_suspend_before_window_short", !specGateShouldSuspend(window: [0], histLen: 0)),
+            ("rolling_recovers", !specGateShouldSuspend(window: Array(bad.dropFirst(4)) + [40, 40, 40, 40], histLen: 48000)),
+        ]
+    }
+
     /// suffix lookup draft（SuffixDecoding-style, 訓練不要・cost ~0）:
     /// 1) seq 末尾の m token(minMatch..maxMatch の最長一致)が seq 内の earlier 位置に出現する
     ///    「全ての」出現位置を収集（旧: 最近 1 箇所のみ）。

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -675,10 +675,27 @@ extension Tell {
         // Set by the streaming backend when the consumer drops the stream, so an
         // aborted request stops at the next spec-step boundary instead of running
         // to N and orphaning the GPU (see SeedlessBackend.generate).
+        // #119: env-gated per-step wall-time buckets (QWISP_SPEC_PROFILE=1). Flag off →
+        // no Date() calls on the hot path, loop byte-identical.
+        let prof = Tell.envFlag("QWISP_SPEC_PROFILE")
+        var pfDraft = 0.0, pfChain = 0.0, pfVerify = 0.0, pfRebuild = 0.0
+        var pfChainCalls = 0
+        let tLoop0 = Date()
+
+        // #119 speculation gate state (see Tell.specGate*): rolling accepted-per-attempt
+        // window + suspension horizon in emitted tokens. A3 keeps the ungated path (opt-in
+        // research mode; the server decode path is non-A3).
+        let gateOn = Tell.specGateEnabled && !useA3
+        var gateWindow: [Int] = []
+        var gateSuspendedUntil = -1
+
         while out.count < N && !(isCancelled?() ?? false) {
             flush()
-            var drafts = Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: Tell.suffixMinMatch,
-                                          traceAlts: Tell.traceAltsEnabled)
+            let tD = prof ? Date() : Date.distantPast
+            var drafts = (gateOn && out.count < gateSuspendedUntil) ? []
+                : Tell.suffixDraft(hist + [u], maxMatch: 32, draftK: maxK, minMatch: Tell.suffixMinMatch,
+                                   traceAlts: Tell.traceAltsEnabled)
+            if prof { pfDraft += Date().timeIntervalSince(tD) * 1000 }
             // #98 DFlash: only when SuffixSpec found nothing (draftless span) and not under A3
             // (dflash is inactive there — see dflashHarvest). Falls back to the old per-step
             // path on nil (cold start / any failure), unchanged behavior.
@@ -706,8 +723,10 @@ extension Tell {
                 // empty-pending greedy span. Chained tokens skip drafting opportunities for
                 // those positions — at d0≈90% almost always free. nil chain fn / failed call
                 // → fall through to per-step.
+                let tC = prof ? Date() : Date.distantPast
                 if chainK > 0, (!useA3 || pending.isEmpty), let chainFn = backend.chainedStepArgmax,
                    let chainResult = chainFn(Int32(u), chainK), !chainResult.isEmpty {
+                    if prof { pfChain += Date().timeIntervalSince(tC) * 1000; pfChainCalls += 1 }
                     out.append(u); hist.append(u)
                     let addN = Swift.min(chainResult.count - 1, N - out.count)
                     for i in 0 ..< addN {
@@ -725,7 +744,9 @@ extension Tell {
                     u = evals[pk]  // next token after pending+u (pk = position of u)
                     pending = []
                 } else {
+                    let tV = prof ? Date() : Date.distantPast
                     guard let evals = backend.stepArgmax([Int32(u)]) else { return nil }
+                    if prof { pfVerify += Date().timeIntervalSince(tV) * 1000 }
                     out.append(u); hist.append(u)
                     dflashHarvest(1)
                     u = evals[0]
@@ -775,14 +796,26 @@ extension Tell {
                 if let fe = fusedEvals {
                     evals = fe
                 } else {
+                    let tV = prof ? Date() : Date.distantPast
                     let verifyTokens: [Int32] = [Int32(u)] + drafts.map { Int32($0) }
                     guard let e = backend.stepArgmax(verifyTokens) else { return nil }
+                    if prof { pfVerify += Date().timeIntervalSince(tV) * 1000 }
                     evals = e
                 }
 
                 var p = 0
                 while p < D && drafts[p] == evals[p] { p += 1 }
                 stAccepted += p
+                // #119 gate: record this attempt's yield; suspend drafting when the rolling
+                // mean falls under the ctx-scaled break-even. Window survives suspension →
+                // a still-bad regime re-suspends after one probe attempt.
+                if gateOn {
+                    gateWindow.append(p)
+                    if gateWindow.count > Tell.specGateWindow { gateWindow.removeFirst() }
+                    if Tell.specGateShouldSuspend(window: gateWindow, histLen: hist.count) {
+                        gateSuspendedUntil = out.count + Tell.specGateReprobe
+                    }
+                }
                 dflashHarvest(p + 1)   // rows 0..p = [u]+accepted drafts (both branches below)
 
                 if p == D {
@@ -796,17 +829,28 @@ extension Tell {
                     stRejects += 1
                     if Tell.traceAltsEnabled, p < Tell.lastDraftAlts.count,
                        Tell.lastDraftAlts[p] == evals[p] { stAltHits += 1 }
+                    let tR = prof ? Date() : Date.distantPast
                     backend.rollback(snap)
                     out.append(u); hist.append(u)
                     for d in drafts.prefix(p) { out.append(d); hist.append(d) }
                     let rebuildTokens: [Int32] = [Int32(u)] + drafts.prefix(p).map { Int32($0) }
                     guard let _ = backend.forward(rebuildTokens) else { return nil }
+                    if prof { pfRebuild += Date().timeIntervalSince(tR) * 1000 }
                     u = evals[p]
                 }
             }
         }
         flush()
         Tell.lastSpecStats = (stSteps, stDrafted, stAccepted, stD0, stRejects, stAltHits)
+        if prof {
+            let total = Date().timeIntervalSince(tLoop0) * 1000
+            let other = total - pfDraft - pfChain - pfVerify - pfRebuild
+            FileHandle.standardError.write(Data(String(format:
+                "[spec-profile] hist0=%d gen=%d steps=%d chainCalls=%d | total %.0fms = draft %.0f + chain %.0f + verify %.0f + rebuild %.0f + other %.0f | ms/tok %.1f\n",
+                promptIds.count, out.count, stSteps, pfChainCalls,
+                total, pfDraft, pfChain, pfVerify, pfRebuild, other,
+                out.isEmpty ? 0 : total / Double(out.count)).utf8))
+        }
         return Array(out.prefix(N))
     }
 

--- a/swift/Sources/qwisp/Selftest.swift
+++ b/swift/Sources/qwisp/Selftest.swift
@@ -98,6 +98,9 @@ func runCompletionSelftest(modelDir: String) async -> String {
     // prefix-cache RAM tier (issue #117; pure keyed-store checks, no GPU).
     for (name, ok) in PrefixRAMStore.selfCheck() { check("prefixram_\(name)", ok) }
 
+    // speculation gate arithmetic (issue #119; pure, no GPU).
+    for (name, ok) in Tell.specGateSelfCheck() { check("specgate_\(name)", ok) }
+
     // continuous-batching scheduler (issue #6; pure logic over a scripted fake engine).
     for (name, ok) in ContinuousScheduler.selfCheck() { check("batch_\(name)", ok) }
 


### PR DESCRIPTION
Closes #119

## Root cause (measured, not conjectured)

New `QWISP_SPEC_PROFILE=1` per-step wall-time buckets in `runSpecLoop` (draft / chain / verify / rebuild), driven through the real server path with natural-text prompts:

| regime | ctx | ms/tok | verify | rebuild | decode |
|---|---|---|---|---|---|
| drafts rarely fire (d0=95%) | 44.5K | 32.5 | 641ms | 73ms | 33.1 tok/s |
| draft-heavy (agentic-style repetition) | 14K | 23.6 | 1154ms | 217ms | 46.0 |
| draft-heavy | 47.8K | 55.3 | **4389ms** | **1368ms** | **18.8** |

The forward path is innocent (probes in `973b453`: raw M=1 @49K = 36 tok/s). The collapse is the **speculation economics**: each SuffixSpec attempt pays the f32 strict verify, whose cost is ~linear in context (288ms/attempt @14K → 878ms @48K, ~14x the f16 forward probe), plus a rebuild on reject. Break-even ≈ 17 accepted tokens/attempt @14K, ≈ 30 @48K; repetitive agentic history with accept 16-29% delivers 4-5 — **every attempt is a net loss**. Production's 6-7 tok/s = this regime with longer drafts (maxK 96).

**A/B proof**: same 47.8K draft-heavy request with drafts disabled (`QWISP_SUFFIX_MINMATCH=99`): 18.8 → **38.0 tok/s**. Chain is the reference greedy path — skipping speculation is lossless by construction.

## Fix: mechanical gate (doctrine: mechanical levers, cliff-detect + re-arm — same shape as the #47 guard)

Rolling accepted-per-attempt window; suspend drafting when the mean falls below a ctx-scaled break-even floor (`4 + hist/3000`), re-probe after 256 emitted tokens. Two structural points:

- **Evidence needed shrinks with context** (`window 8 → 1 @48K`): an attempt's waste is ctx-linear (~900ms @48K) while a false suspension costs only one re-probe span. This matters — a fixed window of 8 never fills in a 160-token response (first E2E attempt proved it: gate inert, 18.6 tok/s unchanged).
- **Window survives suspension**, so a still-bad regime re-suspends after a single probe attempt (~900ms per 256-token span = the whole adaptivity cost).

Default ON; `QWISP_SPEC_GATE=0` restores pre-#119 behavior. A3 (opt-in research path) ungated.

## Results

- E2E collapse regime (47.8K draft-heavy): **18.6 → 32.0 tok/s (+72%)**, spec-profile shows exactly one probe attempt paid; remaining upside to the 38 tok/s chain floor is the designed probe amortization (improves on longer generations).
- Output **byte-identical** to the ungated stream (greedy chain = reference).
- Short-ctx spec upside preserved: threshold 4 @2K, full window of evidence required — high-accept regimes (fusion-era code +36%) never suspend.
- Gates: RAWTESTS 98/98, COMPTEST 54/54 (13 new pure gate checks), BENCHBATCHTEST PASS, TOKTEST 5/5.

## Also in this PR

`QWISP_SPEC_PROFILE=1` instrumentation itself (env-gated, flag-off path byte-identical) — the tool that found the root cause, kept for future regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)