### PR TITLE
feat(server): stable-prefix persist (#112) + batch workload guard (#121)

### DIFF
--- a/docs/measurement.md
+++ b/docs/measurement.md
@@ -16,7 +16,7 @@ Qwen3.6-35B MTPLX path). **The GPU is exclusive — never run two GPU processes 
 | completion core + pure logic (no GPU) | `scripts/test_completion.sh` → COMPTEST |
 | bench harness fixture (no GPU) | `scripts/test_bench_batch.sh` |
 | tokenizer round-trip (no GPU) | `scripts/test_tokenizer.sh` |
-| prefix cache lossless (all tiers) | `QWISP_RUN=prefix-cache-e2e` (+`QWISP_PREFIX_E2E_C=<c>` streaming), `prefix-ram-e2e`, `prefix-persist-e2e`, `prefix-bolt-e2e` |
+| prefix cache lossless (all tiers) | `QWISP_RUN=prefix-cache-e2e` (+`QWISP_PREFIX_E2E_C=<c>` streaming), `prefix-ram-e2e`, `prefix-persist-e2e`, `prefix-stable-e2e`, `prefix-bolt-e2e` |
 
 A red strict-fidelity cell on longctx/shortnl after a fresh checkout is usually missing
 `refs/` (gitignored) — regenerate from Swift raw greedy, never from MLX.

--- a/swift/Sources/QwispCore/ContinuousBatch.swift
+++ b/swift/Sources/QwispCore/ContinuousBatch.swift
@@ -268,7 +268,27 @@ public final class BatchBackend: LLMBackend, @unchecked Sendable {
         self.contextLen = SeedlessBackend.readContextLen(modelDir)
     }
 
+    // #121 workload guard: batch admits pay a FULL prefill per request (no prefix cache,
+    // no SuffixSpec). On agentic-harness traffic — consecutive prompts sharing a large
+    // system+tools prefix — this measured 2.6x SLOWER than the default serialize path
+    // (and diverges: MLX f16 near-tie flips). Detect that signature and say so once.
+    private var lastPromptHead: [Int] = []
+    private var sharedPrefixSeen = 0
+    private var warnedSharedPrefix = false
+
     public func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncStream<Int> {
+        if !warnedSharedPrefix {
+            let head = Array(prompt.prefix(4096))
+            var lcp = 0
+            while lcp < head.count && lcp < lastPromptHead.count && head[lcp] == lastPromptHead[lcp] { lcp += 1 }
+            lastPromptHead = head
+            if lcp >= 1024 { sharedPrefixSeen += 1 }
+            if sharedPrefixSeen >= 2 {
+                warnedSharedPrefix = true
+                FileHandle.standardError.write(Data(
+                    "[qwisp] NOTE: requests share large prompt prefixes (agentic-harness signature). QWISP_BATCH re-prefills every request and loses ~2.6x to the default mode on this traffic (issue #121) — unset QWISP_BATCH unless you need multi-user cold-prompt throughput.\n".utf8))
+            }
+        }
         let headroom = Swift.max(0, contextLen - prompt.count)
         let ceiling = options.maxTokens < 0 ? headroom : Swift.min(options.maxTokens, headroom)
         return scheduler.submit(prompt: prompt, maxTokens: ceiling, stopIds: options.stopTokens)

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -492,7 +492,7 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                     }
                 } else if restoreLen > 0, let s = self.prefixSlots.last(where: { $0.len == restoreLen })?.snap {
                     backend.fullRestore?(s)
-                } else if PrefixPersist.enabled,
+                } else if PrefixPersist.lookupEnabled,
                           let hit = PrefixPersist.bestMatch(modelDir: self.modelDir, content: content),
                           backend.restorePersistentState?(hit.state) == true {
                     // #89 (opt-in): no in-memory restore point — cross-process warm start from
@@ -509,6 +509,25 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                     backend.fullRestore?(e)
                 }
                 self.prefixSlots.removeAll { $0.len > Swift.max(lcp, restoreLen) }
