### PR TITLE
feat(server): lane-batched serving (QWISP_LANES) — bit-exact parallel sub-agent fan-out

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,4 +1,4 @@
-# HANDOFF: lane-batch workstream COMPLETE — PR #126 open (bit-exact fan-out serving, 6/6 replay, 1.63x, TTFT flat)
+# HANDOFF: lane-batch COMPLETE + Stage 1b closed by measurement (all 3 levers NO-GO) — PR #126 open, next lever = #121
 Date: 2026-07-21 | Status: GREEN (awaiting PR review) | Branch: claude/lane-batch (pushed, PR #126 → main) | Root: /Users/penta2himajin/repos/qwisp
 
 > STOP: Before trusting anything below, run the checks in "Verify First".
@@ -7,17 +7,16 @@ Date: 2026-07-21 | Status: GREEN (awaiting PR review) | Branch: claude/lane-batc
 
 ## Verify First
 - `git branch --show-current` → `claude/lane-batch`; `git status` → clean; `gh pr view 126 --json state -q .state` → OPEN.
-- `git log --oneline -3` → `9ae9932` fix(server) canonical hybrid prefill, `adbfdf4` feat(server) lane serving, `759c158` feat(seedless) stepArgmaxBatch.
+- `git log --oneline -3` → `7b0b309` probe lane-kernel-bench (Stage 1b NO-GO), `9ae9932` fix(server) canonical hybrid prefill, `adbfdf4` feat(server) lane serving.
 - `~/bin/jacquard run scripts/test_raw.sh` → RAWTESTS **91/91** (tests 90+91 = lane lossless contract, WRITE-LOCKED, total=91).
 - GPU rule: `~/bin/jacquard` (run=shared / measure=exclusive; `JACQUARD_GPU_IDLE_THRESHOLD=20` for measure). Never two GPU procs; brew service stopped (`brew services info qwisp`).
 
 ## Next Action
-Wait for / respond to review on PR #126 (github.com/penta2himajin/qwisp/pull/126). No code work pending on this branch. If the user wants more per-stream at B≥3 (currently 46.0 tok/s @B=3 vs the ~55-61 aspiration), the lever is Stage 1b — see Then.
+Wait for / respond to review on PR #126 (github.com/penta2himajin/qwisp/pull/126). No code work pending on this branch. Speed at B≥3 is CLOSED: all three Stage-1b levers measured NO-GO (see Rejected) — B=3 ≈ 46-49 tok/s/stream is the engine kernel family's practical floor.
 
 ## Then
-1. (post-merge follow-up, only if per-stream @B≥3 matters) Stage 1b: B-lane kernels — batch GDN conv-shift/recurrence and attn SDPA across lanes in ONE dispatch each (needs per-lane cache buffer indexing: argument buffers or shared cache allocation). BEFORE attempting: profile per-stage to verify the ASSUMPTION that ~100 per-lane dispatches/step (GDN 2×30 + attn 4×10) are the gap, and that GDN state traffic (~480MB/lane/step) is the floor.
-2. (parked, #121) prefix-cache-aware admission on the lane path: admits re-pay shared system+tools prefixes; sharing the prefill across lanes is the next TTFT lever for real OpenCode fan-out (prompts ~8-50K).
-3. Stage 2 (per-row spec-in-batch, tinycodr DraftGate) only if B≥4 per-stream still short after 1b.
+1. (next workstream, #121) prefix-cache-aware admission on the lane path: admits re-pay shared system+tools prefixes; sharing the prefill across lanes is the remaining fan-out lever (TTFT with real 8-50K prompts). Design seam: LaneBatchSlots.admit re-creates the lane per request — a shared-prefix snapshot/restore (prefix cache machinery, LLMBackend.swift#generateCached idioms) could seed the lane state instead of cold prefill.
+2. Stage 2 (per-row spec-in-batch, tinycodr DraftGate) remains the only per-stream decode lever left, and only pays if accept economics beat the qmv M-scaling floor — needs its own measurement before any build.
 
 ## Commands
 - gate:  `~/bin/jacquard run scripts/test_raw.sh` → RAWTESTS 91/91; `scripts/test_bench_batch.sh` PASS; `scripts/test_completion.sh` 57/57; `scripts/test_tokenizer.sh` 5/5
@@ -35,6 +34,9 @@ Wait for / respond to review on PR #126 (github.com/penta2himajin/qwisp/pull/126
 - [ ] TODO: none on this branch — PR review, then optional Stage 1b (see Then).
 
 ## Rejected
+- Stage 1b (merge per-lane sequence-coupled dispatches into B-lane kernels): lane-kernel-bench decomposition shows those kernels total only ~1.6ms/lane of the ~4.4ms increment; dispatch-tax share ~0.5ms → ceiling +2-3 tok/s @B=3. NO-GO. (Probe: `QWISP_RUN=lane-kernel-bench`, no model.)
+- Tiled (shared-dequant) projections at decode M: 9x slower than qmv rows at every M≤8 ([N=8192,K=2048]). NO-GO.
+- qmm4_rows_b (B-row qmv, weight reads shared across ≤4 rows): bit-exact by construction (byte-compare PASS) but 4-6x SLOWER at every B — x_thread[4][16] register file collapses occupancy. Kernel kept in SeedlessLaneBatch.swift as evidence, NOT wired. Do not re-propose weight-read amortization for qmv decode shapes without a zero-extra-register design.
 - Tiled lm_head (QWISP_LMHEAD_QMV=0) for the batch step: 1.7-2x SLOWER at B=2-8 (B=3 argmax 21.7→36.3ms). qmv default stays. Do not re-propose.
 - "Shared laneX/laneOut staging serializes lanes on GPU": buffer separation changed nothing. Real model: encoder-wide hazard barriers ⇒ lane cores never overlap; dispatch COUNT is the cost. Do not re-propose buffer separation as an overlap lever.
 - Raw chunk-64 prefill + solo stepArgmax first token in admit: produces the PRE-hybrid stream → diverges from the canonical serialize stream ~100+ tokens in (f16 near-tie chains). Canonical = hybrid@1024 + qmmTiled/MLX.argMax first token (TellRuntime.swift wiring, Tell.prefill).
@@ -49,7 +51,7 @@ Wait for / respond to review on PR #126 (github.com/penta2himajin/qwisp/pull/126
 - FACT: lane batching is composition-independent — lane-concurrent ≡ lane-serial 6/6 on the real model (and tests 90/91 at synthetic dims).
 - DECISION: LaneServe admits with makeFused(maxM:1024) per request (~200MB transient scratch/lane, resident tier) to get canonical chunk-1024 hybrid prefill. Alternative (persistent small-maxM lanes + raw prefill): rejected, non-canonical stream.
 - DECISION: step() batches only ACTIVE lanes, rebuilt on active-set change (per-lane cost ~linear in B; idle lanes must not ride).
-- ASSUMPTION: per-lane GDN state traffic ~480MB/lane/step is the per-stream floor at B≥3 — unverified; profile before Stage 1b.
+- FACT (was ASSUMPTION, now measured): GDN state traffic is NOT the floor — recurrence DRAM excess is only ~0.2-0.4ms/lane; the residual ~2.8ms/lane is qmv M-scaling (~+19µs/row @[8192,2048]) across projections/MoE, the kernel family floor.
 - DECISION: PR #126 opened referencing #120/#121 (not closing #121 — prefix-sharing on lanes is a real remaining lever).
 
 ## Gotchas & Blockers

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -31,7 +31,8 @@ Wait for / respond to review on PR #126 (github.com/penta2himajin/qwisp/pull/126
 - [x] DONE: LaneServe wiring (adbfdf4) — LaneBatchSlots on ContinuousScheduler + LaneBackend behind QWISP_LANES; step batches ACTIVE lanes only.
 - [x] DONE: canonical admit (9ae9932) — hybrid prefill@1024 + Tell first-token (engine.logits qmmTiled + MLX.argMax). Replay 6/6 byte-identical, 1.63x, TTFT 20-28ms flat (serialize ladder was 3ms→23.4s).
 - [x] MEASURED full greedy step (resident, ctx=1024): B=1 80.4 / B=2 59.6 / B=3 46.0 / B=4 36.2 / B=8 20.4 tok/s (agg 162.9). Layers-only: 86.9/62.4/49.3/40.3/21.9.
-- [ ] TODO: none on this branch — PR review, then optional Stage 1b (see Then).
+- [x] DONE: Stage 1b decomposition probe (7b0b309) — lane-kernel-bench; all 3 B-scaling levers NO-GO (see Rejected).
+- [ ] TODO: none on this branch — PR review; next workstream = #121 (see Then).
 
 ## Rejected
 - Stage 1b (merge per-lane sequence-coupled dispatches into B-lane kernels): lane-kernel-bench decomposition shows those kernels total only ~1.6ms/lane of the ~4.4ms increment; dispatch-tax share ~0.5ms → ceiling +2-3 tok/s @B=3. NO-GO. (Probe: `QWISP_RUN=lane-kernel-bench`, no model.)

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,57 +1,39 @@
-# HANDOFF: #98 A1 = NO-GO vs flag-off chain (bootstrap gate resolved). PR #115 MERGED, PR #116 (bootstrap) OPEN. Decision: merge #116 + park A1 + move to batching #6
-Date: 2026-07-19 | Status: DECISION-PENDING (recommend park) | Branch: claude/issue98-dflash-bootstrap | Root: /Users/penta2himajin/repos/qwisp
+# HANDOFF: Stage 1 lane-batch — core landed bit-exact (test 90 green); NEXT = mixer projection split for speed
+Date: 2026-07-21 | Status: IN-PROGRESS | Branch: claude/lane-batch (pushed) | Root: /Users/penta2himajin/repos/qwisp
 
-> STOP: Before trusting anything below, run the checks in "Verify First".
-> If any observation differs from the expected value, this handoff is stale —
-> the code is the truth, not this document. Report the mismatch before proceeding.
+> STOP: Before trusting anything below, run "Verify First". Code is truth, not this doc.
 
 ## Verify First
-- `git branch --show-current` → `claude/issue98-dflash-bootstrap`; `git status` → clean.
-- `git log --oneline -1` → `bc37cef` feat(dflash) prefill-ctx bootstrap. main == `1ca80a1` (PR #115 merged).
-- PR #115 (fmm16 + fused CB) MERGED. PR #116 (bootstrap) OPEN — recommend merge (correctness-neutral accept lever).
-- Gates verified this session: RAWTESTS **98/98**, BENCHBATCH PASS, COMPTEST 33/33, TOKTEST 5/5.
-- **GPU rule (user instruction): `ps aux | grep -E "qwisp serve|qwisp-poc|mlx"` before EVERY GPU run; stop brew service first; if a proc is running, monitor don't collide.** `brew services info qwisp` → Running true at handoff.
+- `git branch --show-current` → `claude/lane-batch`; `git log --oneline -1` → "feat(seedless): lane-batched greedy decode core".
+- `jacquard run scripts/test_raw.sh` → RAWTESTS **90/90** (test 90 = lane_batch_bitexact, WRITE-LOCKED, total=90).
+- GPU rule: use `~/bin/jacquard` (run=shared / measure=exclusive; ambient ~14% ⇒ ALWAYS `JACQUARD_GPU_IDLE_THRESHOLD=20` for measure). Never two GPU procs; brew service must be stopped.
 
-## THE VERDICT: A1 is structurally NO-GO vs flag-off chain (M=1 greedy)
-Drafter is fully solved (fmm16, 13.4ms/block) AND bootstrap landed (accept lever works), yet DFlash loses to flag-off in EVERY regime. This is NOT a tuning gap — it's the batch-1 latency physics:
-- flag-off `chainedStepArgmax` ≈ 12.1ms/tok (M=1 forwards already near the batch-1 floor; chain amortizes dispatch over K greedy tokens). Very strong baseline on the d0≈90% draftless span.
-- DFlash block=8: verify M=8 = r_8·F ≈ 3.2·12.1 = 39ms → 9.75ms/tok at accept=4, + drafter 13.4/T + reject-rebuild ⇒ ~16ms/tok.
-- Break-even needs T>~5 AND drafter≤7ms AND no rebuild — a stack only longctx's tail approaches. block=4 doesn't rescue (r_4=2.0, fewer tok/block, same class).
-- Same physics as [[seedless-vs-suffixspec-nogo]] / batch-1 wall: **speculation wins at compute-bound M>1, NOT M=1 greedy where chain is cheap.**
+## Context (why)
+Goal: parallel sub-agent fan-out at 50-100 tok/s per stream + TTFT seconds (user target). Route A chosen = lossless batched decode on the raw engine. Measured Stage 0 (Release, real server): serialize per-stream 85-93 but TTFT ladder →27s@8 concurrent; QWISP_BATCH=8 per-stream 17. User-confirmed reinterpretation: old "spec×batch no gain" verdict was B=64-aggregate framing; at fan-out B=2-8 they are complementary (spec-in-batch = Stage 2, only if Stage 1 leaves a gap at B≥4).
 
-## Measured (paired A/B, N=128 resident, service stopped)
-| regime | boot=0 | boot=1 | accept/step | flag-off |
-|---|---|---|---|---|
-| code | 56.8 | 62.5 | 3.19→4.00 | 82.7 |
-| agentic | 54.5 | 62.7 | 3.59→4.54 | 76.0 |
-| longctx | 65.5 | 62.6 | 4.78→5.33 | 90.5 |
-| shortnl | 28.6 | 26.7 | 1.02→0.95 | 81.9 |
-(longctx regresses under bootstrap: one-time full-prompt ctx feed > accept gain at long prompt. shortnl non-transfer.)
-Finding: accept ramp is POSITION/content-dependent, not ctx-size alone (ctx=95 block 1 still gives p=2,1,0,0 then climbs).
+## State
+- [x] `SeedlessLaneBatch.swift` (NEW, additive, frozen files untouched): B lanes = per-lane SeedlessFusedForward (own caches), driver = weights + M=B scratch. Per layer: norm M=B → mixer per-lane M=1 (staged via lane_row_copy kernel) → resid+postNorm M=B → MoE M=B → resid M=B.
+- [x] Locked test 90 lane_batch_bitexact: B=3 divergent-history lanes, 4 chained steps, output rows AND cache trajectories bit-identical to solo M=1. PASS first run.
+- [x] Bench runner `lane-batch-bench` (catalog; QWISP_LANE_B, QWISP_LANE_CTX). Measured (resident, ctx=1024, diverse): B=1 78.3 | B=2 55.9/stream (112 agg) | B=3 37.7 (113) | B=4 32.3 (129) | B=8 16.7 (134, =MLX parity).
+- [ ] NEXT: per-stream at B=2-3 below the fused M-row curve (M=2 13.1ms→77, M=3 ~16.4→61 vs measured 17.9/26.6ms). ROOT CAUSE: mixers run per-lane M=1 ⇒ GDN/attn PROJECTION weights re-read B times (GDN = 30/40 layers, big in/out projs).
 
-## Recommended Next Action (owner call — this is a workstream-park decision)
-1. **Merge PR #116** — bootstrap is a genuine correctness-neutral accept improvement; bank it for any future DFlash-favorable regime.
-2. **Park #98 A1**: shipped opt-in (`QWISP_DFLASH=1` + `QWISP_DFLASH_BOOTSTRAP=1`), default OFF. Infrastructure (fmm16 kernel, fused draft+verify CB, tap, bootstrap) is solid and reusable; the limiter is the M=1 chain baseline being too strong.
-3. **Move to batching #6** — the M>1 continuous-batching regime is where block-drafting economics actually favor speculation (verify M amortized across requests), and where this machinery pays off. See memory [[issue6-batching-validated]].
-4. Unexplored DFlash-favorable angle if #98 is ever revived: slower device tier (8GB streaming, single forwards IO-bound → flips the economics). v1 is resident-scoped; would be a separate measurement.
+## Next Action (the speed fix)
+Split each mixer: dense projections at M=B on driver scratch (row-independent ⇒ M-invariant ⇒ still bit-exact) + sequence-coupled core per lane (GDN: conv shift + recurrent + norm/gate; attn: q/k norm + RoPE@lane-position + KV append + SDPA) + out-proj at M=B. Piece kernels exist as statics (encodeGdnPrepRows, encodeGdnFusionConvShift, encodeGdnNormGateRows, encodeAttnQPrepRows/KPrepRows, encodeQmmRows) — READ encodeGdnLayerRows (SeedlessFusedVerify.swift ~2851) and encodeAttnLayerRows (~2271) FIRST to map exact scratch flow, then recompose in SeedlessLaneBatch with row-copies between driver scratch rows and lane scratch row 0 (KB-scale, trivial). Keep test 90 green after EVERY step — it is the lossless contract.
+Target: B=3 ≥ ~55-61/stream. Then: (a) stepArgmaxBatch (final norm+lm_head+argmax M=B — M-invariance already tested), (b) scheduler wiring (extend ContinuousScheduler BatchEngine or new LaneServe path behind serialize), (c) acceptance = #120 replay harness (fan-out trace: per-stream ≥50, TTFT seconds, 6/6 bit-identical vs serialize).
 
-## What Shipped (all on branch history; PRs #109-#116)
-- #109-#114: tap, MLX drafter, parity, dispatch, c_draft probe (merged).
-- #115 (merged): fused draft+verify CB seam (stepArgmax additive draftPrologue/draftTokensBuf), dflash_fmm16 kernel (qmv-class f16 M-row GEMM, M-invariant by construction), lm_head dequant f16, locked test 98 (total=98).
-- #116 (open): prefill-ctx bootstrap (forwardRowsHybrid encodeTap seam + Tell.prefill onChunk + QWISP_DFLASH_BOOTSTRAP wiring).
+## Key facts
+- Fixture pattern for engine tests: test 23 fused_forward_rows_bitexact (synthetic 2-layer, GPU no model).
+- Driver/lanes share weights physically (same MLX buffers); memory cost = lanes' arenas only.
+- Research assets: `_b` MoE kernels (SeedlessMetalForward.swift:3095+, unused — encodeMoEBlockRows already per-row), archived-experiments/* branches, ghost/issue6 verdicts in memory (spec-in-batch rejection = B=64 framing, reinterpreted with user 2026-07-21).
+- Stage 2 (per-row spec, tinycodr DraftGate design) only if B≥4 per-stream still short after the split.
 
-## Falsified / Closed (do not re-propose — full trail: #98 comments 2026-07-19 ×4)
-CPU-round-trip/CB-context; GPU clock ramp (×2); buffer provenance; allocation granularity; memory pressure; MPS granularity; fmm_rows/fmm_tiled (35GB/s); qmm4_tiled barrier-tree (33ms); per-row .item(); MLX drafter as ship path; block=16; sliding ring v1. "Mystery in-loop tax" NEVER existed (= kernel bw + MPS + misreading r_8 as 12ms). NEW: bootstrap accept lever REAL but insufficient; A1 vs flag-off = structural NO-GO (batch-1 physics).
-
-## Commands
-- build: `cd swift && xcodebuild build -scheme qwisp-poc -configuration Release -destination 'platform=macOS' -derivedDataPath ./.xcode-build-rel -skipPackagePluginValidation`
-- gates: scripts/test_raw.sh (98/98) / test_completion.sh 33/33 / test_tokenizer.sh 5/5 / test_bench_batch.sh PASS
-- A/B bench: `env QWISP_DFLASH=1 [QWISP_DFLASH_BOOTSTRAP=1] QWISP_GEN=128 QWISP_RUN=raw-spec QWISP_MTP_REF=refs/resident/{code,agentic,longctx,shortnl}.safetensors .../qwisp-poc stream` (flag-off = drop QWISP_DFLASH). Probes: dflash-gemm-bench, dflash-raw-bench, QWISP_DFLASH_TRACE.
-
-## Do Not Touch
-- SeedlessVerifyTests.swift WRITE-LOCKED (total=98). Frozen forward path: additive nil-guarded seams only. refs/* raw-greedy only. Never two GPU processes; ps-check before every GPU run.
+## Gotchas
+- SeedlessLaneBatch reaches internal members of SeedlessFusedForward (same module) — fine, but do NOT modify the frozen class; extensions/new files only.
+- kv.len += 1 / gc.swapState() bookkeeping at ENCODE time (mirrors encodePreMoE) — per lane per layer, exactly once.
+- MLXRandom.seed set once in runAll — test order matters for fixtures; do not reorder tests.
+- LSP "No such module MLX"/"Cannot find X" = permanent SourceKit noise; xcodebuild is truth.
+- zsh eats `===` in compound commands; quote or split.
 
 ## Pointers
-- DFlashRawDrafter.swift (fmm16 + prepare/encode/finish), DFlashDispatch.swift#draftFused, SeedlessFusedVerify.swift#stepArgmax seam + forwardRowsHybrid tap, TellRuntime.swift prefill onChunk + both loop wirings.
-- Verdict + cost model: issue #98 comments (rounds 3-4 + bootstrap gate). PRs #109-#116.
-- Parked also: #112 stable-prefix persist (user-approved design); QAD finetune recon (z-lab training-code check ~5min).
+- swift/Sources/QwispCore/SeedlessLaneBatch.swift (core) · SeedlessVerifyTests.swift test 90 (locked contract) · PrefixCachePoC.swift laneBatchBench · docs/measurement.md
+- Memory: opencode-parallel-repro-verdict, spec-gate-longctx-verdict, issue6-batching-validated, ghost-mode-resident-verdict

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,64 +1,66 @@
-# HANDOFF: lane-batch mixer projection split SHIPPED (test 90 green, B=3 37.7→49.3/stream) — next = stepArgmaxBatch + scheduler wiring
-Date: 2026-07-21 | Status: GREEN (rate-limit shutdown, no WIP) | Branch: claude/lane-batch (pushed) | Root: /Users/penta2himajin/repos/qwisp
+# HANDOFF: lane-batch workstream COMPLETE — PR #126 open (bit-exact fan-out serving, 6/6 replay, 1.63x, TTFT flat)
+Date: 2026-07-21 | Status: GREEN (awaiting PR review) | Branch: claude/lane-batch (pushed, PR #126 → main) | Root: /Users/penta2himajin/repos/qwisp
 
 > STOP: Before trusting anything below, run the checks in "Verify First".
 > If any observation differs from the expected value, this handoff is stale —
 > the code is the truth, not this document. Report the mismatch before proceeding.
 
 ## Verify First
-- `git branch --show-current` → `claude/lane-batch`; `git status` → clean.
-- `git log --oneline -2` → `96aa5c1` feat(seedless): lane-batch mixer projection split, then `9d4ac0d` docs handoff.
-- `~/bin/jacquard run scripts/test_raw.sh` → RAWTESTS **90/90** (test 90 = lane_batch_bitexact, WRITE-LOCKED, total=90).
-- GPU rule: `~/bin/jacquard` (run=shared / measure=exclusive; ambient ~14% ⇒ ALWAYS `JACQUARD_GPU_IDLE_THRESHOLD=20` for measure). Never two GPU procs; brew service must be stopped.
+- `git branch --show-current` → `claude/lane-batch`; `git status` → clean; `gh pr view 126 --json state -q .state` → OPEN.
+- `git log --oneline -3` → `9ae9932` fix(server) canonical hybrid prefill, `adbfdf4` feat(server) lane serving, `759c158` feat(seedless) stepArgmaxBatch.
+- `~/bin/jacquard run scripts/test_raw.sh` → RAWTESTS **91/91** (tests 90+91 = lane lossless contract, WRITE-LOCKED, total=91).
+- GPU rule: `~/bin/jacquard` (run=shared / measure=exclusive; `JACQUARD_GPU_IDLE_THRESHOLD=20` for measure). Never two GPU procs; brew service stopped (`brew services info qwisp`).
 
 ## Next Action
-Implement `stepArgmaxBatch` (final norm + lm_head + argmax at M=B) as an additive method on `SeedlessLaneBatch` in swift/Sources/QwispCore/SeedlessLaneBatch.swift, mirroring the driver's solo stepArgmax op-chain (M-invariance already underwrites bit-exactness). Completion: extend locked test 90 (or add within total=90 budget per lock rules — do NOT bump total without the lock ritual) to assert batched argmax tokens ≡ per-lane solo stepArgmax; RAWTESTS stays 90/90-green-equivalent.
+Wait for / respond to review on PR #126 (github.com/penta2himajin/qwisp/pull/126). No code work pending on this branch. If the user wants more per-stream at B≥3 (currently 46.0 tok/s @B=3 vs the ~55-61 aspiration), the lever is Stage 1b — see Then.
 
 ## Then
-1. Scheduler wiring: extend ContinuousScheduler BatchEngine or a new LaneServe path behind `serialize` (see swift/Sources/qwisp/Server.swift#AsyncLock) so fan-out HTTP requests ride SeedlessLaneBatch instead of serialize.
-2. Acceptance = #120 replay harness (fan-out trace): per-stream ≥50 tok/s, TTFT seconds, 6/6 bit-identical vs serialize.
-3. ONLY IF per-stream still short at acceptance: Stage 1b (B-lane kernels: batch conv-shift/recurrence/SDPA across lanes via shared cache allocation or argument buffers — new kernels, higher risk) or Stage 2 (per-row spec, tinycodr DraftGate design).
+1. (post-merge follow-up, only if per-stream @B≥3 matters) Stage 1b: B-lane kernels — batch GDN conv-shift/recurrence and attn SDPA across lanes in ONE dispatch each (needs per-lane cache buffer indexing: argument buffers or shared cache allocation). BEFORE attempting: profile per-stage to verify the ASSUMPTION that ~100 per-lane dispatches/step (GDN 2×30 + attn 4×10) are the gap, and that GDN state traffic (~480MB/lane/step) is the floor.
+2. (parked, #121) prefix-cache-aware admission on the lane path: admits re-pay shared system+tools prefixes; sharing the prefill across lanes is the next TTFT lever for real OpenCode fan-out (prompts ~8-50K).
+3. Stage 2 (per-row spec-in-batch, tinycodr DraftGate) only if B≥4 per-stream still short after 1b.
 
 ## Commands
-- gate:  `~/bin/jacquard run scripts/test_raw.sh` → RAWTESTS 90/90
-- build: `cd swift && xcodebuild build -scheme qwisp-poc -configuration Release -destination 'platform=macOS' -derivedDataPath ./.xcode-build-rel -skipPackagePluginValidation`
-- bench: `JACQUARD_GPU_IDLE_THRESHOLD=20 ~/bin/jacquard measure env QWISP_RUN=lane-batch-bench QWISP_MODEL="$HOME/.mtplx/models/Youssofal--Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16" swift/.xcode-build-rel/Build/Products/Release/qwisp-poc stream`
-  (⚠ the `stream` positional arg is REQUIRED — without it qwisp-poc silently no-ops. Bench prints GPU ms per B now.)
+- gate:  `~/bin/jacquard run scripts/test_raw.sh` → RAWTESTS 91/91; `scripts/test_bench_batch.sh` PASS; `scripts/test_completion.sh` 57/57; `scripts/test_tokenizer.sh` 5/5
+- build: `cd swift && xcodebuild build -scheme qwisp -configuration Release -destination 'platform=macOS' -derivedDataPath ./.xcode-build-rel -skipPackagePluginValidation` (scheme `qwisp-poc` for the gate binary; run scripts from REPO ROOT, not swift/)
+- bench: `JACQUARD_GPU_IDLE_THRESHOLD=20 ~/bin/jacquard measure env QWISP_RUN=lane-batch-bench QWISP_MODEL="$HOME/.mtplx/models/Youssofal--Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16" swift/.xcode-build-rel/Build/Products/Release/qwisp-poc stream` (⚠ `stream` arg REQUIRED; bench prints layers-only AND full-argmax rows + gpu ms)
+- replay acceptance: see tools/opencode-repro/README.md; synthetic 6-stream trace recipe lives in this session's history — craft JSONL recs `{id,method:"POST",path:"/v1/chat/completions",tArrival:0,inflightAtArrival:6,body:"<chat JSON, stream:true>"}`, then `node tools/opencode-repro/replay_concurrent.mjs run <trace> 127.0.0.1:<port> serial|concurrent <out.json> --greedy` and `... diff ref.json cmp.json`
+- lane serve: `QWISP_LANES=<B> qwisp serve` (resident ≥32GB, greedy; `QWISP_LANE_CTX` per-lane ctx, default 16384)
 
 ## State
-- [x] DONE: Stage 1 core — SeedlessLaneBatch bit-exact B-lane step (commit dbadf1b, prior session).
-- [x] DONE: mixer projection split fast path (commit 96aa5c1): row-independent stages at M=B on driver (in-proj/qkv demux, GDN prep, norm/gate, sigmoid gate, out/o-proj); ONLY sequence-coupled kernels per lane (GDN conv-shift + recurrence = 2/layer; attn q-prep/k-prep/v-append/SDPA = 4/layer), bound at byte offsets into driver scratch rows — zero staging copies. Fallback (fusion flags off) = staged hybridDense path, kept in-file.
-- [x] MEASURED (resident, ctx=1024, diverse prompts; wall ms | per-stream | aggregate | gpu ms):
-      B=1 11.51 | 86.9 | — | 9.94 · B=2 16.02 | 62.4 | 124.8 | 14.22 · B=3 20.30 | 49.3 | 147.8 | 18.68 · B=4 24.80 | 40.3 | 161.3 | 22.98 · B=8 45.60 | 21.9 | 175.4 | 42.27
-      (was: 78.3 / 55.9 / 37.7 / 32.3 / 16.7-134agg. Fused M-row reference curve: M=2 13.1ms→77, M=3 ~16.4→61.)
-- [ ] TODO: stepArgmaxBatch → scheduler wiring → #120 replay acceptance (order above).
+- [x] DONE: mixer projection split fast path (96aa5c1) — M=B projections + offset-bound per-lane cores; zero staging copies.
+- [x] DONE: stepArgmaxBatch + locked test 91 (759c158) — 1-CB batched greedy step; total=91.
+- [x] DONE: LaneServe wiring (adbfdf4) — LaneBatchSlots on ContinuousScheduler + LaneBackend behind QWISP_LANES; step batches ACTIVE lanes only.
+- [x] DONE: canonical admit (9ae9932) — hybrid prefill@1024 + Tell first-token (engine.logits qmmTiled + MLX.argMax). Replay 6/6 byte-identical, 1.63x, TTFT 20-28ms flat (serialize ladder was 3ms→23.4s).
+- [x] MEASURED full greedy step (resident, ctx=1024): B=1 80.4 / B=2 59.6 / B=3 46.0 / B=4 36.2 / B=8 20.4 tok/s (agg 162.9). Layers-only: 86.9/62.4/49.3/40.3/21.9.
+- [ ] TODO: none on this branch — PR review, then optional Stage 1b (see Then).
 
 ## Rejected
-- "Shared laneX/laneOut staging is the GPU serializer" hypothesis: splitting to per-lane buffers changed NOTHING (B=3 gpu 21.94 vs 21.78). Real model: encoder-wide hazard barriers mean lane cores NEVER overlap in one encoder regardless of buffer separation; cost driver = per-lane dispatch COUNT. Do not re-propose buffer-separation as an overlap lever.
-- Copying bP/aP rows to lanes on the staged path: hybridDense recomputes a/b per lane from x; weights [32,H] 4-bit ≈ 32KB — negligible vs qkv/out (MB-scale). Not worth a new seam.
-- (carried) spec×batch "no gain" verdict was B=64-aggregate framing; at fan-out B=2-8 they are complementary — Stage 2 only if B≥4 short after acceptance (user-confirmed 2026-07-21).
+- Tiled lm_head (QWISP_LMHEAD_QMV=0) for the batch step: 1.7-2x SLOWER at B=2-8 (B=3 argmax 21.7→36.3ms). qmv default stays. Do not re-propose.
+- "Shared laneX/laneOut staging serializes lanes on GPU": buffer separation changed nothing. Real model: encoder-wide hazard barriers ⇒ lane cores never overlap; dispatch COUNT is the cost. Do not re-propose buffer separation as an overlap lever.
+- Raw chunk-64 prefill + solo stepArgmax first token in admit: produces the PRE-hybrid stream → diverges from the canonical serialize stream ~100+ tokens in (f16 near-tie chains). Canonical = hybrid@1024 + qmmTiled/MLX.argMax first token (TellRuntime.swift wiring, Tell.prefill).
 
 ## Do Not Touch
-- `swift/Sources/QwispCore/SeedlessVerifyTests.swift`: WRITE-LOCKED (total=90 guard). Test 90 = the lossless contract; keep green after EVERY step.
-- Frozen forward path (SeedlessEngine/SeedlessMetalForward/SeedlessFusedVerify/Tell/ExpertArena/ExpertSource): SeedlessLaneBatch reaches their internal statics/pipelines (same module) — fine; never MODIFY them, extensions/new files only.
+- `swift/Sources/QwispCore/SeedlessVerifyTests.swift`: WRITE-LOCKED (total=91 guard; tests 90+91 = lane lossless contract).
+- Frozen forward path (SeedlessEngine/SeedlessMetalForward/SeedlessFusedVerify/Tell/ExpertArena/ExpertSource): SeedlessLaneBatch/LaneServe reach internals (same module) — never MODIFY frozen files.
 - `refs/*.safetensors`: raw-greedy only.
 
 ## Decisions
-- DECISION: per-lane cores use OFFSET-BOUND wrappers (laneConvShift/laneDeltaStep/laneQPrep/laneKPrep/laneWriteKV/laneSdpa in SeedlessLaneBatch) over the frozen pipelines — same pipeline + constants + grid, only setBuffer offsets differ ⇒ bit-exact by construction. Alternative (adding offset params to frozen encode statics): rejected, touches frozen file.
-- DECISION: fast path requires fuseGDN/fuseATTN/fuseA1 + pipelines non-nil; flag-off falls back to the staged path (bisectability preserved). Fast path is what test 90 exercises (default flags).
-- FACT: wall−gpu gap ≈ 1.6-2.0 ms at all B (encode+readback), so remaining per-stream gap vs the M-row curve is GPU-side per-lane dispatch latency (~100 dispatches/lane/step: GDN 2×30 + attn 4×10).
-- ASSUMPTION: GDN recurrence state traffic (state [32,128,128] f32 ≈ 8MB r+w × 30 layers ≈ 480MB/lane/step) is the irreducible per-lane floor — NOT yet isolated by measurement; profile per-stage before attempting Stage 1b.
-- DECISION: accept B=3 = 49.3 for now and proceed to wiring (aggregate 147.8 already ≈ 1.7x serialize single-stream); revisit per-lane kernels only if #120 acceptance falls short of per-stream ≥50.
+- FACT: the canonical greedy stream INCLUDES steel-hybrid prefill@1024 (TellRuntime: "default ON, canonical since refs re-canonicalization"). Any new decode path must mirror Tell.prefill + first-token kernels exactly or it forks the stream.
+- FACT: lane batching is composition-independent — lane-concurrent ≡ lane-serial 6/6 on the real model (and tests 90/91 at synthetic dims).
+- DECISION: LaneServe admits with makeFused(maxM:1024) per request (~200MB transient scratch/lane, resident tier) to get canonical chunk-1024 hybrid prefill. Alternative (persistent small-maxM lanes + raw prefill): rejected, non-canonical stream.
+- DECISION: step() batches only ACTIVE lanes, rebuilt on active-set change (per-lane cost ~linear in B; idle lanes must not ride).
+- ASSUMPTION: per-lane GDN state traffic ~480MB/lane/step is the per-stream floor at B≥3 — unverified; profile before Stage 1b.
+- DECISION: PR #126 opened referencing #120/#121 (not closing #121 — prefix-sharing on lanes is a real remaining lever).
 
 ## Gotchas & Blockers
-- RATE LIMIT: session ended at 5h 100% used — resume after reset.
-- `qwisp-poc` needs the `stream` positional arg; `QWISP_RUN=...` alone prints smoke and exits (bit me this session).
-- kv.len += 1 / gc.swapState() at ENCODE time, per lane per layer, exactly once — in the fast path swapState happens after that lane's laneDeltaStep encode (conv encoded pre-swap in the earlier loop; verified green).
-- setBuffer offsets are BYTES (row × width × 2 for f16, × 4 for g/beta f32); all current offsets are well-aligned power-of-2 multiples.
-- MLXRandom.seed set once in runAll — do not reorder tests. LSP "No such module MLX" = SourceKit noise; xcodebuild is truth. zsh eats `===`; quote or split.
+- `qwisp-poc` needs the `stream` positional arg (env alone silently no-ops). Run scripts from repo root (relative paths break from swift/).
+- The replay harness now collects `delta.reasoning_content` too (thinking models emit content late; without it len=0 and identity is vacuous).
+- gh token lacks `notifications` scope — updateSubscription mutation fails; PR author is auto-subscribed anyway.
+- kv.len/gc.swapState() at ENCODE time per lane per layer exactly once; in the fast path swapState sits after that lane's recurrence encode.
+- MLXRandom.seed once in runAll — do not reorder tests. SourceKit "No such module MLX" = noise. zsh eats `===`.
 
 ## Pointers
-- Read first: swift/Sources/QwispCore/SeedlessLaneBatch.swift (whole file, ~430 lines — fast/staged paths + wrappers); swift/Sources/QwispCore/SeedlessFusedVerify.swift#encodeGdnLayerRows,#encodeAttnLayerRows (the op-chains being recomposed); swift/Sources/QwispCore/PrefixCachePoC.swift#laneBatchBench (bench, now with gpu ms).
-- Pattern to follow for stepArgmaxBatch: driver's solo stepArgmax in SeedlessFusedVerify.swift (SeedlessFusedForward) — reuse its encode statics at M=B.
-- Context (why lane-batch at all): Stage 0 measurement + Route A rationale in commit 9d4ac0d's HANDOFF version (git show 9d4ac0d:HANDOFF.md).
-- Memory: opencode-parallel-repro-verdict, spec-gate-longctx-verdict, issue6-batching-validated, latest-handoff.
+- Read first: swift/Sources/QwispCore/SeedlessLaneBatch.swift (batch core, fast/staged paths, offset wrappers); swift/Sources/QwispCore/LaneServe.swift (slots + backend, canonical admit); tools/opencode-repro/replay_concurrent.mjs (acceptance harness).
+- Canonical prefill pattern: swift/Sources/QwispCore/TellRuntime.swift#prefill + the hybrid wiring block (~line 184).
+- PR: https://github.com/penta2himajin/qwisp/pull/126 · Issues: #120 (verdict), #121 (parked follow-up).
+- Memory: latest-handoff, opencode-parallel-repro-verdict, issue6-batching-validated.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,39 +1,64 @@
-# HANDOFF: Stage 1 lane-batch — core landed bit-exact (test 90 green); NEXT = mixer projection split for speed
-Date: 2026-07-21 | Status: IN-PROGRESS | Branch: claude/lane-batch (pushed) | Root: /Users/penta2himajin/repos/qwisp
+# HANDOFF: lane-batch mixer projection split SHIPPED (test 90 green, B=3 37.7→49.3/stream) — next = stepArgmaxBatch + scheduler wiring
+Date: 2026-07-21 | Status: GREEN (rate-limit shutdown, no WIP) | Branch: claude/lane-batch (pushed) | Root: /Users/penta2himajin/repos/qwisp
 
-> STOP: Before trusting anything below, run "Verify First". Code is truth, not this doc.
+> STOP: Before trusting anything below, run the checks in "Verify First".
+> If any observation differs from the expected value, this handoff is stale —
+> the code is the truth, not this document. Report the mismatch before proceeding.
 
 ## Verify First
-- `git branch --show-current` → `claude/lane-batch`; `git log --oneline -1` → "feat(seedless): lane-batched greedy decode core".
-- `jacquard run scripts/test_raw.sh` → RAWTESTS **90/90** (test 90 = lane_batch_bitexact, WRITE-LOCKED, total=90).
-- GPU rule: use `~/bin/jacquard` (run=shared / measure=exclusive; ambient ~14% ⇒ ALWAYS `JACQUARD_GPU_IDLE_THRESHOLD=20` for measure). Never two GPU procs; brew service must be stopped.
+- `git branch --show-current` → `claude/lane-batch`; `git status` → clean.
+- `git log --oneline -2` → `96aa5c1` feat(seedless): lane-batch mixer projection split, then `9d4ac0d` docs handoff.
+- `~/bin/jacquard run scripts/test_raw.sh` → RAWTESTS **90/90** (test 90 = lane_batch_bitexact, WRITE-LOCKED, total=90).
+- GPU rule: `~/bin/jacquard` (run=shared / measure=exclusive; ambient ~14% ⇒ ALWAYS `JACQUARD_GPU_IDLE_THRESHOLD=20` for measure). Never two GPU procs; brew service must be stopped.
 
-## Context (why)
-Goal: parallel sub-agent fan-out at 50-100 tok/s per stream + TTFT seconds (user target). Route A chosen = lossless batched decode on the raw engine. Measured Stage 0 (Release, real server): serialize per-stream 85-93 but TTFT ladder →27s@8 concurrent; QWISP_BATCH=8 per-stream 17. User-confirmed reinterpretation: old "spec×batch no gain" verdict was B=64-aggregate framing; at fan-out B=2-8 they are complementary (spec-in-batch = Stage 2, only if Stage 1 leaves a gap at B≥4).
+## Next Action
+Implement `stepArgmaxBatch` (final norm + lm_head + argmax at M=B) as an additive method on `SeedlessLaneBatch` in swift/Sources/QwispCore/SeedlessLaneBatch.swift, mirroring the driver's solo stepArgmax op-chain (M-invariance already underwrites bit-exactness). Completion: extend locked test 90 (or add within total=90 budget per lock rules — do NOT bump total without the lock ritual) to assert batched argmax tokens ≡ per-lane solo stepArgmax; RAWTESTS stays 90/90-green-equivalent.
+
+## Then
+1. Scheduler wiring: extend ContinuousScheduler BatchEngine or a new LaneServe path behind `serialize` (see swift/Sources/qwisp/Server.swift#AsyncLock) so fan-out HTTP requests ride SeedlessLaneBatch instead of serialize.
+2. Acceptance = #120 replay harness (fan-out trace): per-stream ≥50 tok/s, TTFT seconds, 6/6 bit-identical vs serialize.
+3. ONLY IF per-stream still short at acceptance: Stage 1b (B-lane kernels: batch conv-shift/recurrence/SDPA across lanes via shared cache allocation or argument buffers — new kernels, higher risk) or Stage 2 (per-row spec, tinycodr DraftGate design).
+
+## Commands
+- gate:  `~/bin/jacquard run scripts/test_raw.sh` → RAWTESTS 90/90
+- build: `cd swift && xcodebuild build -scheme qwisp-poc -configuration Release -destination 'platform=macOS' -derivedDataPath ./.xcode-build-rel -skipPackagePluginValidation`
+- bench: `JACQUARD_GPU_IDLE_THRESHOLD=20 ~/bin/jacquard measure env QWISP_RUN=lane-batch-bench QWISP_MODEL="$HOME/.mtplx/models/Youssofal--Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16" swift/.xcode-build-rel/Build/Products/Release/qwisp-poc stream`
+  (⚠ the `stream` positional arg is REQUIRED — without it qwisp-poc silently no-ops. Bench prints GPU ms per B now.)
 
 ## State
-- [x] `SeedlessLaneBatch.swift` (NEW, additive, frozen files untouched): B lanes = per-lane SeedlessFusedForward (own caches), driver = weights + M=B scratch. Per layer: norm M=B → mixer per-lane M=1 (staged via lane_row_copy kernel) → resid+postNorm M=B → MoE M=B → resid M=B.
-- [x] Locked test 90 lane_batch_bitexact: B=3 divergent-history lanes, 4 chained steps, output rows AND cache trajectories bit-identical to solo M=1. PASS first run.
-- [x] Bench runner `lane-batch-bench` (catalog; QWISP_LANE_B, QWISP_LANE_CTX). Measured (resident, ctx=1024, diverse): B=1 78.3 | B=2 55.9/stream (112 agg) | B=3 37.7 (113) | B=4 32.3 (129) | B=8 16.7 (134, =MLX parity).
-- [ ] NEXT: per-stream at B=2-3 below the fused M-row curve (M=2 13.1ms→77, M=3 ~16.4→61 vs measured 17.9/26.6ms). ROOT CAUSE: mixers run per-lane M=1 ⇒ GDN/attn PROJECTION weights re-read B times (GDN = 30/40 layers, big in/out projs).
+- [x] DONE: Stage 1 core — SeedlessLaneBatch bit-exact B-lane step (commit dbadf1b, prior session).
+- [x] DONE: mixer projection split fast path (commit 96aa5c1): row-independent stages at M=B on driver (in-proj/qkv demux, GDN prep, norm/gate, sigmoid gate, out/o-proj); ONLY sequence-coupled kernels per lane (GDN conv-shift + recurrence = 2/layer; attn q-prep/k-prep/v-append/SDPA = 4/layer), bound at byte offsets into driver scratch rows — zero staging copies. Fallback (fusion flags off) = staged hybridDense path, kept in-file.
+- [x] MEASURED (resident, ctx=1024, diverse prompts; wall ms | per-stream | aggregate | gpu ms):
+      B=1 11.51 | 86.9 | — | 9.94 · B=2 16.02 | 62.4 | 124.8 | 14.22 · B=3 20.30 | 49.3 | 147.8 | 18.68 · B=4 24.80 | 40.3 | 161.3 | 22.98 · B=8 45.60 | 21.9 | 175.4 | 42.27
+      (was: 78.3 / 55.9 / 37.7 / 32.3 / 16.7-134agg. Fused M-row reference curve: M=2 13.1ms→77, M=3 ~16.4→61.)
+- [ ] TODO: stepArgmaxBatch → scheduler wiring → #120 replay acceptance (order above).
 
-## Next Action (the speed fix)
-Split each mixer: dense projections at M=B on driver scratch (row-independent ⇒ M-invariant ⇒ still bit-exact) + sequence-coupled core per lane (GDN: conv shift + recurrent + norm/gate; attn: q/k norm + RoPE@lane-position + KV append + SDPA) + out-proj at M=B. Piece kernels exist as statics (encodeGdnPrepRows, encodeGdnFusionConvShift, encodeGdnNormGateRows, encodeAttnQPrepRows/KPrepRows, encodeQmmRows) — READ encodeGdnLayerRows (SeedlessFusedVerify.swift ~2851) and encodeAttnLayerRows (~2271) FIRST to map exact scratch flow, then recompose in SeedlessLaneBatch with row-copies between driver scratch rows and lane scratch row 0 (KB-scale, trivial). Keep test 90 green after EVERY step — it is the lossless contract.
-Target: B=3 ≥ ~55-61/stream. Then: (a) stepArgmaxBatch (final norm+lm_head+argmax M=B — M-invariance already tested), (b) scheduler wiring (extend ContinuousScheduler BatchEngine or new LaneServe path behind serialize), (c) acceptance = #120 replay harness (fan-out trace: per-stream ≥50, TTFT seconds, 6/6 bit-identical vs serialize).
+## Rejected
+- "Shared laneX/laneOut staging is the GPU serializer" hypothesis: splitting to per-lane buffers changed NOTHING (B=3 gpu 21.94 vs 21.78). Real model: encoder-wide hazard barriers mean lane cores NEVER overlap in one encoder regardless of buffer separation; cost driver = per-lane dispatch COUNT. Do not re-propose buffer-separation as an overlap lever.
+- Copying bP/aP rows to lanes on the staged path: hybridDense recomputes a/b per lane from x; weights [32,H] 4-bit ≈ 32KB — negligible vs qkv/out (MB-scale). Not worth a new seam.
+- (carried) spec×batch "no gain" verdict was B=64-aggregate framing; at fan-out B=2-8 they are complementary — Stage 2 only if B≥4 short after acceptance (user-confirmed 2026-07-21).
 
-## Key facts
-- Fixture pattern for engine tests: test 23 fused_forward_rows_bitexact (synthetic 2-layer, GPU no model).
-- Driver/lanes share weights physically (same MLX buffers); memory cost = lanes' arenas only.
-- Research assets: `_b` MoE kernels (SeedlessMetalForward.swift:3095+, unused — encodeMoEBlockRows already per-row), archived-experiments/* branches, ghost/issue6 verdicts in memory (spec-in-batch rejection = B=64 framing, reinterpreted with user 2026-07-21).
-- Stage 2 (per-row spec, tinycodr DraftGate design) only if B≥4 per-stream still short after the split.
+## Do Not Touch
+- `swift/Sources/QwispCore/SeedlessVerifyTests.swift`: WRITE-LOCKED (total=90 guard). Test 90 = the lossless contract; keep green after EVERY step.
+- Frozen forward path (SeedlessEngine/SeedlessMetalForward/SeedlessFusedVerify/Tell/ExpertArena/ExpertSource): SeedlessLaneBatch reaches their internal statics/pipelines (same module) — fine; never MODIFY them, extensions/new files only.
+- `refs/*.safetensors`: raw-greedy only.
 
-## Gotchas
-- SeedlessLaneBatch reaches internal members of SeedlessFusedForward (same module) — fine, but do NOT modify the frozen class; extensions/new files only.
-- kv.len += 1 / gc.swapState() bookkeeping at ENCODE time (mirrors encodePreMoE) — per lane per layer, exactly once.
-- MLXRandom.seed set once in runAll — test order matters for fixtures; do not reorder tests.
-- LSP "No such module MLX"/"Cannot find X" = permanent SourceKit noise; xcodebuild is truth.
-- zsh eats `===` in compound commands; quote or split.
+## Decisions
+- DECISION: per-lane cores use OFFSET-BOUND wrappers (laneConvShift/laneDeltaStep/laneQPrep/laneKPrep/laneWriteKV/laneSdpa in SeedlessLaneBatch) over the frozen pipelines — same pipeline + constants + grid, only setBuffer offsets differ ⇒ bit-exact by construction. Alternative (adding offset params to frozen encode statics): rejected, touches frozen file.
+- DECISION: fast path requires fuseGDN/fuseATTN/fuseA1 + pipelines non-nil; flag-off falls back to the staged path (bisectability preserved). Fast path is what test 90 exercises (default flags).
+- FACT: wall−gpu gap ≈ 1.6-2.0 ms at all B (encode+readback), so remaining per-stream gap vs the M-row curve is GPU-side per-lane dispatch latency (~100 dispatches/lane/step: GDN 2×30 + attn 4×10).
+- ASSUMPTION: GDN recurrence state traffic (state [32,128,128] f32 ≈ 8MB r+w × 30 layers ≈ 480MB/lane/step) is the irreducible per-lane floor — NOT yet isolated by measurement; profile per-stage before attempting Stage 1b.
+- DECISION: accept B=3 = 49.3 for now and proceed to wiring (aggregate 147.8 already ≈ 1.7x serialize single-stream); revisit per-lane kernels only if #120 acceptance falls short of per-stream ≥50.
+
+## Gotchas & Blockers
+- RATE LIMIT: session ended at 5h 100% used — resume after reset.
+- `qwisp-poc` needs the `stream` positional arg; `QWISP_RUN=...` alone prints smoke and exits (bit me this session).
+- kv.len += 1 / gc.swapState() at ENCODE time, per lane per layer, exactly once — in the fast path swapState happens after that lane's laneDeltaStep encode (conv encoded pre-swap in the earlier loop; verified green).
+- setBuffer offsets are BYTES (row × width × 2 for f16, × 4 for g/beta f32); all current offsets are well-aligned power-of-2 multiples.
+- MLXRandom.seed set once in runAll — do not reorder tests. LSP "No such module MLX" = SourceKit noise; xcodebuild is truth. zsh eats `===`; quote or split.
 
 ## Pointers
-- swift/Sources/QwispCore/SeedlessLaneBatch.swift (core) · SeedlessVerifyTests.swift test 90 (locked contract) · PrefixCachePoC.swift laneBatchBench · docs/measurement.md
-- Memory: opencode-parallel-repro-verdict, spec-gate-longctx-verdict, issue6-batching-validated, ghost-mode-resident-verdict
+- Read first: swift/Sources/QwispCore/SeedlessLaneBatch.swift (whole file, ~430 lines — fast/staged paths + wrappers); swift/Sources/QwispCore/SeedlessFusedVerify.swift#encodeGdnLayerRows,#encodeAttnLayerRows (the op-chains being recomposed); swift/Sources/QwispCore/PrefixCachePoC.swift#laneBatchBench (bench, now with gpu ms).
+- Pattern to follow for stepArgmaxBatch: driver's solo stepArgmax in SeedlessFusedVerify.swift (SeedlessFusedForward) — reuse its encode statics at M=B.
+- Context (why lane-batch at all): Stage 0 measurement + Route A rationale in commit 9d4ac0d's HANDOFF version (git show 9d4ac0d:HANDOFF.md).
+- Memory: opencode-parallel-repro-verdict, spec-gate-longctx-verdict, issue6-batching-validated, latest-handoff.

--- a/swift/Sources/QwispCore/LaneServe.swift
+++ b/swift/Sources/QwispCore/LaneServe.swift
@@ -1,0 +1,121 @@
+import Foundation
+import MLX
+
+// Lane-batched serving path (Stage 1 wiring, parallel sub-agent fan-out).
+//
+// BatchSlots over SeedlessLaneBatch: reuses the issue-#6 ContinuousScheduler
+// (continuous slot refill, one decode thread) but swaps the MLX batched engine
+// for per-slot raw-engine lanes. Unlike ContinuousBatchEngine (MLX, NOT
+// bit-exact — batch near-tie flips), every lane here advances BIT-IDENTICALLY
+// to solo raw greedy decode (locked tests 90/91), so fan-out responses match
+// the serialize path byte-for-byte.
+//
+// Design (v1):
+//   - admit = standalone chunked prefill on a fresh lane forward (the validated
+//     standalone-then-inject shape; prefill-overlap is the known follow-up).
+//   - step  = SeedlessLaneBatch.stepArgmaxBatch over the ACTIVE lanes only —
+//     the batch is rebuilt when the active set changes (per-lane cost is ~linear
+//     in B, so idle lanes must not ride along; rebuild cost is two tiny buffers
+//     per lane).
+//   - release = drop the lane forward (caches freed; next admit re-creates).
+//   - Greedy only, resident tier only. Sequence budget per lane =
+//     min(model context, QWISP_LANE_CTX, default 16384) — KV arena is allocated
+//     per admit at this length.
+public final class LaneBatchSlots: BatchSlots {
+    let engine: SeedlessEngine
+    let driver: SeedlessFusedVerify.SeedlessFusedForward
+    public let slotCount: Int
+    let maxSeqLen: Int
+    private var lanes: [SeedlessFusedVerify.SeedlessFusedForward?]
+    private var batch: SeedlessLaneBatch? = nil
+    private var batchLanes: [ObjectIdentifier] = []   // active-set key for rebuild
+
+    public init?(store: WeightStore, slots: Int, maxSeqLen: Int) {
+        self.engine = SeedlessEngine.build(store: store)
+        // Driver = weights + M=slots scratch; its own caches are never advanced.
+        guard let (drv, _) = engine.makeFused(maxM: Swift.max(8, slots), maxSeqLen: 8) else { return nil }
+        self.driver = drv
+        self.slotCount = slots
+        self.maxSeqLen = maxSeqLen
+        self.lanes = Array(repeating: nil, count: slots)
+    }
+
+    public func admit(prompt: [Int32], slot: Int) -> Int? {
+        guard slot >= 0, slot < slotCount, !prompt.isEmpty, prompt.count < maxSeqLen,
+              let (fwd, _) = engine.makeFused(maxM: 64, maxSeqLen: maxSeqLen) else { return nil }
+        // Chunked prefill of all but the last prompt token; the last token goes
+        // through stepArgmax so the first generated token comes out of the same
+        // 1-CB primitive the decode loop uses (solo path — bit-exact anchor).
+        var pos = 0
+        while pos < prompt.count - 1 {
+            let end = Swift.min(pos + 64, prompt.count - 1)
+            guard fwd.forwardRows(engine.embed(tokens: Array(prompt[pos ..< end])), M: end - pos) != nil
+            else { return nil }
+            pos = end
+        }
+        guard let first = fwd.stepArgmax([prompt[prompt.count - 1]])?.first else { return nil }
+        lanes[slot] = fwd
+        return first
+    }
+
+    public func step(last: [Int32?]) -> [Int?] {
+        let activeSlots = (0 ..< slotCount).filter { last[$0] != nil && lanes[$0] != nil }
+        guard !activeSlots.isEmpty else { return Array(repeating: nil, count: slotCount) }
+        let activeLanes = activeSlots.map { lanes[$0]! }
+        let key = activeLanes.map { ObjectIdentifier($0) }
+        if batch == nil || key != batchLanes {
+            batch = SeedlessLaneBatch(driver: driver, lanes: activeLanes)
+            batchLanes = key
+        }
+        guard let b = batch, let toks = b.stepArgmaxBatch(activeSlots.map { last[$0]! })
+        else { return Array(repeating: nil, count: slotCount) }
+        var out: [Int?] = Array(repeating: nil, count: slotCount)
+        for (i, s) in activeSlots.enumerated() { out[s] = toks[i] }
+        return out
+    }
+
+    public func release(slot: Int) {
+        guard slot >= 0, slot < slotCount else { return }
+        lanes[slot] = nil
+        batch = nil; batchLanes = []   // active set changed
+    }
+}
+
+// ── Server backend ────────────────────────────────────────────────────────────
+/// LLMBackend over the continuous scheduler with lane-batched raw decode:
+/// concurrent generate() calls batch together AND stay bit-exact with the
+/// serialize path. Resident tier only; greedy only (server warns on sampling
+/// params). Opt-in via QWISP_LANES=<B>; the default serial path is untouched.
+public final class LaneBackend: LLMBackend, @unchecked Sendable {
+    let scheduler: ContinuousScheduler
+    let laneCtx: Int
+    public let slots: Int
+
+    public convenience init(modelDir: String, tier: SeedlessTier) throws {
+        try self.init(modelDir: modelDir, slots: Swift.max(2, Tell.envInt("QWISP_LANES", 4)))
+    }
+
+    public init(modelDir: String, slots: Int) throws {
+        guard DeviceCalibration.defaultC() >= 256 else {
+            throw NSError(domain: "qwisp", code: 7, userInfo: [NSLocalizedDescriptionKey:
+                "lane batching (QWISP_LANES) requires a resident-tier machine (≥32GB); this machine resolves to a streaming tier"])
+        }
+        let store = try WeightStore(modelDir: modelDir)
+        store.residentAll()
+        let ctx = Swift.min(SeedlessBackend.readContextLen(modelDir),
+                            Swift.max(2048, Tell.envInt("QWISP_LANE_CTX", 16384)))
+        guard let laneSlots = LaneBatchSlots(store: store, slots: slots, maxSeqLen: ctx) else {
+            throw NSError(domain: "qwisp", code: 7, userInfo: [NSLocalizedDescriptionKey:
+                "lane batching: engine build failed"])
+        }
+        self.slots = slots
+        self.laneCtx = ctx
+        self.scheduler = ContinuousScheduler(slots: laneSlots)
+    }
+
+    public func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncStream<Int> {
+        let headroom = Swift.max(0, laneCtx - prompt.count - 1)
+        let ceiling = options.maxTokens < 0 ? headroom : Swift.min(options.maxTokens, headroom)
+        return scheduler.submit(prompt: prompt, maxTokens: ceiling, stopIds: options.stopTokens)
+    }
+}

--- a/swift/Sources/QwispCore/LaneServe.swift
+++ b/swift/Sources/QwispCore/LaneServe.swift
@@ -41,19 +41,55 @@ public final class LaneBatchSlots: BatchSlots {
     }
 
     public func admit(prompt: [Int32], slot: Int) -> Int? {
+        // maxM 1024 = the canonical steel-hybrid prefill chunk (the shipped serialize
+        // path prefills hybrid@1024; the canonical greedy stream is defined WITH it —
+        // raw chunked prefill produces the pre-hybrid stream and diverges ~100 tokens
+        // in on f16 near-ties). Costs ~200MB scratch per active lane, resident tier.
         guard slot >= 0, slot < slotCount, !prompt.isEmpty, prompt.count < maxSeqLen,
-              let (fwd, _) = engine.makeFused(maxM: 64, maxSeqLen: maxSeqLen) else { return nil }
-        // Chunked prefill of all but the last prompt token; the last token goes
-        // through stepArgmax so the first generated token comes out of the same
-        // 1-CB primitive the decode loop uses (solo path — bit-exact anchor).
+              let (fwd, fnBuf) = engine.makeFused(maxM: 1024, maxSeqLen: maxSeqLen) else { return nil }
+        let hybrid = ProcessInfo.processInfo.environment["QWISP_HYBRID_PREFILL"] != "0"
+        if hybrid {
+            // Same wiring as TellRuntime's hybrid setup: per-layer MLX weight trios.
+            var hw: [Int: (qkv: (MLXArray, MLXArray, MLXArray), z: (MLXArray, MLXArray, MLXArray), out: (MLXArray, MLXArray, MLXArray))] = [:]
+            var aw: [Int: (q: (MLXArray, MLXArray, MLXArray), k: (MLXArray, MLXArray, MLXArray), v: (MLXArray, MLXArray, MLXArray), o: (MLXArray, MLXArray, MLXArray))] = [:]
+            for (i, spec) in engine.layers.enumerated() {
+                if let g = spec.gdn {
+                    hw[i] = (qkv: (g.qkvWq, g.qkvSc, g.qkvBi), z: (g.zWq, g.zSc, g.zBi), out: (g.outWq, g.outSc, g.outBi))
+                } else if let a = spec.attn {
+                    aw[i] = (q: (a.qWq, a.qSc, a.qBi), k: (a.kWq, a.kSc, a.kBi), v: (a.vWq, a.vSc, a.vBi), o: (a.oWq, a.oSc, a.oBi))
+                }
+            }
+            fwd.hybridGdnW = hw
+            fwd.hybridAttnW = aw
+            if Tell.envInt("QWISP_HYBRID_MOE", 1) == 1 {
+                var mw: [Int: (g: (MLXArray, MLXArray, MLXArray), u: (MLXArray, MLXArray, MLXArray), d: (MLXArray, MLXArray, MLXArray))] = [:]
+                for (i, spec) in engine.layers.enumerated() {
+                    let m = spec.moe
+                    mw[i] = (g: (m.swGWq, m.swGSc, m.swGBi), u: (m.swUWq, m.swUSc, m.swUBi), d: (m.swDWq, m.swDSc, m.swDBi))
+                }
+                fwd.hybridMoEW = mw
+            }
+        }
+        // Canonical prefill + first token, mirroring Tell.prefill + the spec-loop
+        // entry EXACTLY (kernel choice and tie-break included): full prompt through
+        // chunked (hybrid) forward with final norm, then first token =
+        // MLX.argMax(engine.logits(lastNormed)) — qmmTiled lm_head, MLX argmax.
+        let chunkSize = hybrid ? 1024 : 64
+        var lastNormed: MLXArray? = nil
         var pos = 0
-        while pos < prompt.count - 1 {
-            let end = Swift.min(pos + 64, prompt.count - 1)
-            guard fwd.forwardRows(engine.embed(tokens: Array(prompt[pos ..< end])), M: end - pos) != nil
+        while pos < prompt.count {
+            let end = Swift.min(pos + chunkSize, prompt.count)
+            let x = engine.embed(tokens: Array(prompt[pos ..< end]))
+            guard let normed = hybrid ? fwd.forwardRowsHybrid(x, M: end - pos, finalNormW: fnBuf)
+                                      : fwd.forwardRows(x, M: end - pos, finalNormW: fnBuf)
             else { return nil }
+            lastNormed = normed[end - pos - 1]
             pos = end
         }
-        guard let first = fwd.stepArgmax([prompt[prompt.count - 1]])?.first else { return nil }
+        guard let ln = lastNormed?.reshaped([1, SeedlessEngine.H]),
+              let lg = engine.logits(ln, M: 1) else { return nil }
+        MLX.eval([lg])
+        let first = MLX.argMax(lg[0], axis: -1).item(Int.self)
         lanes[slot] = fwd
         return first
     }

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Metal
 import MLX
 
 // Feasibility PoC for cross-request prefix caching (issue: agentic TTFT dominated by re-prefilling
@@ -84,6 +85,187 @@ extension Tell {
             }
         }
         return lines.joined(separator: "\n") + "\nLANEBENCH done"
+    }
+
+    // Lane-kernel micro-bench (Stage 1b go/no-go discriminator; GPU, no model):
+    // per-dispatch cost of each PER-LANE sequence-coupled kernel at real dims,
+    // hazard-chained like the real encoder (a shared output buffer WAW-serializes
+    // consecutive dispatches, mirroring the encoder-wide barrier behaviour), with
+    // state buffers cycling over a working set larger than the SLC so recurrence /
+    // KV traffic hits DRAM. Splits the per-lane step cost into dispatch tax
+    // (merge-able by B-lane kernels) vs state bandwidth (irreducible per lane).
+    public static func laneKernelBench() -> String {
+        guard let (device, queue) = SeedlessMetalForward.ensure(),
+              SeedlessFusedVerify.ensureRowsAuxPipelines(),
+              SeedlessFusedVerify.ensureGdnPipelines(),
+              SeedlessFusedVerify.ensureAttnPipelines(),
+              SeedlessFusedVerify.ensureWave3Pipelines(),
+              SeedlessLaneBatch.compileCopy(device)
+        else { return "[lane-kbench] pipeline ensure fail\nLANEKBENCH done" }
+        let Hk = 16, Dk = 128, Hv = 32, Dv = 128, cK = 4
+        let keyDim = Hk * Dk, valueDim = Hv * Dv, convDim = 2 * keyDim + valueDim
+        let nH = 16, nKV = 2, hD = 256, qd2 = 2 * hD, ropeDim = 64
+        let ctx = Tell.envInt("QWISP_LANE_CTX", 1024)
+        let eps: Float = 1e-6, ropeBase: Float = 1e7
+        func buf(_ n: Int) -> MTLBuffer { device.makeBuffer(length: n, options: .storageModeShared)! }
+        let N = 300                      // dispatches per measurement (~10 steps of 30)
+        let nSets = 16                   // state working set: 16×8.4MB rec = 134MB ≫ SLC
+
+        // shared (read or chained-write) buffers
+        let qB = buf(keyDim * 2), kB = buf(keyDim * 2), vB = buf(valueDim * 2)
+        let gB = buf(Hv * 4), betaB = buf(Hv * 4), yB = buf(valueDim * 2)
+        let qkvB = buf(convDim * 2), convOutB = buf(convDim * 2), convW = buf(convDim * cK * 4)
+        let qOutB = buf(nH * qd2 * 2), qNormB = buf(hD * 2), qRotB = buf(nH * hD * 2)
+        let kOutB = buf(nKV * hD * 2), kNormB = buf(hD * 2), kRotB = buf(nKV * hD * 2)
+        let vSrcB = buf(nKV * hD * 2), attnOutB = buf(nH * hD * 2)
+        // cycling per-"lane-layer" state sets
+        let recIn = (0 ..< nSets).map { _ in buf(Hv * Dv * Dk * 4) }
+        let recOut = (0 ..< nSets).map { _ in buf(Hv * Dv * Dk * 4) }
+        let hists = (0 ..< nSets).map { _ in buf(cK * convDim * 2) }
+        let histOuts = (0 ..< nSets).map { _ in buf(cK * convDim * 2) }
+        let kCaches = (0 ..< nSets).map { _ in buf(nKV * ctx * hD * 2) }
+        let vCaches = (0 ..< nSets).map { _ in buf(nKV * ctx * hD * 2) }
+        let copyA = buf(256 * 2), copyBf = buf(256 * 2)
+
+        func timeCB(_ body: (MTLComputeCommandEncoder, Int) -> Void) -> Double {
+            let cb = queue.makeCommandBuffer()!
+            let enc = cb.makeComputeCommandEncoder()!
+            for i in 0 ..< N { body(enc, i) }
+            enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+            return (cb.gpuEndTime - cb.gpuStartTime) * 1000.0
+        }
+        // measure twice (clock ramp), keep the second; report µs/dispatch
+        func us(_ body: @escaping (MTLComputeCommandEncoder, Int) -> Void) -> Double {
+            _ = timeCB(body)
+            return timeCB(body) * 1000.0 / Double(N)
+        }
+
+        let copyUs = us { enc, _ in
+            // dispatch+barrier floor: tiny chained copy (WAW on copyBf)
+            SeedlessLaneBatch.encodeRowCopyStatic(enc, src: copyA, srcOff: 0, dst: copyBf, dstOff: 0, count: 256)
+        }
+        let convUs = us { enc, i in
+            SeedlessFusedVerify.encodeGdnFusionConvShift(enc, hist: hists[i % nSets], qkv: qkvB,
+                                                         w: convW, convOut: convOutB, histOut: histOuts[i % nSets],
+                                                         M: 1, K: cK, C: convDim)
+        }
+        let recUs = us { enc, i in
+            SeedlessFusedVerify.encodeGatedDeltaStepRows(enc, q: qB, k: kB, v: vB, g: gB, beta: betaB,
+                                                         stateIn: recIn[i % nSets], stateOut: recOut[i % nSets],
+                                                         y: yB, T: 1, B: 1, Hv: Hv, Dv: Dv)
+        }
+        let recHotUs = us { enc, _ in
+            // same kernel, ONE state pair reused → SLC-hot: the DRAM-vs-latency split
+            SeedlessFusedVerify.encodeGatedDeltaStepRows(enc, q: qB, k: kB, v: vB, g: gB, beta: betaB,
+                                                         stateIn: recIn[0], stateOut: recOut[0],
+                                                         y: yB, T: 1, B: 1, Hv: Hv, Dv: Dv)
+        }
+        let qPrepUs = us { enc, _ in
+            SeedlessFusedVerify.encodeAttnQPrepRows(enc, qOut: qOutB, qNorm: qNormB, qRot: qRotB,
+                                                    qd2: qd2, headDim: hD, ropeDim: ropeDim, base: ropeBase,
+                                                    startOffset: ctx - 1, numHeads: nH, M: 1, eps: eps)
+        }
+        let kPrepUs = us { enc, i in
+            SeedlessFusedVerify.encodeAttnKPrepRows(enc, kOut: kOutB, kNorm: kNormB, kRot: kRotB,
+                                                    kCache: kCaches[i % nSets], headDim: hD, ropeDim: ropeDim,
+                                                    base: ropeBase, startOffset: ctx - 1, numKV: nKV,
+                                                    maxLen: ctx, M: 1, eps: eps)
+        }
+        let wkvUs = us { enc, i in
+            SeedlessFusedVerify.encodeWriteKVRows(enc, src: vSrcB, cache: vCaches[i % nSets],
+                                                  KV: nKV, D: hD, maxLen: ctx, pos: ctx - 1, M: 1)
+        }
+        let sdpaUs = us { enc, i in
+            SeedlessFusedVerify.encodeSdpaRows(enc, q: qRotB, k: kCaches[i % nSets], v: vCaches[i % nSets],
+                                               out: attnOutB, H: nH, KV: nKV, D: hD,
+                                               baseLenPlus1: ctx, M: 1,
+                                               scale: Float(pow(Double(hD), -0.5)), maxLen: ctx)
+        }
+
+        let gdnLane = 30.0 * (convUs + recUs)
+        let attnLane = 10.0 * (qPrepUs + kPrepUs + wkvUs + sdpaUs)
+        let perLaneMs = (gdnLane + attnLane) / 1000.0
+        let dispatches = 30.0 * 2 + 10.0 * 4
+        let taxMs = dispatches * copyUs / 1000.0
+        let recDramMs = 30.0 * Swift.max(0, recUs - recHotUs) / 1000.0
+        let lines = ["[lane-kbench] per-dispatch µs at real dims, hazard-chained, ctx=\(ctx), N=\(N), sets=\(nSets)",
+                     String(format: "  copy(floor) %6.1f | conv %6.1f | recur %6.1f (hot %6.1f) | qprep %6.1f | kprep %6.1f | wkv %6.1f | sdpa@%d %6.1f",
+                            copyUs, convUs, recUs, recHotUs, qPrepUs, kPrepUs, wkvUs, ctx, sdpaUs),
+                     String(format: "  per-lane/step: GDN 30×(conv+recur)=%.2fms + attn 10×(4)=%.2fms = %.2fms",
+                            gdnLane / 1000, attnLane / 1000, perLaneMs),
+                     String(format: "  split: dispatch-tax(%.0f × copy-floor)=%.2fms | recur DRAM excess=%.2fms | rest=%.2fms",
+                            dispatches, taxMs, recDramMs, perLaneMs - taxMs - recDramMs),
+                     String(format: "  Stage-1b ceiling @B=3 (tax/3, bandwidth kept): %.2fms/lane vs now %.2fms",
+                            perLaneMs - taxMs * 2.0 / 3.0, perLaneMs)]
+
+        // ── projection-kernel M-scaling probe: does qmm4_rows (qmv, per-row weight
+        // reads) vs qmm4_tiled (threadgroup-shared dequant) flip at small M for
+        // LAYER-shaped matrices? This is the residual B-scaling lever: the M=B
+        // projection dispatches dominate the per-lane increment if weights re-read per row.
+        guard SeedlessMetalForward._qmm4TiledPipeline != nil || {
+            let x = MLXRandom.normal([1, 512]).asType(.float16)
+            let wf = MLXRandom.normal([8, 512]).asType(.float16)
+            let (wq, s, b) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine)
+            MLX.eval([x, wq, s, b!])
+            return SeedlessMetalForward.qmmTiled(x, wq, scales: s, biases: b!, M: 1, K: 512, N: 8) != nil
+        }() else { return lines.joined(separator: "\n") + "\nLANEKBENCH done" }
+        let pK = 2048, pN = 8192                      // GDN in-proj shape [8192, 2048]
+        let pw = buf(pN * pK / 2), ps = buf(pN * (pK / 64) * 2), pb = buf(pN * (pK / 64) * 2)
+        var projLines: [String] = ["  proj [N=\(pN),K=\(pK)] µs/dispatch: M → rows | tiled"]
+        for M in [1, 2, 3, 4, 8] {
+            let px = buf(M * pK * 2), po = buf(M * pN * 2)
+            let rowsUs = us { enc, _ in
+                SeedlessFusedVerify.encodeQmmRows(enc, w: pw, scales: ps, biases: pb, x: px, out: po, M: M, K: pK, N: pN)
+            }
+            let tiledUs = us { enc, _ in
+                let qp = SeedlessMetalForward._qmm4TiledPipeline!
+                enc.setComputePipelineState(qp)
+                enc.setBuffer(pw, offset: 0, index: 0); enc.setBuffer(ps, offset: 0, index: 1)
+                enc.setBuffer(pb, offset: 0, index: 2); enc.setBuffer(px, offset: 0, index: 3)
+                enc.setBuffer(po, offset: 0, index: 4)
+                var kk = Int32(pK), nn = Int32(pN), mm = Int32(M)
+                enc.setBytes(&kk, length: 4, index: 5); enc.setBytes(&nn, length: 4, index: 6); enc.setBytes(&mm, length: 4, index: 7)
+                enc.dispatchThreadgroups(MTLSize(width: pN, height: 1, depth: 1),
+                                         threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+            }
+            projLines.append(String(format: "    M=%d  %7.1f | %7.1f", M, rowsUs, tiledUs))
+        }
+
+        // ── qmm4_rows_b (B-row qmv): correctness (byte vs qmm4_rows, random data)
+        // + speed. If B=3 ≪ 3× the M=1 rows cost, the projection lever is real.
+        var bLines: [String] = []
+        if SeedlessLaneBatch.compileQmmB(device) {
+            let xa = MLXRandom.normal([4, pK]).asType(.float16)
+            let wf = MLXRandom.normal([pN, pK]).asType(.float16)
+            let (wq, s0, b0) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine)
+            let sc = s0.asType(.float16), bi = b0!.asType(.float16)
+            MLX.eval([xa, wq, sc, bi])
+            if let bx = SeedlessMetalForward.mtlBuf(xa, device),
+               let bw = SeedlessMetalForward.mtlBuf(wq, device),
+               let bs = SeedlessMetalForward.mtlBuf(sc, device),
+               let bbq = SeedlessMetalForward.mtlBuf(bi, device) {
+                let oA = buf(4 * pN * 2), oB = buf(4 * pN * 2)
+                let ccb = queue.makeCommandBuffer()!
+                let cenc = ccb.makeComputeCommandEncoder()!
+                SeedlessFusedVerify.encodeQmmRows(cenc, w: bw, scales: bs, biases: bbq, x: bx, out: oA, M: 4, K: pK, N: pN)
+                SeedlessLaneBatch.encodeQmmRowsB(cenc, w: bw, scales: bs, biases: bbq, x: bx, xOff: 0, out: oB, outOff: 0, B: 4, K: pK, N: pN)
+                cenc.endEncoding(); ccb.commit(); ccb.waitUntilCompleted()
+                let same = memcmp(oA.contents(), oB.contents(), 4 * pN * 2) == 0
+                withExtendedLifetime([xa, wq, sc, bi]) {}
+                bLines.append("  qmm4_rows_b vs qmm4_rows byte-compare (B=4, random): \(same ? "PASS" : "FAIL")")
+            }
+            for M in [1, 2, 3, 4] {
+                let px = buf(M * pK * 2), po = buf(M * pN * 2)
+                let bUs = us { enc, _ in
+                    SeedlessLaneBatch.encodeQmmRowsB(enc, w: pw, scales: ps, biases: pb,
+                                                     x: px, xOff: 0, out: po, outOff: 0, B: M, K: pK, N: pN)
+                }
+                bLines.append(String(format: "    rows_b B=%d  %7.1f", M, bUs))
+            }
+        } else {
+            bLines.append("  qmm4_rows_b: compile FAIL")
+        }
+        return (lines + projLines + bLines).joined(separator: "\n") + "\nLANEKBENCH done"
     }
 
     // Long-context decay probe (#117 follow-up): the production log shows prefill chunk rate

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -12,6 +12,56 @@ import MLX
 // tail = the generation prompt + generated tokens that the next request rewinds past, B = the new
 // content appended in the next request.
 extension Tell {
+    // Lane-batch bench (Stage 1, parallel agents): real-model speed of the
+    // bit-exact lane-batched greedy step. B lanes prefill DIFFERENT prompts
+    // (diverse routing = worst-case MoE union), then decode batched; reports
+    // ms/step and per-stream + aggregate tok/s vs the M=1 solo baseline.
+    // Env: QWISP_LANE_B (default "1,2,3,4,8" sweep), QWISP_LANE_CTX (default 1024).
+    public static func laneBatchBench(modelDir: String) -> String {
+        guard let store = try? WeightStore(modelDir: modelDir) else { return "[lane-bench] load fail\nLANEBENCH done" }
+        store.residentAll()
+        let engine = SeedlessEngine.build(store: store)
+        let ctx = Tell.envInt("QWISP_LANE_CTX", 1024)
+        let bs = (ProcessInfo.processInfo.environment["QWISP_LANE_B"] ?? "1,2,3,4,8")
+            .split(separator: ",").compactMap { Int($0) }
+        func tok(_ n: Int, _ salt: Int) -> [Int32] { (0..<n).map { Int32((($0 &* 7 &+ salt) % 5000) + 100) } }
+        var lines = ["[lane-bench] ctx=\(ctx)/lane resident — bit-exact lane-batched greedy step",
+                     "     B   ms/step   per-stream   aggregate"]
+        for B in bs {
+            // Fresh lanes each B: own arena + prefill of a DIFFERENT prompt.
+            var lanes: [SeedlessFusedVerify.SeedlessFusedForward] = []
+            for b in 0 ..< B {
+                guard let (fwd, _) = engine.makeFused(maxM: 64, maxSeqLen: ctx + 128) else {
+                    return lines.joined(separator: "\n") + "\n[lane-bench] lane makeFused nil\nLANEBENCH done"
+                }
+                let prompt = tok(ctx, 13 + b * 17)
+                var pos = 0
+                while pos < ctx {
+                    let end = Swift.min(pos + 64, ctx)
+                    _ = fwd.forwardRows(engine.embed(tokens: Array(prompt[pos ..< end])), M: end - pos)
+                    pos = end
+                }
+                lanes.append(fwd)
+            }
+            guard let (drv, _) = engine.makeFused(maxM: Swift.max(8, B), maxSeqLen: 128),
+                  let batch = SeedlessLaneBatch(driver: drv, lanes: lanes) else {
+                return lines.joined(separator: "\n") + "\n[lane-bench] driver nil\nLANEBENCH done"
+            }
+            var ms = 0.0
+            let reps = 30
+            for r in 0 ..< reps {
+                let toks = (0 ..< B).map { Int32(200 + r * 7 + $0 * 31) }
+                let t0 = Date()
+                _ = batch.forwardRowsBatch(engine.embed(tokens: toks))
+                if r >= 5 { ms += Date().timeIntervalSince(t0) * 1000 }   // drop warmup
+            }
+            let step = ms / Double(reps - 5)
+            lines.append(String(format: "  %4d  %8.2f  %8.1f tok/s  %8.1f tok/s",
+                                B, step, 1000.0 / step, Double(B) * 1000.0 / step))
+        }
+        return lines.joined(separator: "\n") + "\nLANEBENCH done"
+    }
+
     // Long-context decay probe (#117 follow-up): the production log shows prefill chunk rate
     // decaying 348→66 tok/s over 0→40K and decode collapsing 45→7 tok/s at 48K. This isolates
     // WHY, per stage, using forwardRowsProfiled (exact per-encoder GPU ms bucketed GDN/attn/MoE).

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -61,6 +61,27 @@ extension Tell {
             let step = ms / Double(reps - 5)
             lines.append(String(format: "  %4d  %8.2f  %8.1f tok/s  %8.1f tok/s   (gpu %.2f ms)",
                                 B, step, 1000.0 / step, Double(B) * 1000.0 / step, gpuMs / Double(reps - 5)))
+            // Full greedy step (embed→layers→head→argmax, 1 CB, int-only readback)
+            // — the serve-path primitive; token feedback chains the trajectory.
+            var ams = 0.0, agpu = 0.0
+            var toks = (0 ..< B).map { Int32(300 + $0 * 13) }
+            var argmaxOK = true
+            for r in 0 ..< reps {
+                let t0 = Date()
+                guard let next = batch.stepArgmaxBatch(toks) else { argmaxOK = false; break }
+                if r >= 5 {
+                    ams += Date().timeIntervalSince(t0) * 1000
+                    agpu += SeedlessFusedVerify.SeedlessFusedForward.profLastGPUMs
+                }
+                toks = next.map { Int32($0) }
+            }
+            if argmaxOK {
+                let astep = ams / Double(reps - 5)
+                lines.append(String(format: "        argmax %6.2f  %8.1f tok/s  %8.1f tok/s   (gpu %.2f ms)",
+                                    astep, 1000.0 / astep, Double(B) * 1000.0 / astep, agpu / Double(reps - 5)))
+            } else {
+                lines.append("        argmax: stepArgmaxBatch nil (no head?)")
+            }
         }
         return lines.joined(separator: "\n") + "\nLANEBENCH done"
     }

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -47,17 +47,20 @@ extension Tell {
                   let batch = SeedlessLaneBatch(driver: drv, lanes: lanes) else {
                 return lines.joined(separator: "\n") + "\n[lane-bench] driver nil\nLANEBENCH done"
             }
-            var ms = 0.0
+            var ms = 0.0, gpuMs = 0.0
             let reps = 30
             for r in 0 ..< reps {
                 let toks = (0 ..< B).map { Int32(200 + r * 7 + $0 * 31) }
                 let t0 = Date()
                 _ = batch.forwardRowsBatch(engine.embed(tokens: toks))
-                if r >= 5 { ms += Date().timeIntervalSince(t0) * 1000 }   // drop warmup
+                if r >= 5 {   // drop warmup
+                    ms += Date().timeIntervalSince(t0) * 1000
+                    gpuMs += SeedlessFusedVerify.SeedlessFusedForward.profLastGPUMs
+                }
             }
             let step = ms / Double(reps - 5)
-            lines.append(String(format: "  %4d  %8.2f  %8.1f tok/s  %8.1f tok/s",
-                                B, step, 1000.0 / step, Double(B) * 1000.0 / step))
+            lines.append(String(format: "  %4d  %8.2f  %8.1f tok/s  %8.1f tok/s   (gpu %.2f ms)",
+                                B, step, 1000.0 / step, Double(B) * 1000.0 / step, gpuMs / Double(reps - 5)))
         }
         return lines.joined(separator: "\n") + "\nLANEBENCH done"
     }

--- a/swift/Sources/QwispCore/SeedlessLaneBatch.swift
+++ b/swift/Sources/QwispCore/SeedlessLaneBatch.swift
@@ -7,29 +7,41 @@ import MLX
 // B concurrent sequences ("lanes"), each with its OWN caches (KV arena + GDN
 // state) held by a per-lane SeedlessFusedForward, advance ONE token each through
 // a SINGLE fused pass so the dense/MoE weight reads amortize across lanes (the
-// M>1 prize: ~3x/token at M=16, spec-width probe) while the sequence-coupled
-// mixers (attention / GDN recurrence) run per-lane at literal M=1 with that
-// lane's caches — the exact solo kernels on the exact solo state.
+// M>1 prize) while the sequence-coupled kernels (attention SDPA/KV, GDN
+// conv/recurrence) run per-lane at literal M=1 against that lane's caches.
+//
+// Fast path (fusion flags ON, the default): every row-independent stage runs at
+// M=B on the DRIVER scratch — in-proj demux, GDN prep, norm/gate, attn sigmoid
+// gate, out/o-proj — and only the sequence-coupled kernels are dispatched per
+// lane, bound at a BYTE OFFSET into the driver scratch so lane b's core reads
+// and writes driver row b directly (no staging copies at all). Per lane per
+// layer that leaves 2 dispatches (GDN: conv shift + recurrence) or 4 (attn:
+// q-prep + k-prep + v-append + SDPA); everything else is one M=B dispatch per
+// layer regardless of B. Big projection weights are read ONCE per layer.
 //
 // Bit-exactness by construction (locked test `lane_batch_bitexact`):
-//   - mixer rows: literal M=1 solo path per lane (same kernel, same shapes,
-//     same cache) ⇒ identical bits.
-//   - norm/MoE/resid rows at M=B: per-row grids whose row math is M-invariant —
-//     the engine's core self-consistency guarantee (M-row kernel suite,
-//     RAWTESTS) that already underwrites strict verify ≡ M=1 decode.
+//   - per-lane kernels: same pipeline, same constants, same cache as solo M=1 —
+//     the offset binding only relocates the row storage ⇒ identical bits.
+//   - M=B stages: per-row grids whose row math is M-invariant — the engine's
+//     core self-consistency guarantee (M-row kernel suite, RAWTESTS) that
+//     already underwrites strict verify ≡ M=1 decode.
 //
-// Per layer: norm (M=B) → mixer per lane (M=1, staged via lane_row_copy) →
-// resid+postNorm (M=B) → MoE (M=B, per-row routing) → residAdd (M=B).
+// Fallback path (any fusion flag OFF / pipelines absent): the Stage-1 staged
+// form — projections at M=B, mixer CORE per lane via the hybridDense seam of
+// encodeGdnLayerRows/encodeAttnLayerRows, rows staged via lane_row_copy.
 //
-// Additive: reuses the frozen encode statics + Layer weight structs from the
-// driver; no frozen file is modified. Resident tier only (streaming's chunked
-// expert IO is a different scheduling problem — out of Stage 1 scope).
+// Additive: reuses the frozen encode statics + pipelines + Layer weight structs;
+// no frozen file is modified. Resident tier only (streaming's chunked expert IO
+// is a different scheduling problem — out of Stage 1 scope).
 public final class SeedlessLaneBatch {
     let driver: SeedlessFusedVerify.SeedlessFusedForward     // weights + M=B scratch
     let lanes: [SeedlessFusedVerify.SeedlessFusedForward]    // per-lane caches + scratch
     public let B: Int
-    let laneX: MTLBuffer                                     // [1, H] mixer input staging
-    let laneOut: MTLBuffer                                   // [1, H] mixer output staging
+    // Per-lane staging for the FALLBACK path only (one [1, H] pair PER lane: a
+    // shared pair would chain every lane through one buffer and Metal's
+    // buffer-granular hazard tracking would serialize the lane cores).
+    let laneXs: [MTLBuffer]
+    let laneOuts: [MTLBuffer]
 
     nonisolated(unsafe) static var copyPipeline: MTLComputePipelineState? = nil
     static func compileCopy(_ device: MTLDevice) -> Bool {
@@ -66,8 +78,8 @@ public final class SeedlessLaneBatch {
     }
 
     /// driver: weights + scratch sized maxM ≥ lanes.count. lanes: one forward per
-    /// sequence (its caches are the lane state; its scratch serves the M=1 mixer).
-    /// All must be resident-mode with the same layer stack.
+    /// sequence (its caches are the lane state; its scratch serves the fallback
+    /// M=1 mixer). All must be resident-mode with the same layer stack.
     public init?(driver: SeedlessFusedVerify.SeedlessFusedForward,
                  lanes: [SeedlessFusedVerify.SeedlessFusedForward]) {
         guard !lanes.isEmpty, driver.maxM >= lanes.count,
@@ -76,10 +88,277 @@ public final class SeedlessLaneBatch {
         self.driver = driver
         self.lanes = lanes
         self.B = lanes.count
-        guard let lx = driver.device.makeBuffer(length: driver.H * 2, options: .storageModeShared),
-              let lo = driver.device.makeBuffer(length: driver.H * 2, options: .storageModeShared) else { return nil }
-        self.laneX = lx
-        self.laneOut = lo
+        var lxs: [MTLBuffer] = [], los: [MTLBuffer] = []
+        for _ in lanes {
+            guard let lx = driver.device.makeBuffer(length: driver.H * 2, options: .storageModeShared),
+                  let lo = driver.device.makeBuffer(length: driver.H * 2, options: .storageModeShared) else { return nil }
+            lxs.append(lx); los.append(lo)
+        }
+        self.laneXs = lxs
+        self.laneOuts = los
+    }
+
+    // ── Offset-bound wrappers over the frozen per-lane pipelines ──────────────
+    // Same pipeline, same constants, same grid as the SeedlessFusedVerify encode
+    // statics; the ONLY difference is a byte offset on the row buffers so lane
+    // b's sequence-coupled kernel reads/writes driver scratch row b in place.
+
+    private func laneConvShift(_ enc: MTLComputeCommandEncoder, hist: MTLBuffer,
+                               qkv: MTLBuffer, qkvOff: Int, w: MTLBuffer,
+                               convOut: MTLBuffer, convOff: Int, histOut: MTLBuffer,
+                               K: Int, C: Int) {
+        let p = SeedlessFusedVerify._convShiftFusedRowsPipeline!
+        enc.setComputePipelineState(p)
+        enc.setBuffer(hist, offset: 0, index: 0); enc.setBuffer(qkv, offset: qkvOff, index: 1)
+        enc.setBuffer(w, offset: 0, index: 2); enc.setBuffer(convOut, offset: convOff, index: 3)
+        enc.setBuffer(histOut, offset: 0, index: 4)
+        var kk = UInt32(K), cc = UInt32(C), mm = UInt32(1)
+        enc.setBytes(&kk, length: 4, index: 5); enc.setBytes(&cc, length: 4, index: 6); enc.setBytes(&mm, length: 4, index: 7)
+        enc.dispatchThreads(MTLSize(width: C, height: 2, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: min(p.maxTotalThreadsPerThreadgroup, 256), height: 1, depth: 1))
+    }
+
+    private func laneDeltaStep(_ enc: MTLComputeCommandEncoder,
+                               q: MTLBuffer, qOff: Int, k: MTLBuffer, kOff: Int, v: MTLBuffer, vOff: Int,
+                               g: MTLBuffer, gOff: Int, beta: MTLBuffer, betaOff: Int,
+                               stateIn: MTLBuffer, stateOut: MTLBuffer, y: MTLBuffer, yOff: Int,
+                               Hv: Int, Dv: Int) {
+        let p = SeedlessMetalForward._recurPipeline!
+        enc.setComputePipelineState(p)
+        enc.setBuffer(q, offset: qOff, index: 0); enc.setBuffer(k, offset: kOff, index: 1)
+        enc.setBuffer(v, offset: vOff, index: 2)
+        enc.setBuffer(g, offset: gOff, index: 3); enc.setBuffer(beta, offset: betaOff, index: 4)
+        enc.setBuffer(stateIn, offset: 0, index: 5)
+        var tt = Int32(1); enc.setBytes(&tt, length: 4, index: 6)
+        enc.setBuffer(y, offset: yOff, index: 7); enc.setBuffer(stateOut, offset: 0, index: 8)
+        SeedlessMetalForward.bindStop(enc, 16)
+        enc.dispatchThreads(MTLSize(width: 32, height: Dv, depth: Hv),
+                            threadsPerThreadgroup: MTLSize(width: 32, height: 4, depth: 1))
+    }
+
+    private func laneQPrep(_ enc: MTLComputeCommandEncoder, qOut: MTLBuffer, qOutOff: Int,
+                           qNorm: MTLBuffer, qRot: MTLBuffer, qRotOff: Int,
+                           qd2: Int, headDim: Int, ropeDim: Int, base: Float,
+                           startOffset: Int, numHeads: Int, eps: Float) {
+        let p = SeedlessFusedVerify._attnQPrepRowsPipeline!
+        enc.setComputePipelineState(p)
+        enc.setBuffer(qOut, offset: qOutOff, index: 0)
+        enc.setBuffer(qNorm, offset: 0, index: 1)
+        enc.setBuffer(qRot, offset: qRotOff, index: 2)
+        var qd2v = UInt32(qd2), hd = UInt32(headDim), rd = UInt32(ropeDim)
+        var bs = base, so = UInt32(startOffset), nh = UInt32(numHeads), ee = eps
+        enc.setBytes(&qd2v, length: 4, index: 3); enc.setBytes(&hd, length: 4, index: 4)
+        enc.setBytes(&rd, length: 4, index: 5); enc.setBytes(&bs, length: 4, index: 6)
+        enc.setBytes(&so, length: 4, index: 7); enc.setBytes(&nh, length: 4, index: 8)
+        enc.setBytes(&ee, length: 4, index: 9)
+        SeedlessMetalForward.bindStop(enc, 16)
+        let tgSize = (((headDim + 3) / 4 + 31) / 32) * 32
+        enc.dispatchThreadgroups(MTLSize(width: numHeads, height: 1, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: tgSize, height: 1, depth: 1))
+    }
+
+    private func laneKPrep(_ enc: MTLComputeCommandEncoder, kOut: MTLBuffer, kOutOff: Int,
+                           kNorm: MTLBuffer, kRot: MTLBuffer, kRotOff: Int, kCache: MTLBuffer,
+                           headDim: Int, ropeDim: Int, base: Float,
+                           startOffset: Int, numKV: Int, maxLen: Int, eps: Float) {
+        let p = SeedlessFusedVerify._attnKPrepRowsPipeline!
+        enc.setComputePipelineState(p)
+        enc.setBuffer(kOut, offset: kOutOff, index: 0)
+        enc.setBuffer(kNorm, offset: 0, index: 1)
+        enc.setBuffer(kRot, offset: kRotOff, index: 2)
+        enc.setBuffer(kCache, offset: 0, index: 3)
+        var hd = UInt32(headDim), rd = UInt32(ropeDim), bs = base
+        var so = UInt32(startOffset), nkv = UInt32(numKV), ml = UInt32(maxLen), ee = eps
+        enc.setBytes(&hd, length: 4, index: 4); enc.setBytes(&rd, length: 4, index: 5)
+        enc.setBytes(&bs, length: 4, index: 6); enc.setBytes(&so, length: 4, index: 7)
+        enc.setBytes(&nkv, length: 4, index: 8); enc.setBytes(&ml, length: 4, index: 9)
+        enc.setBytes(&ee, length: 4, index: 10)
+        SeedlessMetalForward.bindStop(enc, 16)
+        let tgSize = (((headDim + 3) / 4 + 31) / 32) * 32
+        enc.dispatchThreadgroups(MTLSize(width: numKV, height: 1, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: tgSize, height: 1, depth: 1))
+    }
+
+    private func laneWriteKV(_ enc: MTLComputeCommandEncoder, src: MTLBuffer, srcOff: Int,
+                             cache: MTLBuffer, KV: Int, D: Int, maxLen: Int, pos: Int) {
+        let p = SeedlessFusedVerify._writeKVRowsPipeline!
+        enc.setComputePipelineState(p)
+        enc.setBuffer(src, offset: srcOff, index: 0); enc.setBuffer(cache, offset: 0, index: 1)
+        var kv = UInt32(KV), dd = UInt32(D), ml = UInt32(maxLen), pp = UInt32(pos), t = UInt32(KV * D)
+        enc.setBytes(&kv, length: 4, index: 2); enc.setBytes(&dd, length: 4, index: 3)
+        enc.setBytes(&ml, length: 4, index: 4); enc.setBytes(&pp, length: 4, index: 5); enc.setBytes(&t, length: 4, index: 6)
+        enc.dispatchThreads(MTLSize(width: KV * D, height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: min(p.maxTotalThreadsPerThreadgroup, 256), height: 1, depth: 1))
+    }
+
+    private func laneSdpa(_ enc: MTLComputeCommandEncoder, q: MTLBuffer, qOff: Int,
+                          k: MTLBuffer, v: MTLBuffer, out: MTLBuffer, outOff: Int,
+                          H: Int, KV: Int, D: Int, baseLenPlus1: Int, scale: Float, maxLen: Int) {
+        let p = SeedlessMetalForward._sdpaRowsPipeline!
+        enc.setComputePipelineState(p)
+        enc.setBuffer(q, offset: qOff, index: 0); enc.setBuffer(k, offset: 0, index: 1)
+        enc.setBuffer(v, offset: 0, index: 2); enc.setBuffer(out, offset: outOff, index: 3)
+        var gqa = Int32(H / KV), bn = Int32(baseLenPlus1)
+        var khs = Int32(maxLen * D), kss = Int32(D), vhs = Int32(maxLen * D), vss = Int32(D), sc = scale
+        enc.setBytes(&gqa, length: 4, index: 4); enc.setBytes(&bn, length: 4, index: 5)
+        enc.setBytes(&khs, length: 4, index: 6); enc.setBytes(&kss, length: 4, index: 7)
+        enc.setBytes(&vhs, length: 4, index: 8); enc.setBytes(&vss, length: 4, index: 9)
+        enc.setBytes(&sc, length: 4, index: 10)
+        enc.dispatchThreadgroups(MTLSize(width: H, height: 1, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 1024, height: 1, depth: 1))
+    }
+
+    // ── Per-layer encoders ────────────────────────────────────────────────────
+
+    /// Fast GDN layer: demux (M=B) → conv shift per lane (offset-bound) → prep
+    /// (M=B) → recurrence per lane (offset-bound) → norm/gate (M=B) → out_proj (M=B).
+    private func encodeGdnLayerFast(_ enc: MTLComputeCommandEncoder, li: Int, gw: SeedlessFusedVerify.GdnLayerBufs,
+                                    keyDim: Int, valueDim: Int, convDim: Int) {
+        let H = driver.H, Hv = driver.numVHeads
+        SeedlessFusedVerify.encodeQmmInProjDemuxRows(
+            enc, w: gw.catInProjW!, scales: gw.catInProjS!, biases: gw.catInProjB!, x: driver.normed,
+            outQkv: driver.gdnSc.qkv, outZ: driver.gdnSc.z,
+            outB: driver.gdnSc.bP, outA: driver.gdnSc.aP,
+            M: B, K: H, dims: (qkv: convDim, z: valueDim, b: Hv, a: Hv))
+        for b in 0 ..< B {
+            let gc = lanes[b].layers[li].gdnCache!
+            laneConvShift(enc, hist: gc.convHist, qkv: driver.gdnSc.qkv, qkvOff: b * convDim * 2,
+                          w: gw.conv1dW, convOut: driver.gdnSc.convOut, convOff: b * convDim * 2,
+                          histOut: gc.convHistOut, K: driver.convKernel, C: convDim)
+        }
+        let invScale = Float(pow(Double(driver.headKDim), -0.5))
+        SeedlessFusedVerify.encodeGdnPrepRows(enc, convOut: driver.gdnSc.convOut,
+                                              aP: driver.gdnSc.aP, bP: driver.gdnSc.bP,
+                                              aLog: gw.aLog, dtBias: gw.dtBias,
+                                              qn: driver.gdnSc.qn, kn: driver.gdnSc.kn, v: driver.gdnSc.v1,
+                                              g: driver.gdnSc.g, beta: driver.gdnSc.beta,
+                                              M: B, numKH: driver.numKHeads, headKD: driver.headKDim, numVH: Hv,
+                                              keyDim: keyDim, valDim: valueDim, eps: driver.eps,
+                                              qScale: invScale * invScale, kScale: invScale)
+        for b in 0 ..< B {
+            let gc = lanes[b].layers[li].gdnCache!
+            laneDeltaStep(enc, q: driver.gdnSc.qn, qOff: b * keyDim * 2,
+                          k: driver.gdnSc.kn, kOff: b * keyDim * 2,
+                          v: driver.gdnSc.v1, vOff: b * valueDim * 2,
+                          g: driver.gdnSc.g, gOff: b * Hv * 4,
+                          beta: driver.gdnSc.beta, betaOff: b * Hv * 4,
+                          stateIn: gc.state, stateOut: gc.stateOut,
+                          y: driver.gdnSc.coreOut, yOff: b * valueDim * 2,
+                          Hv: Hv, Dv: driver.headVDim)
+            gc.swapState()
+        }
+        SeedlessFusedVerify.encodeGdnNormGateRows(enc, coreOut: driver.gdnSc.coreOut, z: driver.gdnSc.z,
+                                                  normWeight: gw.normWeight, outV: driver.gdnSc.outV,
+                                                  M: B, Hv: Hv, Dv: driver.headVDim,
+                                                  eps: driver.eps, promoteF32: gw.promoteRMS)
+        SeedlessFusedVerify.encodeQmmRows(enc, w: gw.outW, scales: gw.outS, biases: gw.outB,
+                                          x: driver.gdnSc.outV, out: driver.mixerOut,
+                                          M: B, K: valueDim, N: H)
+    }
+
+    /// Fast attn layer: qkv demux (M=B) → q-prep/k-prep/v-append/SDPA per lane
+    /// (offset-bound, RoPE at the lane's own position) → sigmoid gate (M=B) → o_proj (M=B).
+    private func encodeAttnLayerFast(_ enc: MTLComputeCommandEncoder, li: Int, aw: SeedlessFusedVerify.AttnLayerBufs) {
+        let H = driver.H, nH = driver.numHeads, nKV = driver.numKV, hD = driver.headDim
+        let qd2 = 2 * hD
+        let scale = Float(pow(Double(hD), -0.5))
+        SeedlessFusedVerify.encodeQmmInProjDemuxRows(
+            enc, w: aw.catQkvW!, scales: aw.catQkvS!, biases: aw.catQkvB!, x: driver.normed,
+            outQkv: driver.attnSc.qOut, outZ: driver.attnSc.kOut,
+            outB: driver.attnSc.vOut, outA: aw.catQkvDummy!,
+            M: B, K: H, dims: (qkv: nH * qd2, z: nKV * hD, b: nKV * hD, a: 0))
+        for b in 0 ..< B {
+            let kv = lanes[b].layers[li].kvCache!
+            let baseLen = kv.len
+            laneQPrep(enc, qOut: driver.attnSc.qOut, qOutOff: b * nH * qd2 * 2,
+                      qNorm: aw.qNorm, qRot: driver.attnSc.qRot, qRotOff: b * nH * hD * 2,
+                      qd2: qd2, headDim: hD, ropeDim: driver.ropeDim, base: driver.ropeBase,
+                      startOffset: baseLen, numHeads: nH, eps: driver.eps)
+            laneKPrep(enc, kOut: driver.attnSc.kOut, kOutOff: b * nKV * hD * 2,
+                      kNorm: aw.kNorm, kRot: driver.attnSc.kRot, kRotOff: b * nKV * hD * 2,
+                      kCache: kv.kCache, headDim: hD, ropeDim: driver.ropeDim, base: driver.ropeBase,
+                      startOffset: baseLen, numKV: nKV, maxLen: kv.maxLen, eps: driver.eps)
+            laneWriteKV(enc, src: driver.attnSc.vOut, srcOff: b * nKV * hD * 2,
+                        cache: kv.vCache, KV: nKV, D: hD, maxLen: kv.maxLen, pos: baseLen)
+            laneSdpa(enc, q: driver.attnSc.qRot, qOff: b * nH * hD * 2,
+                     k: kv.kCache, v: kv.vCache, out: driver.attnSc.attnOut, outOff: b * nH * hD * 2,
+                     H: nH, KV: nKV, D: hD, baseLenPlus1: baseLen + 1, scale: scale, maxLen: kv.maxLen)
+            kv.len += 1
+        }
+        SeedlessFusedVerify.encodeSigmoidMul(enc, attnOut: driver.attnSc.attnOut, qOut: driver.attnSc.qOut,
+                                             gated: driver.attnSc.gated,
+                                             headDim: hD, qd2: qd2, total: B * nH * hD)
+        SeedlessFusedVerify.encodeQmmRows(enc, w: aw.oW, scales: aw.oS, biases: aw.oB,
+                                          x: driver.attnSc.gated, out: driver.mixerOut,
+                                          M: B, K: nH * hD, N: H)
+    }
+
+    /// Fallback GDN layer (fusion flags off): in-proj at M=B where possible, mixer
+    /// core per lane via the hybridDense seam, rows staged through lane scratch.
+    private func encodeGdnLayerStaged(_ enc: MTLComputeCommandEncoder, li: Int, gw: SeedlessFusedVerify.GdnLayerBufs,
+                                      keyDim: Int, valueDim: Int, convDim: Int) {
+        let H = driver.H
+        SeedlessFusedVerify.encodeQmmRows(enc, w: gw.qkvW, scales: gw.qkvS, biases: gw.qkvB,
+                                          x: driver.normed, out: driver.gdnSc.qkv, M: B, K: H, N: convDim)
+        SeedlessFusedVerify.encodeQmmRows(enc, w: gw.zW, scales: gw.zS, biases: gw.zB,
+                                          x: driver.normed, out: driver.gdnSc.z, M: B, K: H, N: valueDim)
+        for b in 0 ..< B {
+            let lane = lanes[b]
+            let gc = lane.layers[li].gdnCache!
+            encodeRowCopy(enc, src: driver.normed, srcOff: b * H, dst: laneXs[b], dstOff: 0, count: H)
+            encodeRowCopy(enc, src: driver.gdnSc.qkv, srcOff: b * convDim,
+                          dst: lane.gdnSc.qkv, dstOff: 0, count: convDim)
+            encodeRowCopy(enc, src: driver.gdnSc.z, srcOff: b * valueDim,
+                          dst: lane.gdnSc.z, dstOff: 0, count: valueDim)
+            SeedlessFusedVerify.encodeGdnLayerRows(enc, x: laneXs[b], out: laneOuts[b], w: gw,
+                                                   sc: lane.gdnSc, cache: gc, M: 1, H: H,
+                                                   numKHeads: driver.numKHeads, numVHeads: driver.numVHeads,
+                                                   headKDim: driver.headKDim, headVDim: driver.headVDim,
+                                                   convKernel: driver.convKernel, eps: driver.eps,
+                                                   hybridDense: true)
+            gc.swapState()
+            encodeRowCopy(enc, src: lane.gdnSc.outV, srcOff: 0,
+                          dst: driver.gdnSc.outV, dstOff: b * valueDim, count: valueDim)
+        }
+        SeedlessFusedVerify.encodeQmmRows(enc, w: gw.outW, scales: gw.outS, biases: gw.outB,
+                                          x: driver.gdnSc.outV, out: driver.mixerOut,
+                                          M: B, K: valueDim, N: H)
+    }
+
+    /// Fallback attn layer (fusion flags off): qkv at M=B, core per lane via the
+    /// hybridDense seam, rows staged through lane scratch.
+    private func encodeAttnLayerStaged(_ enc: MTLComputeCommandEncoder, li: Int, aw: SeedlessFusedVerify.AttnLayerBufs) {
+        let H = driver.H, nH = driver.numHeads, nKV = driver.numKV, hD = driver.headDim
+        let qd2 = 2 * hD
+        SeedlessFusedVerify.encodeQmmRows(enc, w: aw.qW, scales: aw.qS, biases: aw.qB,
+                                          x: driver.normed, out: driver.attnSc.qOut, M: B, K: H, N: nH * qd2)
+        SeedlessFusedVerify.encodeQmmRows(enc, w: aw.kW, scales: aw.kS, biases: aw.kB,
+                                          x: driver.normed, out: driver.attnSc.kOut, M: B, K: H, N: nKV * hD)
+        SeedlessFusedVerify.encodeQmmRows(enc, w: aw.vW, scales: aw.vS, biases: aw.vB,
+                                          x: driver.normed, out: driver.attnSc.vOut, M: B, K: H, N: nKV * hD)
+        for b in 0 ..< B {
+            let lane = lanes[b]
+            let kv = lane.layers[li].kvCache!
+            encodeRowCopy(enc, src: driver.attnSc.qOut, srcOff: b * nH * qd2,
+                          dst: lane.attnSc.qOut, dstOff: 0, count: nH * qd2)
+            encodeRowCopy(enc, src: driver.attnSc.kOut, srcOff: b * nKV * hD,
+                          dst: lane.attnSc.kOut, dstOff: 0, count: nKV * hD)
+            encodeRowCopy(enc, src: driver.attnSc.vOut, srcOff: b * nKV * hD,
+                          dst: lane.attnSc.vOut, dstOff: 0, count: nKV * hD)
+            // x unused by the hybridDense attn path (① skipped) — per-lane placeholder.
+            SeedlessFusedVerify.encodeAttnLayerRows(enc, x: laneXs[b], out: laneOuts[b], w: aw,
+                                                    sc: lane.attnSc, kv: kv, M: 1, H: H,
+                                                    numHeads: nH, numKV: nKV,
+                                                    headDim: hD, ropeDim: driver.ropeDim,
+                                                    ropeBase: driver.ropeBase, eps: driver.eps,
+                                                    hybridDense: true)
+            kv.len += 1
+            encodeRowCopy(enc, src: lane.attnSc.gated, srcOff: 0,
+                          dst: driver.attnSc.gated, dstOff: b * nH * hD, count: nH * hD)
+        }
+        SeedlessFusedVerify.encodeQmmRows(enc, w: aw.oW, scales: aw.oS, biases: aw.oB,
+                                          x: driver.attnSc.gated, out: driver.mixerOut,
+                                          M: B, K: nH * hD, N: H)
     }
 
     /// One batched step: row b of `x` [B, H] is lane b's next-token hidden input.
@@ -94,32 +373,37 @@ public final class SeedlessLaneBatch {
         driver.hBuf.contents().bindMemory(to: Float16.self, capacity: driver.maxM * H)
             .update(from: arr, count: B * H)
 
+        let keyDim = driver.headKDim * driver.numKHeads
+        let valueDim = driver.headVDim * driver.numVHeads
+        let convDim = keyDim * 2 + valueDim
+        let gdnFast = SeedlessFusedVerify.SeedlessFusedForward.fuseGDN
+            && SeedlessFusedVerify._gdnPrepRowsPipeline != nil
+            && SeedlessFusedVerify._convShiftFusedRowsPipeline != nil
+        let attnFast = SeedlessFusedVerify.SeedlessFusedForward.fuseATTN
+            && SeedlessFusedVerify.SeedlessFusedForward.fuseA1Enabled
+            && SeedlessFusedVerify.ensureWave3Pipelines()
+
         let cb = driver.queue.makeCommandBuffer()!
         let enc = cb.makeComputeCommandEncoder()!
         for li in driver.layers.indices {
             let L = driver.layers[li]
             SeedlessFusedVerify.encodeRmsNormRows(enc, x: driver.hBuf, w: L.inputLN,
                                                   out: driver.normed, rows: B, D: H, eps: driver.eps)
-            for b in 0 ..< B {
-                let lane = lanes[b]
-                let LL = lane.layers[li]
-                encodeRowCopy(enc, src: driver.normed, srcOff: b * H, dst: laneX, dstOff: 0, count: H)
-                if L.isLinear, let gw = L.gdn, let gc = LL.gdnCache {
-                    SeedlessFusedVerify.encodeGdnLayerRows(enc, x: laneX, out: laneOut, w: gw,
-                                                           sc: lane.gdnSc, cache: gc, M: 1, H: H,
-                                                           numKHeads: driver.numKHeads, numVHeads: driver.numVHeads,
-                                                           headKDim: driver.headKDim, headVDim: driver.headVDim,
-                                                           convKernel: driver.convKernel, eps: driver.eps)
-                    gc.swapState()
-                } else if let aw = L.attn, let kv = LL.kvCache {
-                    SeedlessFusedVerify.encodeAttnLayerRows(enc, x: laneX, out: laneOut, w: aw,
-                                                            sc: lane.attnSc, kv: kv, M: 1, H: H,
-                                                            numHeads: driver.numHeads, numKV: driver.numKV,
-                                                            headDim: driver.headDim, ropeDim: driver.ropeDim,
-                                                            ropeBase: driver.ropeBase, eps: driver.eps)
-                    kv.len += 1
+            if L.isLinear, let gw = L.gdn {
+                if gdnFast, gw.catInProjW != nil,
+                   gw.totalInProjN == convDim + valueDim + 2 * driver.numVHeads,
+                   gw.promoteRMS ? SeedlessFusedVerify._gdnNormGateRowsF32Pipeline != nil
+                                 : SeedlessFusedVerify._gdnNormGateRowsPipeline != nil {
+                    encodeGdnLayerFast(enc, li: li, gw: gw, keyDim: keyDim, valueDim: valueDim, convDim: convDim)
+                } else {
+                    encodeGdnLayerStaged(enc, li: li, gw: gw, keyDim: keyDim, valueDim: valueDim, convDim: convDim)
                 }
-                encodeRowCopy(enc, src: laneOut, srcOff: 0, dst: driver.mixerOut, dstOff: b * H, count: H)
+            } else if let aw = L.attn {
+                if attnFast, aw.catQkvW != nil, aw.catQkvDummy != nil {
+                    encodeAttnLayerFast(enc, li: li, aw: aw)
+                } else {
+                    encodeAttnLayerStaged(enc, li: li, aw: aw)
+                }
             }
             // resid + postNorm at M=B — mirrors encodePreMoE's tail exactly.
             if SeedlessFusedVerify.SeedlessFusedForward.fuseGDN,

--- a/swift/Sources/QwispCore/SeedlessLaneBatch.swift
+++ b/swift/Sources/QwispCore/SeedlessLaneBatch.swift
@@ -64,8 +64,148 @@ public final class SeedlessLaneBatch {
         return true
     }
 
-    private func encodeRowCopy(_ enc: MTLComputeCommandEncoder,
-                               src: MTLBuffer, srcOff: Int, dst: MTLBuffer, dstOff: Int, count: Int) {
+    // ── qmm4_rows_b: B-row qmv (Stage 1b projection lever — measured NO-GO) ───
+    // Same grid/simdgroup structure and PER-ROW arithmetic order as the shipped
+    // qmm4 (qmv) kernel — the ONLY change is an inner b-loop so the device weight
+    // reads are shared across up to 4 x-rows instead of re-read per row.
+    // Per-(row,b) accumulation = identical fma sequence to qmm4 with that x row
+    // ⇒ bit-exact by construction (byte-compared PASS in lane-kernel-bench).
+    // VERDICT (2026-07-21, lane-kernel-bench @[N=8192,K=2048]): 4-6x SLOWER than
+    // qmm4_rows at every B (B=1 107µs vs 26; B=3 402 vs 65) — the x_thread[4][16]
+    // register file collapses occupancy and costs far more than the ~0.7x/row
+    // weight re-read it saves. NOT wired into any forward path; kept only as the
+    // measured evidence + harness for the Stage-1b projection-lever NO-GO. Do not
+    // re-propose weight-read amortization for qmv decode shapes without a design
+    // that adds rows WITHOUT growing per-thread register state.
+    nonisolated(unsafe) static var qmmBPipeline: MTLComputePipelineState? = nil
+    static func compileQmmB(_ device: MTLDevice) -> Bool {
+        if qmmBPipeline != nil { return true }
+        let src = """
+        #include <metal_stdlib>
+        using namespace metal;
+        #define SIMD_SIZE 32
+        inline float ld16(const device half* x, thread float* xt) {
+            float sum = 0.0f;
+            for (int i = 0; i < 16; i += 4) {
+                sum += x[i] + x[i+1] + x[i+2] + x[i+3];
+                xt[i]   = x[i];
+                xt[i+1] = x[i+1] / 16.0f;
+                xt[i+2] = x[i+2] / 256.0f;
+                xt[i+3] = x[i+3] / 4096.0f;
+            }
+            return sum;
+        }
+        inline float qd4(const device uint8_t* w, const thread float* xt, float scale, float bias, float sum) {
+            float accum = 0.0f;
+            const device uint16_t* ws = (const device uint16_t*)w;
+            for (int i = 0; i < 4; i++) {
+                accum += (xt[4*i]   * (float)(ws[i] & 0x000f) +
+                          xt[4*i+1] * (float)(ws[i] & 0x00f0) +
+                          xt[4*i+2] * (float)(ws[i] & 0x0f00) +
+                          xt[4*i+3] * (float)(ws[i] & 0xf000));
+            }
+            return scale * accum + sum * bias;
+        }
+        kernel void qmm4_rows_b(device const uint32_t* w      [[buffer(0)]],
+                                device const half*     scales [[buffer(1)]],
+                                device const half*     biases [[buffer(2)]],
+                                device const half*     x      [[buffer(3)]],
+                                device half*           y      [[buffer(4)]],
+                                constant int&          in_vec_size  [[buffer(5)]],   // K
+                                constant int&          out_vec_size [[buffer(6)]],   // N
+                                constant int&          nrows        [[buffer(7)]],   // B ≤ 4
+                                uint3 tid      [[threadgroup_position_in_grid]],
+                                uint  simd_gid [[simdgroup_index_in_threadgroup]],
+                                uint  simd_lid [[thread_index_in_simdgroup]]) {
+            constexpr int packs_per_thread = 2;
+            constexpr int num_simdgroups = 2;
+            constexpr int results_per_simdgroup = 4;
+            constexpr int pack_factor = 8;
+            constexpr int bytes_per_pack = 4;
+            constexpr int values_per_thread = 16;
+            constexpr int block_size = 512;
+            constexpr int scale_step_per_thread = 4;
+            const device uint8_t* ws = (const device uint8_t*)w;
+            typedef float U;
+            thread U x_thread[4][16];
+            thread U sums[4];
+            thread U result[4][4] = {{0}};        // [out-row][b]
+            const int B = nrows;
+            const int in_vec_size_w = in_vec_size * bytes_per_pack / pack_factor;
+            const int in_vec_size_g = in_vec_size / 64;
+            const int out_row = tid.y * (num_simdgroups * results_per_simdgroup) + simd_gid * results_per_simdgroup;
+            ws     += out_row * in_vec_size_w + simd_lid * packs_per_thread * bytes_per_pack;
+            scales += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+            biases += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+            y += out_row;
+            int xoff = simd_lid * values_per_thread;
+            for (int k = 0; k < in_vec_size; k += block_size) {
+                for (int b = 0; b < B; b++)
+                    sums[b] = ld16(x + b * in_vec_size + xoff, x_thread[b]);
+                for (int row = 0; row < results_per_simdgroup; row++) {
+                    auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
+                    const device half* sl = scales + row * in_vec_size_g;
+                    const device half* bl = biases + row * in_vec_size_g;
+                    U s = sl[0]; U bi = bl[0];
+                    for (int b = 0; b < B; b++)
+                        result[row][b] += qd4(wl, x_thread[b], s, bi, sums[b]);
+                }
+                ws += block_size * bytes_per_pack / pack_factor;
+                scales += block_size / 64;
+                biases += block_size / 64;
+                xoff += block_size;
+            }
+            for (int row = 0; row < results_per_simdgroup; row++) {
+                for (int b = 0; b < B; b++) {
+                    result[row][b] = simd_sum(result[row][b]);
+                    if (simd_lid == 0) y[b * out_vec_size + row] = (half)result[row][b];
+                }
+            }
+        }
+        """
+        // Math opts MUST mirror the shipped qmm4 compile (QWISP_QMM_MATH, default
+        // safe) — bit-exactness of qd4 depends on identical FMA-contraction setting.
+        let opts = MTLCompileOptions()
+        let mathSel = ProcessInfo.processInfo.environment["QWISP_QMM_MATH"] ?? "safe"
+        if #available(macOS 15.0, *) {
+            switch mathSel {
+            case "fast": opts.mathMode = .fast
+            case "relaxed": opts.mathMode = .relaxed
+            default: opts.mathMode = .safe
+            }
+        } else {
+            opts.fastMathEnabled = (mathSel == "fast")
+        }
+        guard let lib = try? device.makeLibrary(source: src, options: opts),
+              let fn = lib.makeFunction(name: "qmm4_rows_b"),
+              let ps = try? device.makeComputePipelineState(function: fn) else { return false }
+        qmmBPipeline = ps
+        return true
+    }
+
+    /// Encode qmm4_rows_b: x[B,K] · W[N,K] → y[B,N], B ≤ 4 per dispatch (callers
+    /// split larger B into row groups). x/y offsets are BYTE offsets (row groups).
+    static func encodeQmmRowsB(_ enc: MTLComputeCommandEncoder,
+                               w: MTLBuffer, scales: MTLBuffer, biases: MTLBuffer,
+                               x: MTLBuffer, xOff: Int, out: MTLBuffer, outOff: Int,
+                               B: Int, K: Int, N: Int) {
+        let p = SeedlessLaneBatch.qmmBPipeline!
+        enc.setComputePipelineState(p)
+        enc.setBuffer(w, offset: 0, index: 0)
+        enc.setBuffer(scales, offset: 0, index: 1)
+        enc.setBuffer(biases, offset: 0, index: 2)
+        enc.setBuffer(x, offset: xOff, index: 3)
+        enc.setBuffer(out, offset: outOff, index: 4)
+        var kk = Int32(K), nn = Int32(N), bb = Int32(B)
+        enc.setBytes(&kk, length: 4, index: 5)
+        enc.setBytes(&nn, length: 4, index: 6)
+        enc.setBytes(&bb, length: 4, index: 7)
+        enc.dispatchThreadgroups(MTLSize(width: 1, height: N / 8, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 32, height: 2, depth: 1))
+    }
+
+    static func encodeRowCopyStatic(_ enc: MTLComputeCommandEncoder,
+                                    src: MTLBuffer, srcOff: Int, dst: MTLBuffer, dstOff: Int, count: Int) {
         let ps = SeedlessLaneBatch.copyPipeline!
         enc.setComputePipelineState(ps)
         enc.setBuffer(src, offset: 0, index: 0)
@@ -75,6 +215,11 @@ public final class SeedlessLaneBatch {
         enc.setBytes(&do_, length: 4, index: 3)
         enc.dispatchThreads(MTLSize(width: count, height: 1, depth: 1),
                             threadsPerThreadgroup: MTLSize(width: min(ps.maxTotalThreadsPerThreadgroup, 256), height: 1, depth: 1))
+    }
+
+    private func encodeRowCopy(_ enc: MTLComputeCommandEncoder,
+                               src: MTLBuffer, srcOff: Int, dst: MTLBuffer, dstOff: Int, count: Int) {
+        SeedlessLaneBatch.encodeRowCopyStatic(enc, src: src, srcOff: srcOff, dst: dst, dstOff: dstOff, count: count)
     }
 
     /// driver: weights + scratch sized maxM ≥ lanes.count. lanes: one forward per

--- a/swift/Sources/QwispCore/SeedlessLaneBatch.swift
+++ b/swift/Sources/QwispCore/SeedlessLaneBatch.swift
@@ -361,18 +361,10 @@ public final class SeedlessLaneBatch {
                                           M: B, K: nH * hD, N: H)
     }
 
-    /// One batched step: row b of `x` [B, H] is lane b's next-token hidden input.
-    /// Returns the residual-stream output rows [B, H] (pre-final-norm, mirroring
-    /// forwardRows(finalNormW: nil)). Each lane's caches advance by exactly one
-    /// position — bit-identical to that lane running forwardRows(M: 1) alone.
-    public func forwardRowsBatch(_ x: MLXArray) -> MLXArray? {
+    /// Encode all layers for one batched step (rows already in driver.hBuf [B, H]).
+    /// Shared by forwardRowsBatch and stepArgmaxBatch.
+    private func encodeAllLayers(_ enc: MTLComputeCommandEncoder) {
         let H = driver.H
-        guard x.dim(0) == B, x.dim(1) == H else { return nil }
-        let xf = x.asType(.float16).reshaped([-1]); xf.eval()
-        let arr = xf.asArray(Float16.self)
-        driver.hBuf.contents().bindMemory(to: Float16.self, capacity: driver.maxM * H)
-            .update(from: arr, count: B * H)
-
         let keyDim = driver.headKDim * driver.numKHeads
         let valueDim = driver.headVDim * driver.numVHeads
         let convDim = keyDim * 2 + valueDim
@@ -383,8 +375,6 @@ public final class SeedlessLaneBatch {
             && SeedlessFusedVerify.SeedlessFusedForward.fuseA1Enabled
             && SeedlessFusedVerify.ensureWave3Pipelines()
 
-        let cb = driver.queue.makeCommandBuffer()!
-        let enc = cb.makeComputeCommandEncoder()!
         for li in driver.layers.indices {
             let L = driver.layers[li]
             SeedlessFusedVerify.encodeRmsNormRows(enc, x: driver.hBuf, w: L.inputLN,
@@ -421,10 +411,84 @@ public final class SeedlessLaneBatch {
                                                    M: B, E: L.E, I: L.I, Ktop: L.Ktop, H: H)
             SeedlessFusedVerify.encodeResidAdd(enc, h: driver.hBuf, r: driver.moeOut, total: B * H)
         }
+    }
+
+    /// One batched step: row b of `x` [B, H] is lane b's next-token hidden input.
+    /// Returns the residual-stream output rows [B, H] (pre-final-norm, mirroring
+    /// forwardRows(finalNormW: nil)). Each lane's caches advance by exactly one
+    /// position — bit-identical to that lane running forwardRows(M: 1) alone.
+    public func forwardRowsBatch(_ x: MLXArray) -> MLXArray? {
+        let H = driver.H
+        guard x.dim(0) == B, x.dim(1) == H else { return nil }
+        let xf = x.asType(.float16).reshaped([-1]); xf.eval()
+        let arr = xf.asArray(Float16.self)
+        driver.hBuf.contents().bindMemory(to: Float16.self, capacity: driver.maxM * H)
+            .update(from: arr, count: B * H)
+
+        let cb = driver.queue.makeCommandBuffer()!
+        let enc = cb.makeComputeCommandEncoder()!
+        encodeAllLayers(enc)
         enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
         SeedlessFusedVerify.SeedlessFusedForward.profLastGPUMs = (cb.gpuEndTime - cb.gpuStartTime) * 1000.0
 
         let ptr = driver.hBuf.contents().bindMemory(to: Float16.self, capacity: driver.maxM * H)
         return MLXArray(Array(UnsafeBufferPointer(start: ptr, count: B * H)), [B, H])
+    }
+
+    /// One batched GREEDY step: token ids [B] → next token ids [B]. A single CB
+    /// (embed → layers → final norm → lm_head → argmax), int32-only readback —
+    /// the batched mirror of the driver's solo stepArgmax. The head stages run at
+    /// M=B (row-independent ⇒ M-invariant); uses the DRIVER's attached head.
+    /// Bit-identical per lane to that lane running solo stepArgmax (locked test
+    /// lane_batch_argmax_bitexact).
+    public func stepArgmaxBatch(_ tokens: [Int32]) -> [Int]? {
+        guard let hd = driver.head, tokens.count == B,
+              SeedlessFusedVerify._embedRowsPipeline != nil,
+              SeedlessFusedVerify._argmaxRowsPipeline != nil else { return nil }
+        let H = driver.H
+        hd.tokensIn.contents().bindMemory(to: Int32.self, capacity: driver.maxM)
+            .update(from: tokens, count: B)
+
+        let cb = driver.queue.makeCommandBuffer()!
+        let enc = cb.makeComputeCommandEncoder()!
+        // embed: tokens → hBuf [B, H] (mirrors stepArgmax's encodeEmbed at M=B)
+        let ep = SeedlessFusedVerify._embedRowsPipeline!
+        enc.setComputePipelineState(ep)
+        enc.setBuffer(hd.embedW, offset: 0, index: 0); enc.setBuffer(hd.embedS, offset: 0, index: 1)
+        enc.setBuffer(hd.embedB, offset: 0, index: 2); enc.setBuffer(hd.tokensIn, offset: 0, index: 3)
+        enc.setBuffer(driver.hBuf, offset: 0, index: 4)
+        var hh = UInt32(H), tt = UInt32(B * H)
+        enc.setBytes(&hh, length: 4, index: 5); enc.setBytes(&tt, length: 4, index: 6)
+        enc.dispatchThreads(MTLSize(width: B * H, height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: min(ep.maxTotalThreadsPerThreadgroup, 256), height: 1, depth: 1))
+        encodeAllLayers(enc)
+        // final norm → lm_head → argmax at M=B (mirrors stepArgmax's encodeFinalOps)
+        SeedlessFusedVerify.encodeRmsNormRows(enc, x: driver.hBuf, w: hd.fnW,
+                                              out: driver.normed, rows: B, D: H, eps: driver.eps)
+        if SeedlessFusedVerify.SeedlessFusedForward.lmHeadQmv {
+            SeedlessFusedVerify.encodeQmmRows(enc, w: hd.lmW, scales: hd.lmS, biases: hd.lmB,
+                                              x: driver.normed, out: hd.logits, M: B, K: H, N: hd.vocab)
+        } else {
+            let qp = SeedlessMetalForward._qmm4TiledPipeline!
+            enc.setComputePipelineState(qp)
+            enc.setBuffer(hd.lmW, offset: 0, index: 0); enc.setBuffer(hd.lmS, offset: 0, index: 1)
+            enc.setBuffer(hd.lmB, offset: 0, index: 2); enc.setBuffer(driver.normed, offset: 0, index: 3)
+            enc.setBuffer(hd.logits, offset: 0, index: 4)
+            var kk = Int32(H), nn = Int32(hd.vocab), mm = Int32(B)
+            enc.setBytes(&kk, length: 4, index: 5); enc.setBytes(&nn, length: 4, index: 6); enc.setBytes(&mm, length: 4, index: 7)
+            enc.dispatchThreadgroups(MTLSize(width: hd.vocab, height: 1, depth: 1),
+                                     threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        }
+        let ap = SeedlessFusedVerify._argmaxRowsPipeline!
+        enc.setComputePipelineState(ap)
+        enc.setBuffer(hd.logits, offset: 0, index: 0); enc.setBuffer(hd.tokensOut, offset: 0, index: 1)
+        var vv = UInt32(hd.vocab); enc.setBytes(&vv, length: 4, index: 2)
+        enc.dispatchThreadgroups(MTLSize(width: B, height: 1, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+        SeedlessFusedVerify.SeedlessFusedForward.profLastGPUMs = (cb.gpuEndTime - cb.gpuStartTime) * 1000.0
+
+        let ptr = hd.tokensOut.contents().bindMemory(to: Int32.self, capacity: driver.maxM)
+        return (0 ..< B).map { Int(ptr[$0]) }
     }
 }

--- a/swift/Sources/QwispCore/SeedlessLaneBatch.swift
+++ b/swift/Sources/QwispCore/SeedlessLaneBatch.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Metal
+import MLX
+
+// Lane-batched greedy decode — Stage 1 of the parallel-agent speedup.
+//
+// B concurrent sequences ("lanes"), each with its OWN caches (KV arena + GDN
+// state) held by a per-lane SeedlessFusedForward, advance ONE token each through
+// a SINGLE fused pass so the dense/MoE weight reads amortize across lanes (the
+// M>1 prize: ~3x/token at M=16, spec-width probe) while the sequence-coupled
+// mixers (attention / GDN recurrence) run per-lane at literal M=1 with that
+// lane's caches — the exact solo kernels on the exact solo state.
+//
+// Bit-exactness by construction (locked test `lane_batch_bitexact`):
+//   - mixer rows: literal M=1 solo path per lane (same kernel, same shapes,
+//     same cache) ⇒ identical bits.
+//   - norm/MoE/resid rows at M=B: per-row grids whose row math is M-invariant —
+//     the engine's core self-consistency guarantee (M-row kernel suite,
+//     RAWTESTS) that already underwrites strict verify ≡ M=1 decode.
+//
+// Per layer: norm (M=B) → mixer per lane (M=1, staged via lane_row_copy) →
+// resid+postNorm (M=B) → MoE (M=B, per-row routing) → residAdd (M=B).
+//
+// Additive: reuses the frozen encode statics + Layer weight structs from the
+// driver; no frozen file is modified. Resident tier only (streaming's chunked
+// expert IO is a different scheduling problem — out of Stage 1 scope).
+public final class SeedlessLaneBatch {
+    let driver: SeedlessFusedVerify.SeedlessFusedForward     // weights + M=B scratch
+    let lanes: [SeedlessFusedVerify.SeedlessFusedForward]    // per-lane caches + scratch
+    public let B: Int
+    let laneX: MTLBuffer                                     // [1, H] mixer input staging
+    let laneOut: MTLBuffer                                   // [1, H] mixer output staging
+
+    nonisolated(unsafe) static var copyPipeline: MTLComputePipelineState? = nil
+    static func compileCopy(_ device: MTLDevice) -> Bool {
+        if copyPipeline != nil { return true }
+        let src = """
+        #include <metal_stdlib>
+        using namespace metal;
+        kernel void lane_row_copy(device const half* src [[buffer(0)]],
+                                  device half* dst [[buffer(1)]],
+                                  constant uint& srcOff [[buffer(2)]],
+                                  constant uint& dstOff [[buffer(3)]],
+                                  uint i [[thread_position_in_grid]]) {
+            dst[dstOff + i] = src[srcOff + i];
+        }
+        """
+        guard let lib = try? device.makeLibrary(source: src, options: nil),
+              let fn = lib.makeFunction(name: "lane_row_copy"),
+              let ps = try? device.makeComputePipelineState(function: fn) else { return false }
+        copyPipeline = ps
+        return true
+    }
+
+    private func encodeRowCopy(_ enc: MTLComputeCommandEncoder,
+                               src: MTLBuffer, srcOff: Int, dst: MTLBuffer, dstOff: Int, count: Int) {
+        let ps = SeedlessLaneBatch.copyPipeline!
+        enc.setComputePipelineState(ps)
+        enc.setBuffer(src, offset: 0, index: 0)
+        enc.setBuffer(dst, offset: 0, index: 1)
+        var so = UInt32(srcOff), do_ = UInt32(dstOff)
+        enc.setBytes(&so, length: 4, index: 2)
+        enc.setBytes(&do_, length: 4, index: 3)
+        enc.dispatchThreads(MTLSize(width: count, height: 1, depth: 1),
+                            threadsPerThreadgroup: MTLSize(width: min(ps.maxTotalThreadsPerThreadgroup, 256), height: 1, depth: 1))
+    }
+
+    /// driver: weights + scratch sized maxM ≥ lanes.count. lanes: one forward per
+    /// sequence (its caches are the lane state; its scratch serves the M=1 mixer).
+    /// All must be resident-mode with the same layer stack.
+    public init?(driver: SeedlessFusedVerify.SeedlessFusedForward,
+                 lanes: [SeedlessFusedVerify.SeedlessFusedForward]) {
+        guard !lanes.isEmpty, driver.maxM >= lanes.count,
+              lanes.allSatisfy({ $0.layers.count == driver.layers.count }),
+              SeedlessLaneBatch.compileCopy(driver.device) else { return nil }
+        self.driver = driver
+        self.lanes = lanes
+        self.B = lanes.count
+        guard let lx = driver.device.makeBuffer(length: driver.H * 2, options: .storageModeShared),
+              let lo = driver.device.makeBuffer(length: driver.H * 2, options: .storageModeShared) else { return nil }
+        self.laneX = lx
+        self.laneOut = lo
+    }
+
+    /// One batched step: row b of `x` [B, H] is lane b's next-token hidden input.
+    /// Returns the residual-stream output rows [B, H] (pre-final-norm, mirroring
+    /// forwardRows(finalNormW: nil)). Each lane's caches advance by exactly one
+    /// position — bit-identical to that lane running forwardRows(M: 1) alone.
+    public func forwardRowsBatch(_ x: MLXArray) -> MLXArray? {
+        let H = driver.H
+        guard x.dim(0) == B, x.dim(1) == H else { return nil }
+        let xf = x.asType(.float16).reshaped([-1]); xf.eval()
+        let arr = xf.asArray(Float16.self)
+        driver.hBuf.contents().bindMemory(to: Float16.self, capacity: driver.maxM * H)
+            .update(from: arr, count: B * H)
+
+        let cb = driver.queue.makeCommandBuffer()!
+        let enc = cb.makeComputeCommandEncoder()!
+        for li in driver.layers.indices {
+            let L = driver.layers[li]
+            SeedlessFusedVerify.encodeRmsNormRows(enc, x: driver.hBuf, w: L.inputLN,
+                                                  out: driver.normed, rows: B, D: H, eps: driver.eps)
+            for b in 0 ..< B {
+                let lane = lanes[b]
+                let LL = lane.layers[li]
+                encodeRowCopy(enc, src: driver.normed, srcOff: b * H, dst: laneX, dstOff: 0, count: H)
+                if L.isLinear, let gw = L.gdn, let gc = LL.gdnCache {
+                    SeedlessFusedVerify.encodeGdnLayerRows(enc, x: laneX, out: laneOut, w: gw,
+                                                           sc: lane.gdnSc, cache: gc, M: 1, H: H,
+                                                           numKHeads: driver.numKHeads, numVHeads: driver.numVHeads,
+                                                           headKDim: driver.headKDim, headVDim: driver.headVDim,
+                                                           convKernel: driver.convKernel, eps: driver.eps)
+                    gc.swapState()
+                } else if let aw = L.attn, let kv = LL.kvCache {
+                    SeedlessFusedVerify.encodeAttnLayerRows(enc, x: laneX, out: laneOut, w: aw,
+                                                            sc: lane.attnSc, kv: kv, M: 1, H: H,
+                                                            numHeads: driver.numHeads, numKV: driver.numKV,
+                                                            headDim: driver.headDim, ropeDim: driver.ropeDim,
+                                                            ropeBase: driver.ropeBase, eps: driver.eps)
+                    kv.len += 1
+                }
+                encodeRowCopy(enc, src: laneOut, srcOff: 0, dst: driver.mixerOut, dstOff: b * H, count: H)
+            }
+            // resid + postNorm at M=B — mirrors encodePreMoE's tail exactly.
+            if SeedlessFusedVerify.SeedlessFusedForward.fuseGDN,
+               SeedlessFusedVerify._gdnResidPostNormRowsPipeline != nil {
+                SeedlessFusedVerify.encodeGdnResidPostNormRows(enc, h: driver.hBuf, r: driver.mixerOut,
+                                                               w: L.postLN, postNorm: driver.postNorm,
+                                                               M: B, H: H, eps: driver.eps)
+            } else {
+                SeedlessFusedVerify.encodeResidAdd(enc, h: driver.hBuf, r: driver.mixerOut, total: B * H)
+                SeedlessFusedVerify.encodeRmsNormRows(enc, x: driver.hBuf, w: L.postLN,
+                                                      out: driver.postNorm, rows: B, D: H, eps: driver.eps)
+            }
+            SeedlessFusedVerify.encodeMoEBlockRows(enc, x: driver.postNorm, out: driver.moeOut,
+                                                   w: L.moe, sc: driver.moeSc,
+                                                   M: B, E: L.E, I: L.I, Ktop: L.Ktop, H: H)
+            SeedlessFusedVerify.encodeResidAdd(enc, h: driver.hBuf, r: driver.moeOut, total: B * H)
+        }
+        enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+        SeedlessFusedVerify.SeedlessFusedForward.profLastGPUMs = (cb.gpuEndTime - cb.gpuStartTime) * 1000.0
+
+        let ptr = driver.hBuf.contents().bindMemory(to: Float16.self, capacity: driver.maxM * H)
+        return MLXArray(Array(UnsafeBufferPointer(start: ptr, count: B * H)), [B, H])
+    }
+}

--- a/swift/Sources/QwispCore/SeedlessVerifyTests.swift
+++ b/swift/Sources/QwispCore/SeedlessVerifyTests.swift
@@ -49,7 +49,7 @@ public enum SeedlessVerifyTests {
         MLXRandom.seed(UInt64(42))
         var lines: [String] = []
         var passed = 0
-        let total = 90
+        let total = 91
 
         // Nested runner: records result and increments counter
         func run(_ name: String, body: () -> (Bool, String)) {
@@ -5529,6 +5529,114 @@ public enum SeedlessVerifyTests {
                     let (ok, d) = bitEqual(xx, yy)
                     if !ok { return (false, "\(nm) lane=\(b): \(d)") }
                 }
+            }
+            return (true, "ok")
+        }
+
+        // WRITE-LOCKED (guarded by total = 91). Do not weaken/skip/delete.
+        //
+        // Test 91: lane_batch_argmax_bitexact
+        // Full 1-CB batched greedy step (embed → layers → final norm → lm_head →
+        // argmax, all at M=B / per-lane cores) must produce token ids BIT-identical
+        // to each lane running solo stepArgmax — chained 4 steps feeding the argmax
+        // outputs back as the next tokens (real greedy trajectory, cache continuity).
+        run("lane_batch_argmax_bitexact") {
+            let H = 2048, E = 16, I = 512, vocab = 1024
+            func q4(_ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine); return (q, s, b!)
+            }
+            func q8(_ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 8, mode: .affine); return (q, s, b!)
+            }
+            func q4e(_ e: Int, _ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([e, n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine); return (q, s, b!)
+            }
+            func mkMoE() -> SeedlessVerifyForward.MoEBlockW {
+                let (gW, gS, gB) = q8(E, H); let (sgW, sgS, sgB) = q8(8, H)
+                let (a0, a1, a2) = q4e(E, I, H); let (b0, b1, b2) = q4e(E, I, H); let (c0, c1, c2) = q4e(E, H, I)
+                let (d0, d1, d2) = q4(I, H); let (e0, e1, e2) = q4(I, H); let (f0, f1, f2) = q4(H, I)
+                return SeedlessVerifyForward.MoEBlockW(gateWq: gW, gateSc: gS, gateBi: gB,
+                    swGWq: a0, swGSc: a1, swGBi: a2, swUWq: b0, swUSc: b1, swUBi: b2,
+                    swDWq: c0, swDSc: c1, swDBi: c2, shGWq: d0, shGSc: d1, shGBi: d2,
+                    shUWq: e0, shUSc: e1, shUBi: e2, shDWq: f0, shDSc: f1, shDBi: f2,
+                    sharedGateWq: sgW, sharedGateSc: sgS, sharedGateBi: sgB)
+            }
+            let Hk = 16, Dk = 128, Hv = 32, Dv = 128, cK = 4
+            let convDim = Hk * Dk * 2 + Hv * Dv
+            let (qkvW, qkvS, qkvB) = q4(convDim, H); let (zW, zS, zB) = q4(Hv * Dv, H)
+            let (bW, bS, bB) = q4(Hv, H); let (aW, aS, aB) = q4(Hv, H); let (oW, oS, oB) = q4(H, Hv * Dv)
+            let gdnW = SeedlessVerifyForward.GDNLayerW(qkvWq: qkvW, qkvSc: qkvS, qkvBi: qkvB,
+                zWq: zW, zSc: zS, zBi: zB, bWq: bW, bSc: bS, bBi: bB, aWq: aW, aSc: aS, aBi: aB,
+                outWq: oW, outSc: oS, outBi: oB,
+                conv1dW: MLXRandom.normal([convDim, cK]).asType(.float16),
+                normWeight: MLXRandom.normal([Dv]).asType(.float16),
+                aLog: MLXRandom.normal([Hv]).asType(.float32), dtBias: MLXRandom.normal([Hv]).asType(.float32))
+            let nH = 16, nKV = 2, hD = 256
+            let (aqW, aqS, aqB) = q4(nH * 2 * hD, H); let (akW, akS, akB) = q4(nKV * hD, H)
+            let (avW, avS, avB) = q4(nKV * hD, H); let (aoW, aoS, aoB) = q4(H, nH * hD)
+            let attnW = SeedlessVerifyForward.AttnLayerW(qWq: aqW, qSc: aqS, qBi: aqB, kWq: akW, kSc: akS, kBi: akB,
+                vWq: avW, vSc: avS, vBi: avB, oWq: aoW, oSc: aoS, oBi: aoB,
+                qNorm: MLXRandom.normal([hD]).asType(.float16), kNorm: MLXRandom.normal([hD]).asType(.float16))
+            let layers = [
+                SeedlessVerifyForward.LayerSpec(isLinear: true,
+                    inputLN: MLXRandom.normal([H]).asType(.float16), postLN: MLXRandom.normal([H]).asType(.float16),
+                    gdn: gdnW, attn: nil, moe: mkMoE(), moeE: E, moeI: I),
+                SeedlessVerifyForward.LayerSpec(isLinear: false,
+                    inputLN: MLXRandom.normal([H]).asType(.float16), postLN: MLXRandom.normal([H]).asType(.float16),
+                    gdn: nil, attn: attnW, moe: mkMoE(), moeE: E, moeI: I),
+            ]
+            let (eW, eS, eB) = q4(vocab, H)
+            let (lW, lS, lB) = q4(vocab, H)
+            let fnW = MLXRandom.normal([H]).asType(.float16)
+            let cs0 = MLXRandom.normal([cK - 1, convDim]).asType(.float16)
+            let rs0 = MLXRandom.normal([1, Hv, Dv, Dk]).asType(.float32)
+            let kC0 = MLXRandom.normal([nKV, 16, hD]).asType(.float16)
+            let vC0 = MLXRandom.normal([nKV, 16, hD]).asType(.float16)
+            MLX.eval([cs0, rs0, kC0, vC0, eW, eS, eB, lW, lS, lB, fnW])
+            func freshCaches() -> [SeedlessVerifyForward.LayerCaches] {
+                [SeedlessVerifyForward.LayerCaches(convState: cs0, recState: rs0),
+                 SeedlessVerifyForward.LayerCaches(kCache: kC0, vCache: vC0)]
+            }
+            let B = 3
+            var solos: [SeedlessFusedVerify.SeedlessFusedForward] = []
+            var laneFwds: [SeedlessFusedVerify.SeedlessFusedForward] = []
+            for b in 0 ..< B {
+                guard let s1 = SeedlessFusedVerify.SeedlessFusedForward(layers: layers, caches: freshCaches(),
+                                                                        maxM: 4, H: H, maxSeqLen: 64),
+                      let l1 = SeedlessFusedVerify.SeedlessFusedForward(layers: layers, caches: freshCaches(),
+                                                                        maxM: 4, H: H, maxSeqLen: 64)
+                else { return (false, "lane/solo init nil b=\(b)") }
+                guard s1.attachHead(embedW: eW, embedS: eS, embedB: eB, lmW: lW, lmS: lS, lmB: lB,
+                                    fnW: fnW, vocab: vocab)
+                else { return (false, "solo attachHead fail b=\(b)") }
+                // Divergent warm-up: b+1 M=1 steps, the SAME inputs to solo and lane.
+                for _ in 0 ... b {
+                    let xw = MLXRandom.normal([1, H]).asType(.float16); xw.eval()
+                    guard s1.forwardRows(xw, M: 1) != nil, l1.forwardRows(xw, M: 1) != nil
+                    else { return (false, "warmup nil b=\(b)") }
+                }
+                solos.append(s1); laneFwds.append(l1)
+            }
+            guard let drv = SeedlessFusedVerify.SeedlessFusedForward(layers: layers, caches: freshCaches(),
+                                                                     maxM: 8, H: H, maxSeqLen: 64),
+                  drv.attachHead(embedW: eW, embedS: eS, embedB: eB, lmW: lW, lmS: lS, lmB: lB,
+                                 fnW: fnW, vocab: vocab),
+                  let batch = SeedlessLaneBatch(driver: drv, lanes: laneFwds)
+            else { return (false, "driver/batch init nil") }
+            var toks: [Int32] = [7, 123, 500]
+            for step in 0 ..< 4 {
+                var refs: [Int] = []
+                for b in 0 ..< B {
+                    guard let r = solos[b].stepArgmax([toks[b]]), r.count == 1
+                    else { return (false, "solo stepArgmax nil b=\(b) step=\(step)") }
+                    refs.append(r[0])
+                }
+                guard let got = batch.stepArgmaxBatch(toks) else { return (false, "batch nil step=\(step)") }
+                if got != refs { return (false, "tokens step=\(step): got \(got) want \(refs)") }
+                toks = got.map { Int32($0) }
             }
             return (true, "ok")
         }

--- a/swift/Sources/QwispCore/SeedlessVerifyTests.swift
+++ b/swift/Sources/QwispCore/SeedlessVerifyTests.swift
@@ -49,7 +49,7 @@ public enum SeedlessVerifyTests {
         MLXRandom.seed(UInt64(42))
         var lines: [String] = []
         var passed = 0
-        let total = 89
+        let total = 90
 
         // Nested runner: records result and increments counter
         func run(_ name: String, body: () -> (Bool, String)) {
@@ -5413,6 +5413,123 @@ public enum SeedlessVerifyTests {
             // k4 far beyond budget clamps to budget/slot4=64, leaving m2=0.
             let over = DeviceCalibration.mixedKM(budgetBytes: budget, slot4Bytes: slot4, slot2Bytes: slot2, k4: 999)
             if over.k4 != 64 || over.m2 != 0 { return (false, "k4=999 → \(over) != (64,0)") }
+            return (true, "ok")
+        }
+
+
+        // ── Lane-batched greedy decode (Stage 1, parallel agents) ─────────
+        // WRITE-LOCKED (guarded by total = 90). Do not weaken/skip/delete.
+        //
+        // Test 90: lane_batch_bitexact
+        // B=3 lanes with DIVERGENT histories (1/2/3 warm-up steps each) advance one
+        // token per step through SeedlessLaneBatch.forwardRowsBatch. Every lane's
+        // output row and cache trajectory must be BIT-identical to that lane running
+        // solo forwardRows(M:1) — the lossless contract of batched multi-sequence
+        // decode. 4 chained steps assert cache continuity, not just one forward.
+        run("lane_batch_bitexact") {
+            let H = 2048, E = 16, I = 512
+            func q4(_ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine); return (q, s, b!)
+            }
+            func q8(_ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 8, mode: .affine); return (q, s, b!)
+            }
+            func q4e(_ e: Int, _ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([e, n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine); return (q, s, b!)
+            }
+            func mkMoE() -> SeedlessVerifyForward.MoEBlockW {
+                let (gW, gS, gB) = q8(E, H); let (sgW, sgS, sgB) = q8(8, H)
+                let (a0, a1, a2) = q4e(E, I, H); let (b0, b1, b2) = q4e(E, I, H); let (c0, c1, c2) = q4e(E, H, I)
+                let (d0, d1, d2) = q4(I, H); let (e0, e1, e2) = q4(I, H); let (f0, f1, f2) = q4(H, I)
+                return SeedlessVerifyForward.MoEBlockW(gateWq: gW, gateSc: gS, gateBi: gB,
+                    swGWq: a0, swGSc: a1, swGBi: a2, swUWq: b0, swUSc: b1, swUBi: b2,
+                    swDWq: c0, swDSc: c1, swDBi: c2, shGWq: d0, shGSc: d1, shGBi: d2,
+                    shUWq: e0, shUSc: e1, shUBi: e2, shDWq: f0, shDSc: f1, shDBi: f2,
+                    sharedGateWq: sgW, sharedGateSc: sgS, sharedGateBi: sgB)
+            }
+            let Hk = 16, Dk = 128, Hv = 32, Dv = 128, cK = 4
+            let convDim = Hk * Dk * 2 + Hv * Dv
+            let (qkvW, qkvS, qkvB) = q4(convDim, H); let (zW, zS, zB) = q4(Hv * Dv, H)
+            let (bW, bS, bB) = q4(Hv, H); let (aW, aS, aB) = q4(Hv, H); let (oW, oS, oB) = q4(H, Hv * Dv)
+            let gdnW = SeedlessVerifyForward.GDNLayerW(qkvWq: qkvW, qkvSc: qkvS, qkvBi: qkvB,
+                zWq: zW, zSc: zS, zBi: zB, bWq: bW, bSc: bS, bBi: bB, aWq: aW, aSc: aS, aBi: aB,
+                outWq: oW, outSc: oS, outBi: oB,
+                conv1dW: MLXRandom.normal([convDim, cK]).asType(.float16),
+                normWeight: MLXRandom.normal([Dv]).asType(.float16),
+                aLog: MLXRandom.normal([Hv]).asType(.float32), dtBias: MLXRandom.normal([Hv]).asType(.float32))
+            let nH = 16, nKV = 2, hD = 256
+            let (aqW, aqS, aqB) = q4(nH * 2 * hD, H); let (akW, akS, akB) = q4(nKV * hD, H)
+            let (avW, avS, avB) = q4(nKV * hD, H); let (aoW, aoS, aoB) = q4(H, nH * hD)
+            let attnW = SeedlessVerifyForward.AttnLayerW(qWq: aqW, qSc: aqS, qBi: aqB, kWq: akW, kSc: akS, kBi: akB,
+                vWq: avW, vSc: avS, vBi: avB, oWq: aoW, oSc: aoS, oBi: aoB,
+                qNorm: MLXRandom.normal([hD]).asType(.float16), kNorm: MLXRandom.normal([hD]).asType(.float16))
+            let layers = [
+                SeedlessVerifyForward.LayerSpec(isLinear: true,
+                    inputLN: MLXRandom.normal([H]).asType(.float16), postLN: MLXRandom.normal([H]).asType(.float16),
+                    gdn: gdnW, attn: nil, moe: mkMoE(), moeE: E, moeI: I),
+                SeedlessVerifyForward.LayerSpec(isLinear: false,
+                    inputLN: MLXRandom.normal([H]).asType(.float16), postLN: MLXRandom.normal([H]).asType(.float16),
+                    gdn: nil, attn: attnW, moe: mkMoE(), moeE: E, moeI: I),
+            ]
+            let cs0 = MLXRandom.normal([cK - 1, convDim]).asType(.float16)
+            let rs0 = MLXRandom.normal([1, Hv, Dv, Dk]).asType(.float32)
+            let kC0 = MLXRandom.normal([nKV, 16, hD]).asType(.float16)
+            let vC0 = MLXRandom.normal([nKV, 16, hD]).asType(.float16)
+            MLX.eval([cs0, rs0, kC0, vC0])
+            func freshCaches() -> [SeedlessVerifyForward.LayerCaches] {
+                [SeedlessVerifyForward.LayerCaches(convState: cs0, recState: rs0),
+                 SeedlessVerifyForward.LayerCaches(kCache: kC0, vCache: vC0)]
+            }
+            let B = 3
+            var solos: [SeedlessFusedVerify.SeedlessFusedForward] = []
+            var laneFwds: [SeedlessFusedVerify.SeedlessFusedForward] = []
+            for b in 0 ..< B {
+                guard let s1 = SeedlessFusedVerify.SeedlessFusedForward(layers: layers, caches: freshCaches(),
+                                                                        maxM: 4, H: H, maxSeqLen: 64),
+                      let l1 = SeedlessFusedVerify.SeedlessFusedForward(layers: layers, caches: freshCaches(),
+                                                                        maxM: 4, H: H, maxSeqLen: 64)
+                else { return (false, "lane/solo init nil b=\(b)") }
+                // Divergent warm-up: b+1 M=1 steps, the SAME inputs to solo and lane.
+                for _ in 0 ... b {
+                    let xw = MLXRandom.normal([1, H]).asType(.float16); xw.eval()
+                    guard s1.forwardRows(xw, M: 1) != nil, l1.forwardRows(xw, M: 1) != nil
+                    else { return (false, "warmup nil b=\(b)") }
+                }
+                solos.append(s1); laneFwds.append(l1)
+            }
+            guard let drv = SeedlessFusedVerify.SeedlessFusedForward(layers: layers, caches: freshCaches(),
+                                                                     maxM: 8, H: H, maxSeqLen: 64),
+                  let batch = SeedlessLaneBatch(driver: drv, lanes: laneFwds)
+            else { return (false, "driver/batch init nil") }
+            for step in 0 ..< 4 {
+                let xs = MLXRandom.normal([B, H]).asType(.float16); xs.eval()
+                guard let got = batch.forwardRowsBatch(xs) else { return (false, "batch nil step=\(step)") }
+                got.eval()
+                for b in 0 ..< B {
+                    let xb = xs[b ..< (b + 1)]
+                    guard let ref = solos[b].forwardRows(xb, M: 1) else { return (false, "solo nil b=\(b)") }
+                    ref.eval()
+                    let (ok, d) = bitEqual(got[b ..< (b + 1)], ref)
+                    if !ok { return (false, "h step=\(step) lane=\(b): \(d)") }
+                }
+            }
+            // Cache trajectories must match too (gdn conv/rec at layer 0, kv at layer 1).
+            for b in 0 ..< B {
+                let (lc, lr) = laneFwds[b].readLayerCache(0)
+                let (sc2, sr) = solos[b].readLayerCache(0)
+                let (lk, lv) = laneFwds[b].readLayerCache(1)
+                let (sk, sv) = solos[b].readLayerCache(1)
+                let pairs: [(MLXArray?, MLXArray?, String)] = [
+                    (lc, sc2, "convState"), (lr, sr, "recState"), (lk, sk, "kCache"), (lv, sv, "vCache")]
+                for (x, y, nm) in pairs {
+                    guard let xx = x, let yy = y else { return (false, "\(nm) nil lane=\(b)") }
+                    let (ok, d) = bitEqual(xx, yy)
+                    if !ok { return (false, "\(nm) lane=\(b): \(d)") }
+                }
+            }
             return (true, "ok")
         }
 

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -61,6 +61,8 @@ if CommandLine.arguments.contains("stream") {
         Runner(name: "prefix-cache-poc", desc: "snapshot/restore byte-identity micro-PoC (design validation, pre-e2e)",
                run: { md, _ in Tell.prefixCachePoC(modelDir: md) }),
         // ── kernel micro-benchmarks (no model) ──
+        Runner(name: "lane-kernel-bench", desc: "per-lane sequence-coupled kernel µs at real dims (Stage 1b go/no-go: dispatch tax vs state bandwidth; GPU, no model; QWISP_LANE_CTX)",
+               run: { _, _ in Tell.laneKernelBench() }),
         Runner(name: "grouped-moe-bench", desc: "grouped MoE expert kernel micro-bench",
                run: { _, _ in GroupedMoEPoC.bench() }),
         Runner(name: "dense-tiled-bench", desc: "dense tiled matmul micro-bench",

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -37,6 +37,8 @@ if CommandLine.arguments.contains("stream") {
         // ── decode speed (regressions, long-context) ──
         Runner(name: "raw-spec", desc: "shipping decode bench, strict/bolt tok/s + token dump (GPU+model+refs) — bench_batch.sh cell",
                run: { try Tell.run(modelDir: $0, refPath: $1) }),
+        Runner(name: "lane-batch-bench", desc: "bit-exact lane-batched greedy: ms/step + per-stream/aggregate tok/s by B (Stage 1; QWISP_LANE_B, QWISP_LANE_CTX)",
+               run: { md, _ in Tell.laneBatchBench(modelDir: md) }),
         Runner(name: "long-context-decay", desc: "per-stage (GDN/attn/MoE) GPU ms: prefill chunks by position + M=1 decode by ctx up to 48K (#119; QWISP_DECAY_MAX)",
                run: { md, _ in Tell.longContextDecayProbe(modelDir: md) }),
         Runner(name: "spec-width", desc: "verify forward stage ms by draft width M at fixed ctx (#119; QWISP_SPEC_CTX) — is speculation paying?",

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -40,6 +40,10 @@ environment:
   QWISP_BATCH=<B>                    serve only: continuous batching with B slots (multi-user
                                      aggregate throughput; resident ≥32GB, greedy-only, not
                                      bit-exact with single-stream — opt-in)
+  QWISP_LANES=<B>                    serve only: lane batching with B raw-engine lanes
+                                     (parallel sub-agent fan-out; resident ≥32GB, greedy-only,
+                                     BIT-EXACT with single-stream — opt-in). Per-lane context
+                                     capped by QWISP_LANE_CTX (default 16384)
 
 first run: `qwisp pull` downloads ~20GB. The first chat/serve request loads the model, and
 on <32GB machines runs a one-time bolt calibration (a few minutes; progress goes to stderr).
@@ -68,6 +72,13 @@ case "serve":
     if ProcessInfo.processInfo.environment["QWISP_FAKE"] == "1" {
         print("[qwisp serve] FAKE backend (no engine load) — wire-format testing only")
         backend = FakeBackend(script: tok.encode("Hello! This is qwisp with a fake backend for wire-format testing."))
+    } else if let ls = Int(ProcessInfo.processInfo.environment["QWISP_LANES"] ?? ""), ls >= 2 {
+        // Lane batching (parallel sub-agent fan-out, opt-in): raw-engine lanes on the
+        // continuous scheduler — bit-exact with the default serialize path, resident
+        // tier only, greedy only. Per-lane context capped by QWISP_LANE_CTX (16384).
+        print("[qwisp serve] lane batching: B=\(ls) lanes (raw engine, greedy, bit-exact; requests batch instead of queueing)")
+        backend = try LaneBackend(modelDir: model, slots: ls)
+        batchMode = true
     } else if let bs = Int(ProcessInfo.processInfo.environment["QWISP_BATCH"] ?? ""), bs >= 2 {
         // Continuous batching (issue #6, opt-in): multi-user aggregate-throughput mode.
         // Resident tier only, greedy only, and NOT bit-exact with single-stream decode

--- a/tools/opencode-repro/replay_concurrent.mjs
+++ b/tools/opencode-repro/replay_concurrent.mjs
@@ -39,7 +39,11 @@ function fire(hostport, body, greedy) {
             if (!line.startsWith("data:")) continue;
             const d = line.slice(5).trim();
             if (d === "[DONE]") continue;
-            try { const j = JSON.parse(d); const delta = j.choices?.[0]?.delta?.content; if (delta) text += delta; } catch {}
+            try {
+              const j = JSON.parse(d); const dl = j.choices?.[0]?.delta;
+              if (dl?.reasoning_content) text += dl.reasoning_content;   // thinking models
+              if (dl?.content) text += dl.content;
+            } catch {}
           }
         });
         res.on("end", () => resolve({ ok: true, text, ttft, wall: Date.now() - t0, status: res.statusCode }));


### PR DESCRIPTION
## Summary

Route A of the parallel sub-agent speedup (#120 follow-up): **lossless batched decode on the raw engine**, shipped end-to-end as an opt-in serving mode `QWISP_LANES=<B>`.

- **`SeedlessLaneBatch`** (additive, frozen files untouched): B lanes with their own caches advance one token each through a single fused pass. Row-independent stages (in-proj/qkv demux, GDN prep, norm/gate, sigmoid gate, out/o-proj, final norm + lm_head + argmax) run **once at M=B** on the driver; only the sequence-coupled kernels (GDN conv shift + recurrence; attn q/k-prep + v-append + SDPA) dispatch per lane, **offset-bound** into driver scratch rows — zero staging copies on the fast path.
- **`stepArgmaxBatch`**: 1-CB batched greedy step (embed → layers → head), int32-only readback.
- **`LaneServe`**: `BatchSlots` over the existing `ContinuousScheduler`; admit = canonical steel-hybrid prefill@1024 + Tell first-token path; step = batch over the ACTIVE lane subset only; `LaneBackend` behind `QWISP_LANES` (resident tier, greedy). Default serialize path untouched.

## Lossless contract

- Locked tests **90** (`lane_batch_bitexact`) and **91** (`lane_batch_argmax_bitexact`, total=91): output rows, cache trajectories, and chained greedy token ids bit-identical to solo `forwardRows(M:1)` / `stepArgmax`.
- #120-style replay (6-stream fan-out burst, 320 tok each): **6/6 streams byte-identical** to the default serialize serial reference; lane-concurrent ≡ lane-serial 6/6 (composition-independent).

## Measured (resident, ctx=1024, diverse prompts; full greedy step incl. lm_head)

| B | per-stream | aggregate |
|---|-----------|-----------|
| 1 | 80.4 tok/s | 80.4 |
| 2 | 59.6 | 119.2 |
| 3 | 46.0 | 138.0 |
| 4 | 36.2 | 144.6 |
| 8 | 20.4 | 162.9 |

Replay acceptance: totalWall 27.3s → 16.7s (**1.63x**), TTFT ladder 3ms…23.4s → **20–28ms flat**.

Doctrine learned: within one Metal encoder, hazard barriers are encoder-wide — lane cores never overlap; per-lane **dispatch count** is the cost driver (buffer separation does nothing, measured). Remaining per-stream gap at B≥3 = per-lane dispatch latency; Stage 1b (B-lane kernels) only if needed.

## Gates

RAWTESTS 91/91 · BENCHBATCHTEST PASS · COMPTEST 57/57 · TOKTEST 5/5

Refs #120. #121 (prefix-cache-aware admission) remains a follow-up on this path — lane admits still re-pay shared prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)