### PR TITLE
docs(poc): measurement catalog — QWISP_RUN=list + symptom→probe guide

### DIFF
--- a/docs/measurement.md
+++ b/docs/measurement.md
@@ -1,0 +1,78 @@
+# Measurement guide — which probe answers which question
+
+qwisp is measurement-driven: every speed/lossless claim traces to a runner. This page maps
+**symptom → the probe that answers it**. The full runner catalog with one-line descriptions:
+`QWISP_RUN=list qwisp-poc stream` (no GPU needed for the listing itself).
+
+All runners: `QWISP_RUN=<name> qwisp-poc stream`, model via `QWISP_MODEL` (defaults to the
+Qwen3.6-35B MTPLX path). **The GPU is exclusive — never run two GPU processes (check
+`ps aux | grep -E "qwisp serve|qwisp-poc"` and stop the brew service first).**
+
+## Correctness (green = safe to commit)
+
+| gate | command |
+|---|---|
+| engine kernels lossless (no model) | `scripts/test_raw.sh` → RAWTESTS N/N |
+| completion core + pure logic (no GPU) | `scripts/test_completion.sh` → COMPTEST |
+| bench harness fixture (no GPU) | `scripts/test_bench_batch.sh` |
+| tokenizer round-trip (no GPU) | `scripts/test_tokenizer.sh` |
+| prefix cache lossless (all tiers) | `QWISP_RUN=prefix-cache-e2e` (+`QWISP_PREFIX_E2E_C=<c>` streaming), `prefix-ram-e2e`, `prefix-persist-e2e`, `prefix-bolt-e2e` |
+
+A red strict-fidelity cell on longctx/shortnl after a fresh checkout is usually missing
+`refs/` (gitignored) — regenerate from Swift raw greedy, never from MLX.
+
+## "Decode got slow" / long-context regressions
+
+1. **Real request, real path first**: `QWISP_SPEC_PROFILE=1` on `qwisp serve`, replay the
+   offending request → one stderr line per generation:
+   `[spec-profile] ... total = draft + chain + verify + rebuild + other`.
+   - verify+rebuild dominates → speculation economics (see #119 / the spec gate; check
+     accept in the serve log's `spec[...]` field). draft dominates → suffixDraft scan.
+     chain ≈ total → the forward itself; go to 2.
+2. **Forward physics by context**: `QWISP_RUN=long-context-decay` — per-stage
+   (GDN/attn/MoE) GPU ms for prefill chunks by position AND M=1 decode steps by context.
+   attn linear in ctx with flat GDN/MoE = fundamental full-attention O(N), not a bug.
+3. **Is a wider verify worth it?** `QWISP_RUN=spec-width` (`QWISP_SPEC_CTX=<n>`) — stage
+   ms by draft width M. `seqmt-m` for the r_M scaling view.
+4. **Shipping-config tok/s + fidelity cells**: `scripts/bench_batch.sh` (strict/bolt ×
+   4 regimes; needs refs).
+
+Known verdicts before re-measuring: forward is near-optimal (M=1 @49K ≈ 36 tok/s
+resident); the 48K collapse was speculation waste, fixed by the accept-driven gate
+(`QWISP_SPEC_GATE=0` restores old behavior for A/B). Synthetic periodic prompts give
+SuffixSpec unrealistically high accept — reproduce with natural text + repetitive tails.
+
+## "TTFT / prefill is slow"
+
+1. **Which kind of slow?** The serve log prints `prefill=<tok/s> ttft=<ms>` per request
+   and `prefill a/b (x%) · r tok/s` progress lines. Low reuse on a warm server →
+   prefix-cache miss (conversation switch? check `prompt=` sizes interleaving);
+   cold-prefill rate itself low → kernel/position physics.
+2. `QWISP_RUN=prefix-cache-speed` — TTFT cold vs cross-conversation vs intra.
+3. `QWISP_RUN=prefill-probe` (chunk-size sweep: overhead- vs compute-bound),
+   `prefill-breakdown` (wall vs GPU = dispatch/sync tax),
+   `prefill-stage-profile` (per-stage + MLX matrix-unit reference),
+   `hybrid-estimate` / `hybrid-prefill-bench` (steel-hybrid lever).
+4. Position decay (348→66 tok/s over 0→40K) is fundamental full-attn O(N) — the
+   mitigation is cache reuse (#117/#118), not kernel work.
+
+## Server / harness behavior (OpenCode etc.)
+
+- Wire-level ground truth + concurrent replay + identity/throughput diff:
+  `tools/opencode-repro/` (capture proxy → replay serial/concurrent → diff). This is the
+  acceptance gate for admission/batching work (#121).
+- Per-request serve log fields: `prompt= prefill= gen= ttft= decode= spec[steps tok/step
+  accept d0 rej]`.
+
+## Kernel micro-benchmarks (no model)
+
+`grouped-moe-bench`, `dense-tiled-bench`, `steel-route-bench`, `gqmm2-bench`,
+`mlx-qmm-minv` (bit-stability of MLX kernel switches by M).
+
+## Adding a new probe
+
+One entry in the `runners` registry (`swift/Sources/qwisp-poc/main.swift`) with a one-line
+desc — it appears in `QWISP_RUN=list` automatically. Put the implementation next to its
+subject (e.g. prefix probes in PrefixCachePoC.swift). Add a row here only if it answers a
+recurring symptom. Measure-first doctrine: a probe that answered a question is kept — it
+is the regression tool for the next time the number moves.

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -16,37 +16,70 @@ if CommandLine.arguments.contains("stream") {
     let env = ProcessInfo.processInfo.environment
     let mtpRef = env["QWISP_MTP_REF"] ?? "/tmp/qwisp_mtp_ref.safetensors"
 
-    // Gate / bench entry points:
-    //   test_raw.sh      → QWISP_RUN=raw-tests (SeedlessVerifyTests, the correctness gate)
-    //   bench_batch.sh   → QWISP_RUN=raw-spec  (Tell.run, strict/bolt)
-    let runners: [(String, (String, String) throws -> String)] = [
-        ("raw-tests", { _, _ in SeedlessVerifyTests.runAll() }),
-        ("raw-spec",  { try Tell.run(modelDir: $0, refPath: $1) }),
-        ("prefix-cache-poc", { md, _ in Tell.prefixCachePoC(modelDir: md) }),
-        ("prefill-breakdown", { md, _ in Tell.prefillBreakdownProbe(modelDir: md) }),
-        ("prefill-stage-profile", { md, _ in Tell.prefillStageProfile(modelDir: md) }),
-        ("grouped-moe-bench", { _, _ in GroupedMoEPoC.bench() }),
-        ("dense-tiled-bench", { _, _ in GroupedMoEPoC.denseBench() }),
-        ("mlx-qmm-minv", { md, _ in Tell.mlxQmmInvariance(modelDir: md) }),
-        ("steel-route-bench", { _, _ in GroupedMoEPoC.steelRouteBench() }),
-        ("hybrid-estimate", { md, _ in Tell.hybridEstimate(modelDir: md) }),
-        ("hybrid-prefill-bench", { md, _ in Tell.hybridPrefillBench(modelDir: md) }),
-        ("prefix-cache-e2e", { md, _ in Tell.prefixCacheE2E(modelDir: md) }),
-        ("prefix-persist-e2e", { md, _ in Tell.prefixPersistE2E(modelDir: md) }),   // #89 restart gate
-        ("prefix-ram-e2e", { md, _ in Tell.prefixRAME2E(modelDir: md) }),           // #117 RAM-tier gate
-        ("prefix-bolt-e2e", { md, _ in Tell.prefixBoltE2E(modelDir: md) }),         // #76 bolt-side gate
-        ("seqmt-m", { md, _ in Tell.seqMTScalingProbe(modelDir: md) }),             // #90 Step 0 probe
-        ("prefix-cache-speed", { md, _ in Tell.prefixCacheSpeedProbe(modelDir: md) }),
-        ("prefill-probe", { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),
-        ("long-context-decay", { md, _ in Tell.longContextDecayProbe(modelDir: md) }), // #117 follow-up profiling
-        ("spec-width", { md, _ in Tell.specWidthProbe(modelDir: md) }),             // #117 verify-width scaling
-        ("gqmm2-bench", { _, _ in SeedlessMetalForward.gqmm2Bench() }),   // notes/18 W1 speed sim
+    // Measurement runner registry — ONE entry per metric. `QWISP_RUN=list` prints this
+    // catalog; docs/measurement.md maps symptoms → runners. Format: (name, "what it
+    // answers · requirements · knobs", closure). Keep descriptions to one line.
+    struct Runner { let name: String; let desc: String; let run: (String, String) throws -> String }
+    let runners: [Runner] = [
+        // ── correctness gates (green = safe to commit) ──
+        Runner(name: "raw-tests", desc: "RAWTESTS lossless gate (engine kernels; GPU, no model) — scripts/test_raw.sh",
+               run: { _, _ in SeedlessVerifyTests.runAll() }),
+        Runner(name: "prefix-cache-e2e", desc: "prefix cache lossless: reuse/extend/cross/reset byte-compare vs cache-off (#76; GPU+model; QWISP_PREFIX_E2E_C=<c> for streaming)",
+               run: { md, _ in Tell.prefixCacheE2E(modelDir: md) }),
+        Runner(name: "prefix-persist-e2e", desc: "disk-persist restart lossless gate (#89; GPU+model)",
+               run: { md, _ in Tell.prefixPersistE2E(modelDir: md) }),
+        Runner(name: "prefix-ram-e2e", desc: "RAM-tier conversation-switch lossless gate + ramHits assertions (#117; GPU+model)",
+               run: { md, _ in Tell.prefixRAME2E(modelDir: md) }),
+        Runner(name: "prefix-bolt-e2e", desc: "bolt prompt-prefix blob reuse byte-identity (#76 bolt side; GPU+model)",
+               run: { md, _ in Tell.prefixBoltE2E(modelDir: md) }),
+        // ── decode speed (regressions, long-context) ──
+        Runner(name: "raw-spec", desc: "shipping decode bench, strict/bolt tok/s + token dump (GPU+model+refs) — bench_batch.sh cell",
+               run: { try Tell.run(modelDir: $0, refPath: $1) }),
+        Runner(name: "long-context-decay", desc: "per-stage (GDN/attn/MoE) GPU ms: prefill chunks by position + M=1 decode by ctx up to 48K (#119; QWISP_DECAY_MAX)",
+               run: { md, _ in Tell.longContextDecayProbe(modelDir: md) }),
+        Runner(name: "spec-width", desc: "verify forward stage ms by draft width M at fixed ctx (#119; QWISP_SPEC_CTX) — is speculation paying?",
+               run: { md, _ in Tell.specWidthProbe(modelDir: md) }),
+        Runner(name: "seqmt-m", desc: "M-row verify scaling r_M (#90) — cost of widening the verify",
+               run: { md, _ in Tell.seqMTScalingProbe(modelDir: md) }),
+        // ── prefill / TTFT ──
+        Runner(name: "prefill-probe", desc: "prefill tok/s by chunk size (overhead- vs compute-bound discriminator)",
+               run: { md, _ in Tell.prefillThroughputProbe(modelDir: md) }),
+        Runner(name: "prefill-breakdown", desc: "prefill wall vs GPU time split (dispatch/sync tax; chunk + floor variants)",
+               run: { md, _ in Tell.prefillBreakdownProbe(modelDir: md) }),
+        Runner(name: "prefill-stage-profile", desc: "per-stage prefill GPU ms (GDN/attn/MoE) + MLX matrix-unit reference (QWISP_PREFILL_LEN)",
+               run: { md, _ in Tell.prefillStageProfile(modelDir: md) }),
+        Runner(name: "hybrid-estimate", desc: "steel-hybrid prefill win estimate (analytic, cheap)",
+               run: { md, _ in Tell.hybridEstimate(modelDir: md) }),
+        Runner(name: "hybrid-prefill-bench", desc: "steel-hybrid prefill measured tok/s vs baseline",
+               run: { md, _ in Tell.hybridPrefillBench(modelDir: md) }),
+        Runner(name: "prefix-cache-speed", desc: "TTFT cold vs cross-conversation vs intra-conversation (QWISP_PREFIX_SHARED)",
+               run: { md, _ in Tell.prefixCacheSpeedProbe(modelDir: md) }),
+        Runner(name: "prefix-cache-poc", desc: "snapshot/restore byte-identity micro-PoC (design validation, pre-e2e)",
+               run: { md, _ in Tell.prefixCachePoC(modelDir: md) }),
+        // ── kernel micro-benchmarks (no model) ──
+        Runner(name: "grouped-moe-bench", desc: "grouped MoE expert kernel micro-bench",
+               run: { _, _ in GroupedMoEPoC.bench() }),
+        Runner(name: "dense-tiled-bench", desc: "dense tiled matmul micro-bench",
+               run: { _, _ in GroupedMoEPoC.denseBench() }),
+        Runner(name: "steel-route-bench", desc: "steel routing kernel micro-bench",
+               run: { _, _ in GroupedMoEPoC.steelRouteBench() }),
+        Runner(name: "gqmm2-bench", desc: "gqmm 2-bit kernel micro-bench (notes/18 W1)",
+               run: { _, _ in SeedlessMetalForward.gqmm2Bench() }),
+        Runner(name: "mlx-qmm-minv", desc: "MLX qmm M-invariance check (kernel-switch bit stability)",
+               run: { md, _ in Tell.mlxQmmInvariance(modelDir: md) }),
     ]
+    func catalog() -> String {
+        "QWISP_RUN catalog (see docs/measurement.md for symptom → runner):\n"
+            + runners.map { "  " + $0.name.padding(toLength: 22, withPad: " ", startingAt: 0) + $0.desc }.joined(separator: "\n")
+            + "\n  server-side: QWISP_SPEC_PROFILE=1 on serve = per-step decode buckets (draft/chain/verify/rebuild)"
+    }
     if let name = env["QWISP_RUN"] {
-        if let r = runners.first(where: { $0.0 == name }) {
-            do { print(try r.1(md, mtpRef)) } catch { print("[\(name)] error: \(error)") }
+        if name == "list" {
+            print(catalog())
+        } else if let r = runners.first(where: { $0.name == name }) {
+            do { print(try r.run(md, mtpRef)) } catch { print("[\(name)] error: \(error)") }
         } else {
-            print("unknown QWISP_RUN=\(name)\n  available: \(runners.map { $0.0 }.joined(separator: ", "))")
+            print("unknown QWISP_RUN=\(name)\n" + catalog())
         }
         exit(0)
     }


### PR DESCRIPTION
Part 2 of the recent-PR cleanup (stacked on #123 — merge that first; this PR's base is `claude/remove-dflash` and will be retargeted to main after #123 lands).

## What

The 21 measurement runners existed but were undiscoverable (bare name list on a typo). Now:

- **`QWISP_RUN=list`** prints a grouped catalog: every runner with one line of "what it answers · requirements (GPU/model/refs) · env knobs". Unknown runner names print the catalog instead of just the name list. Registry is the single source of truth — adding a probe = one entry, it appears in `list` automatically.
- **`docs/measurement.md`** — the symptom→probe map: "decode got slow" (server `QWISP_SPEC_PROFILE=1` buckets → `long-context-decay` → `spec-width`), "TTFT slow" (log fields → `prefix-cache-speed` → prefill probes), correctness gate table, and the **measured verdicts to check before re-measuring** (forward near-optimal at 49K, spec-gate history, the synthetic-periodic-prompt trap) so closed questions don't get re-opened by accident.

Also fixes a segfault in the new list path (`String(format: "%s")` with a Swift String).

Gates: RAWTESTS 89/89 · COMPTEST 54/54 · BENCHBATCHTEST PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)