+                // #112 stable-prefix persist: divergence from the arena path (= a NEW
+                // conversation) that still shares a ≥stableMinTokens restore point is
+                // recurrence evidence — the shared block is the harness system+tools
+                // prefix. The arena is exactly at restoreLen here, so persistentState()
+                // captures the stable boundary with zero extra prefill. has() gates the
+                // (expensive) state copy to once per key; save() dedupes re-writes, so
+                // the #89 per-turn wear cannot occur. restoreLen ≤ lcp excludes RAM-tier
+                // whole-conversation restores (those are not shared-prefix evidence).
+                if PrefixPersist.stableEnabled, lcp < self.arenaContent.count,
+                   restoreLen >= PrefixPersist.stableMinTokens, restoreLen <= lcp {
+                    let toks = Array(content[0 ..< restoreLen])
+                    if !PrefixPersist.has(modelDir: self.modelDir, tokens: toks),
+                       let blob = backend.persistentState?() {
+                        let model = self.modelDir
+                        DispatchQueue.global(qos: .utility).async {
+                            PrefixPersist.save(modelDir: model, tokens: toks, state: blob)
+                        }
+                    }
+                }
 
                 // Re-prefill the delta [restoreLen ..< contentLen], snapshotting at stride-aligned
                 // boundaries (so different conversations that share a prefix snapshot at the SAME

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -334,6 +334,75 @@ extension Tell {
         return lines.joined(separator: "\n")
     }
 
+    // #112 gate: stable-prefix persist. Conversation A warms the arena; conversation B
+    // (same ≥1024-token "harness prefix", different tail) diverges → the recurrence
+    // trigger persists the shared restore point ONCE to disk. resetPrefixCache() (=
+    // process restart: arena, slots, and the RAM tier all die) then conversation C with
+    // the same prefix must warm-start from the DISK entry (restoreHits asserts the
+    // restore fired) and stream byte-identical to the cache-off path. Also asserts the
+    // store holds exactly ONE file (recurrence writes once — no per-turn wear).
+    public static func prefixStableE2E(modelDir: String) -> String {
+        let ec = Tell.envInt("QWISP_PREFIX_E2E_C", 0)
+        let tier: SeedlessTier = ec > 0 ? .streaming(c: ec) : .auto
+        guard let backend = try? SeedlessBackend(modelDir: modelDir, tier: tier) else { return "[prefix-stable-e2e] load fail\nPREFIXSTABLEE2E FAIL" }
+        if ec > 0 { backend.losslessForced = true }
+        let store = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("qwisp-prefix-stable-e2e-\(ProcessInfo.processInfo.processIdentifier)")
+        setenv("QWISP_PREFIX_PERSIST_DIR", store.path, 1)
+        setenv("QWISP_PREFIX_SNAP_STRIDE", "512", 1)   // slots inside the 1200-token prefix
+        defer { unsetenv("QWISP_PREFIX_PERSIST_DIR"); try? FileManager.default.removeItem(at: store) }
+
+        func toks(_ n: Int, _ salt: Int) -> [Int] { (0..<n).map { (($0 &* 7 &+ salt) % 5000) + 100 } }
+        let shared = toks(1200, 13)                    // ≥ stableMinTokens at a 1024 slot boundary
+        let cA = shared + toks(48, 1)
+        let cB = shared + toks(48, 2)                  // recurrence: same prefix, new conversation
+        let cC = shared + toks(48, 3)                  // post-"restart" conversation
+        func req(_ content: [Int]) -> (prompt: [Int], cl: Int) { (content + toks(8, 777), content.count) }
+        let maxTok = 24
+
+        final class Box: @unchecked Sendable { var v: [Int] = [] }
+        func gen(_ p: [Int], _ cl: Int) -> [Int] {
+            let box = Box()
+            let sem = DispatchSemaphore(value: 0)
+            let stream = backend.generate(p, options: GenerateOptions(maxTokens: maxTok, promptContentLen: cl))
+            Task { for await t in stream { box.v.append(t) }; sem.signal() }
+            sem.wait()
+            return box.v
+        }
+        func binCount() -> Int {
+            (try? FileManager.default.contentsOfDirectory(atPath: store.path).filter { $0.hasSuffix(".bin") }.count) ?? 0
+        }
+
+        backend.prefixCacheForced = false
+        let refs = [req(cA), req(cB), req(cC)].map { gen($0.prompt, $0.cl) }
+        backend.prefixCacheForced = true
+        backend.resetPrefixCache()
+        let gotA = gen(req(cA).prompt, req(cA).cl)                 // cold, warms the arena path
+        let filesAfterA = binCount()
+        let gotB = gen(req(cB).prompt, req(cB).cl)                 // divergence → stable persist fires
+        var waited = 0.0                                            // async write → poll
+        while waited < 15, binCount() == 0 { Thread.sleep(forTimeInterval: 0.2); waited += 0.2 }
+        let filesAfterB = binCount()
+        backend.resetPrefixCache()                                  // "restart": only the disk survives
+        let hits0 = PrefixPersist.restoreHits
+        let gotC = gen(req(cC).prompt, req(cC).cl)
+        let diskRestored = PrefixPersist.restoreHits > hits0
+        let filesAfterC = binCount()
+
+        var lines = ["[prefix-stable-e2e] shared=1200tok, stride=512, tier=\(ec > 0 ? "streaming C=\(ec)" : "resident")"]
+        var pass = true
+        func check(_ name: String, _ ok: Bool, _ detail: String) {
+            pass = pass && ok
+            lines.append("  \(name)  \(detail)  \(ok ? "✅" : "❌")")
+        }
+        check("R1 A cold      ", refs[0] == gotA && filesAfterA == 0, "identical=\(refs[0] == gotA) files=\(filesAfterA) (want 0 — one conversation is no evidence)")
+        check("R2 B recurrence", refs[1] == gotB && filesAfterB == 1, "identical=\(refs[1] == gotB) files=\(filesAfterB) (want 1 — persisted once)")
+        check("R3 C restart   ", refs[2] == gotC && diskRestored, "identical=\(refs[2] == gotC) diskRestore=\(diskRestored ? "HIT" : "MISS")")
+        check("write-once     ", filesAfterC == 1, "files=\(filesAfterC) (want 1 — no per-turn growth)")
+        lines.append("PREFIXSTABLEE2E \(pass ? "PASS" : "FAIL")")
+        return lines.joined(separator: "\n")
+    }
+
     // #117 gate: PREFIXE2E for the RAM tier. Interleaved conversations — A cold, B cold
     // (unrelated → replaces A's arena path), then A extended: the third request must
     // restore A's whole-conversation state from the RAM store (prefixRAMHits asserts the

--- a/swift/Sources/QwispCore/PrefixPersist.swift
+++ b/swift/Sources/QwispCore/PrefixPersist.swift
@@ -22,8 +22,19 @@ public enum PrefixPersist {
     static let format: UInt32 = 1
 
     public static var enabled: Bool { Tell.envInt("QWISP_PREFIX_PERSIST", 0) != 0 }
-    static var maxSlots: Int { Swift.max(1, Tell.envInt("QWISP_PREFIX_PERSIST_SLOTS", 4)) }
+    // #112 stable-prefix tier (default ON; QWISP_PREFIX_STABLE=0 opts out): a harness's
+    // system+tools block is operationally defined by RECURRENCE — the shared prefix of two
+    // DIFFERENT conversations. That trigger writes the SAME key once per (harness × prompt
+    // version), so the per-turn SSD wear that keeps #89 opt-in cannot occur here.
+    public static var stableEnabled: Bool { Tell.envInt("QWISP_PREFIX_STABLE", 1) != 0 }
+    /// Minimum shared-prefix restore point (tokens) that counts as recurrence evidence.
+    public static var stableMinTokens: Int { Swift.max(64, Tell.envInt("QWISP_PREFIX_STABLE_MIN", 1024)) }
+    /// Disk restore lookups run when either tier is on.
+    public static var lookupEnabled: Bool { enabled || stableEnabled }
+    static var maxSlots: Int { Swift.max(1, Tell.envInt("QWISP_PREFIX_PERSIST_SLOTS", 20)) }
     static var maxBytes: Int { Swift.max(1, Tell.envInt("QWISP_PREFIX_PERSIST_MAX_MB", 512)) * 1_048_576 }
+    /// #112: total store byte budget (LRU-evicted), sized for 6-20 harness entries.
+    static var storeBudget: Int { Swift.max(1, Tell.envInt("QWISP_PREFIX_STORE_MB", 2048)) * 1_048_576 }
 
     static var defaultDir: URL {
         if let p = ProcessInfo.processInfo.environment["QWISP_PREFIX_PERSIST_DIR"] {
@@ -82,6 +93,11 @@ public enum PrefixPersist {
         return (model, tokens, wantState ? d.subdata(in: off ..< d.count) : Data())
     }
 
+    /// Cheap existence probe for `tokens` (no blob IO) — gates the expensive state copy.
+    public static func has(modelDir: String, tokens: [Int32], dir: URL? = nil) -> Bool {
+        FileManager.default.fileExists(atPath: url(dir: dir ?? defaultDir, modelDir: modelDir, tokens: tokens).path)
+    }
+
     /// Persist one content-boundary state. Skips oversized blobs; LRU-evicts beyond maxSlots.
     public static func save(modelDir: String, tokens: [Int32], state: Data, dir: URL? = nil) {
         guard state.count <= maxBytes, !tokens.isEmpty else { return }
@@ -118,15 +134,20 @@ public enum PrefixPersist {
         return (tokens, state)
     }
 
-    static func evict(dir: URL) {
+    static func evict(dir: URL, budget: Int? = nil) {
         let fm = FileManager.default
-        guard let files = try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: [.contentModificationDateKey]) else { return }
-        let bins = files.filter { $0.pathExtension == "bin" }
-        guard bins.count > maxSlots else { return }
-        let dated = bins.map { f -> (URL, Date) in
-            ((f, (try? f.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast))
-        }.sorted { $0.1 < $1.1 }
-        for (f, _) in dated.prefix(bins.count - maxSlots) { try? fm.removeItem(at: f) }
+        guard let files = try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey]) else { return }
+        var dated = files.filter { $0.pathExtension == "bin" }.map { f -> (url: URL, mtime: Date, size: Int) in
+            let rv = try? f.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+            return (f, rv?.contentModificationDate ?? .distantPast, rv?.fileSize ?? 0)
+        }.sorted { $0.mtime < $1.mtime }                       // oldest first
+        var total = dated.reduce(0) { $0 + $1.size }
+        let cap = budget ?? storeBudget
+        while let oldest = dated.first, dated.count > maxSlots || total > cap {
+            try? fm.removeItem(at: oldest.url)
+            total -= oldest.size
+            dated.removeFirst()
+        }
     }
 
     /// Pure self-check (no GPU, tmp dir): round trip, longest-prefix match, model isolation, LRU.
@@ -148,12 +169,25 @@ public enum PrefixPersist {
             ("model_isolation", bestMatch(modelDir: "/nope", content: ab, dir: tmp) == nil),
             ("miss_diverge", missDiverge == nil),
         ]
+        // #112: existence probe (no blob IO).
+        checks.append(("has_existing", has(modelDir: "/m", tokens: a, dir: tmp)))
+        checks.append(("has_missing", !has(modelDir: "/m", tokens: [77, 78], dir: tmp)))
         // LRU: with maxSlots files already present, adding more evicts the oldest.
         for i in 0 ..< maxSlots + 2 {
             save(modelDir: "/m", tokens: [100, Int32(i)], state: state, dir: tmp)
         }
         let n = (try? FileManager.default.contentsOfDirectory(at: tmp, includingPropertiesForKeys: nil).filter { $0.pathExtension == "bin" }.count) ?? -1
         checks.append(("lru_cap", n == maxSlots))
+        // #112: byte-budget eviction — squeeze the budget to one file's size ⇒ only the
+        // most recently used survives.
+        func binCount() -> Int {
+            (try? FileManager.default.contentsOfDirectory(at: tmp, includingPropertiesForKeys: nil).filter { $0.pathExtension == "bin" }.count) ?? -1
+        }
+        let one = (try? FileManager.default.contentsOfDirectory(at: tmp, includingPropertiesForKeys: [.fileSizeKey])
+            .filter { $0.pathExtension == "bin" }
+            .compactMap { try? $0.resourceValues(forKeys: [.fileSizeKey]).fileSize }.max()) ?? 0
+        evict(dir: tmp, budget: one)
+        checks.append(("byte_budget_evict", binCount() == 1 && one > 0))
         return checks
     }
 }

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -28,6 +28,8 @@ if CommandLine.arguments.contains("stream") {
                run: { md, _ in Tell.prefixCacheE2E(modelDir: md) }),
         Runner(name: "prefix-persist-e2e", desc: "disk-persist restart lossless gate (#89; GPU+model)",
                run: { md, _ in Tell.prefixPersistE2E(modelDir: md) }),
+        Runner(name: "prefix-stable-e2e", desc: "stable-prefix recurrence persist: write-once + restart warm-start lossless gate (#112; GPU+model)",
+               run: { md, _ in Tell.prefixStableE2E(modelDir: md) }),
         Runner(name: "prefix-ram-e2e", desc: "RAM-tier conversation-switch lossless gate + ramHits assertions (#117; GPU+model)",
                run: { md, _ in Tell.prefixRAME2E(modelDir: md) }),
         Runner(name: "prefix-bolt-e2e", desc: "bolt prompt-prefix blob reuse byte-identity (#76 bolt side; GPU+model)",

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -73,6 +73,7 @@ case "serve":
         // Resident tier only, greedy only, and NOT bit-exact with single-stream decode
         // (batch near-tie flips) — hence never the default.
         print("[qwisp serve] continuous batching: B=\(bs) slots (resident MLX path, greedy; requests batch instead of queueing)")
+        print("[qwisp serve] NOTE: batching targets multi-user cold-prompt throughput; for agentic harnesses (OpenCode etc.) the DEFAULT mode is faster (measured 2.6x) and bit-exact — see issue #121")
         backend = try BatchBackend(modelDir: model, slots: bs)
         batchMode = true
     } else {


### PR DESCRIPTION
Closes #112. (Stacked: #123 → #124 → this; will retarget to main as bases merge.)

Implements the issue's design verbatim — recurrence as the stability discriminator:

- **Trigger**: `generateCached` divergence (new conversation) with a ≥1024-token in-path restore point ⇒ the shared block is a harness system+tools prefix ⇒ persist that restore point's state (arena is exactly at the boundary — zero extra prefill). RAM-tier whole-conversation restores are excluded (`restoreLen ≤ lcp`) — they are not shared-prefix evidence.
- **Write-once**: same prefix ⇒ same key ⇒ existing `save()` dedupe; `has()` gates the expensive state copy to once per (harness × prompt version). The per-turn wear that keeps #89 opt-in structurally cannot occur ⇒ **default ON** (`QWISP_PREFIX_STABLE=0` opts out).
- **Store**: keyed collection (existing #89 dir + `bestMatch`), now with a **byte-budget LRU** (`QWISP_PREFIX_STORE_MB`, default 2GB; slot cap raised 4→20 for multi-harness coexistence). Disk lookups active when either tier is on.
- **Effect**: server restart / reboot warm-starts the harness prefix from disk (~0.5s-class restore + delta re-prefill) instead of a cold multi-minute prefill. This was the last remaining first-request pain for the real-harness goal after #118 (in-process conversation switches) and #122 (long-context decode).
- Bolt-side trigger (issue item 4) deferred to a streaming-tier follow-up (same store/format).

## Gates

- **New `prefix-stable-e2e`** (in the catalog): A cold (no write — one conversation is no evidence) → B recurrence (**exactly 1 file** written) → reset = restart → C warm-starts from **disk** (`restoreHits` asserts) — all streams byte-identical vs cache-off. **PASS** (resident).
- Regressions: `prefix-persist-e2e` (#89) PASS, `prefix-ram-e2e` (#117) PASS.
- RAWTESTS 89/89 · COMPTEST 57/57 (3 new pure store checks: `has`, byte-budget evict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)