### PR TITLE
feat(seedless): prefix-cache-aware lane admission — fan-out shares the prefill (#121)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,8 @@ red strict cell.
 
 1. Do not regenerate `refs/*.safetensors` from MLX or any non-raw-greedy source.
 2. Do not weaken, skip, or delete the `WRITE-LOCKED` tests in
-   `swift/Sources/QwispCore/SeedlessVerifyTests.swift` (guarded by `total = 89`). They are the lossless safety net.
+   `swift/Sources/QwispCore/SeedlessVerifyTests.swift` (guarded by the `total = N` counter; extending the
+   suite with new locked tests bumps N — weakening existing ones never does). They are the lossless safety net.
 3. Do not rewrite the shipped forward path (SeedlessEngine / SeedlessMetalForward / SeedlessFusedVerify /
    Tell / ExpertArena / ExpertSource + model layers). It is frozen — refactor/rename only, never rewrite.
 4. Do not rewrite `main`'s history. Work on a topic branch (`claude/<topic>`, etc.) and open a PR to `main`.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,87 +1,101 @@
-# HANDOFF: PR #126 MERGED; parallel-speedup ceiling investigation CLOSED (kernel+system+roofline) — B-scaling is at the floor, next = #121
-Date: 2026-07-22 | Status: GREEN | Branch: claude/lane-ceiling (probe commits, PR to open/merge) | Root: /Users/penta2himajin/repos/qwisp
+# HANDOFF: #121 SHIPPED on branch — prefix-cache-aware lane admission (aligned-boundary restore); PR to open/merge, then L3 relaxation discussion
+Date: 2026-07-22 | Status: GREEN | Branch: claude/lane-prefix-admission (PR to open → merge) | Root: /Users/penta2himajin/repos/qwisp
 
 > STOP: Before trusting anything below, run the checks in "Verify First".
 > If any observation differs from the expected value, this handoff is stale —
 > the code is the truth, not this document. Report the mismatch before proceeding.
 
 ## Verify First
-- `git branch --show-current` → `claude/lane-ceiling`; `git status` → clean; PR #126 → MERGED (main has e492bbc).
-- `git log --oneline -2` → `f19630c` probe MLX quantizedMM M-scaling, on top of main merge.
-- `~/bin/jacquard run scripts/test_raw.sh` → RAWTESTS **91/91** (tests 90+91 = lane lossless contract, WRITE-LOCKED, total=91).
-- GPU rule: `~/bin/jacquard` (run=shared / measure=exclusive; `JACQUARD_GPU_IDLE_THRESHOLD=20` for measure). Never two GPU procs; brew service stopped (`brew services info qwisp`).
+- `git branch --show-current` → `claude/lane-prefix-admission`; `git status` → clean; PR #126/#127 MERGED (main has 9317732).
+- `git log --oneline -2` → `0bd0747` feat(seedless): prefix-cache-aware lane admission (+ a docs commit on top).
+- `~/bin/jacquard run scripts/test_raw.sh` → RAWTESTS **92/92** (test 92 = lane_admit_restore_bitexact, WRITE-LOCKED, total=92).
+- `scripts/test_completion.sh` → COMPTEST **67/67** (laneadmit_* 7 + prefixram maxlcp_* 3 new).
+- GPU rule: `~/bin/jacquard` (run=shared / measure=exclusive). Never two GPU procs; brew service stopped.
 
 ## Next Action
-Open/merge the small probe PR from `claude/lane-ceiling` (7b0b309 already merged via #126; f19630c = MLX reference probe). Then start #121 (prefix-cache-aware admission on lanes) — the ceiling investigation is CLOSED (see CEILING VERDICT).
+1. Open/merge the PR from `claude/lane-prefix-admission` (Closes #121).
+2. Then the user wants to DISCUSS L3 relaxation (see L3 section below) — margin-accept MTP in lanes is the one high-EV experiment; do not build before that discussion.
 
-## CEILING VERDICT (2026-07-22, M1 Max 64GB / 400GB/s / SLC 48MB)
-Question: is further parallel (B-lane) decode speedup possible? Answer: NO at the kernel and system level; only two small orthogonal levers remain (below).
-- Kernel: 3 designs measured NO-GO (Stage-1b merge +2-3 tok/s ceiling; tiled 9x slower; qmm4_rows_b register-collapse 4-6x slower). MLX's own quantizedMM measured on the same shape scales ~+19µs/row — SAME as our qmv port — and MLX's dispatch (get_qmv_batch_limit, metal/quantized.cpp) keeps per-row qmv up to M=12 for [K=2048,N=8192] on this chip, steel only beyond: the reference implementation has no better small-M kernel.
-- System: QWISP_BATCH=6 (MLX batched model path) on the 6-stream replay = 16.62s vs lanes 16.67s (tie), not bit-exact, and loses at B=8 (17 vs 21.9/stream, #120). No upside.
-- Roofline (CORRECTED 2026-07-22 by the Lean derivation — earlier "0.5GB GDN state/lane" was a ×3.9 arithmetic error): W = 1671.8MB (derived from config.json, kernel-checked), S = 129.8MB/lane (2.10MB state + 64KB conv hist, r+w, ×30). Pure-BW ideal B=3/B=1 ratio 5591/4887 ≈ 1.144; actual 1.748 ⇒ efficiency 65-66% vs pure-BW ideal, 60-61% vs the two-component (latency+BW) ideal; honest range [~0.60, ~0.66], robust ±3% (0.61-0.70). Coherence: measured recurrence DRAM excess 0.24-0.36ms/lane ≈ corrected S/BW = 0.324ms.
-- Lean-certified (qwisp-lean `4ae5d4c`, `Qwispmath/LaneCeiling.lean`, no sorry): W/S DERIVED not pinned (Wbytes_val/Sbytes_val); NO-GO ratios; Stage-1b < +2 tok/s; raw≡MLX marginal bands; aggregate ceilings 233 (empirical kernel-family) / 3083 (physics, assumption-free — S/BW marginal only); io_schedule_fits (physics floor NOT blocked by I/O — 32KB on-chip suffices); b_exact_wins (see next bullet). NO-GO verdicts independent of the ideal-model choice.
-- b2/b3 B-exact variants: isolated kernel win (−8-10%, bit-exact, `b_exact_wins`) but LOSES ~1ms in-chain at B=3 (`b_exact_chain_loss`, grid-parallelism/occupancy trade vs encoder barriers) — wired OPT-IN `QWISP_LANE_BEXACT=1`, default OFF (7a83e2b). Doctrine: isolated-dispatch throughput ≠ in-chain throughput. Next kernel lever (unmeasured): raw-half x_thread + exact f32 scale-on-use.
+## What shipped this session (#121)
+`LaneBatchSlots.admit` consults two `PrefixRAMStore` tiers before prefilling and restores the
+longest cached prefix into the fresh lane (`restorePersistentState`), prefilling only the delta:
+- **sharedStore** — recurrence-detected harness prefixes (fan-out sharing; capture boundary =
+  floor(LCP with any stored key / chunk) when ≥ stableMinTokens(1024)).
+- **convStore** — per-conversation last-aligned-boundary states (multi-turn extension).
+- Two stores because save()'s supersede semantics would drop a shared-harness boundary entry
+  whenever a longer full-prompt key lands (alternate requests would re-pay the shared prefill).
+- **ALL boundaries are ABSOLUTE chunk-aligned (1024 hybrid / 64 raw)** ⇒ delta prefill reproduces
+  the cold path's chunk boundaries exactly ⇒ bit-exact BY CONSTRUCTION (no chunk-composition
+  invariance assumption on the steel-hybrid kernels; serialize's arbitrary-boundary restores lean
+  on PREFIXE2E instead).
+- Default ON; `QWISP_LANE_PREFIX=0` or `QWISP_LANE_PREFIX_MB=0` opts out (budget default 3072MB,
+  1/3 shared / 2/3 conv). `LaneBatchSlots.restoreHits` = observability counter.
+- Pure plan logic `LaneBatchSlots.admitPlan` (COMPTEST `laneadmit_*`); `PrefixRAMStore.maxCommonPrefix` added.
 
-
-## L3 RELAXATION ANALYSIS (2026-07-22, answered from measured data — no new runs)
-Question: what opens if the bit-exact contract is removed / relaxed to greedy-equal or quality-equal?
-- Greedy-equal (re-canonicalization tier, precedent: steel-hybrid prefill): opens accumulation-order freedoms (split-K, simdgroup-matrix, half-accum) — but the measured obstacle is latency/occupancy/barriers, NOT arithmetic order, and MLX tuning shows simdgroup-matrix loses below M~12. Gain: single-digit %. NOT worth it alone.
-- L3 (quality-bounded): THE unlock is margin-accept MTP speculation in lanes — verify rows disappear (strict spec-in-batch is a wash: B=3+D1 exact-verify ~x0.95 by the SpecWidth accounting, same batch-1 physics as #98). Assets all exist: raw MTP-D1 port (green, default OFF), measured D1 accepts (code .720/agentic .829/longctx .803/shortnl .506), margin instrumentation (lastMargin), tinycodr DraftGate design. Estimate at B=3 (accept .75 x cov .7): 46 -> ~64 tok/s/stream (+40%); aggregate ceiling 233 -> ~350. shortnl degrades gracefully (gate closes). Quality must be MEASURED (token-match + task eval; bolt fidelity 88.7-98.2 is the reference dial).
-- Lower-bit W: closed (2-bit quality-rejected, lm_head cert mathematically closed). Union expert routing across lanes: few % (latency-bound).
-- Realistic stacked ceiling: B=3 ~75-85 tok/s (~1.6-1.8x). Physics 3083 unreachable even at L3 (lat 7.9ms + per-row dequant are quality-independent structure).
-- IF pursuing this axis: the one high-EV experiment is "Stage 2 = margin-gated MTP-D1 in lanes" probe WITH quality measurement (~1 session to GO/NO-GO). Priority order still favors #121 first.
+## Measured (synthetic 6-stream fan-out, 12.4K-char shared system prefix, max_tokens 256, QWISP_LANES=6)
+- Identity vs strict serial reference: **6/6 byte-identical** (prefix ON and OFF).
+- Admission lever isolated: lanes prefix OFF 56.2s → ON **32.8s = 1.71x** (cold admit ~3.9s/req → restore+delta ~0.15s).
+- vs serialize concurrent 38.1s (1.16x), vs serial reference 42.6s (1.30x). Streams are short
+  (256 tok) and decode-dominated — the admission win scales with prompt length (real traces 8-50K).
+- Trace generator + driver: scratchpad `gen_fanout_prefix.py`, `driver.sh`, `fanout6-prefix.jsonl`
+  (session scratchpad; regenerate as needed — recipe: 6 recs, shared ~12.4K-char system, distinct
+  short user tasks, stream:true, temperature 0).
+- OBSERVATION (unmeasured, follow-up): server-path decode ≈110-127ms/step at B=6 vs bench ~45-49ms
+  full-argmax step — the serialize server shows the same ~2x server-vs-bench gap (40 tok/s vs 80-96
+  solo). Per-token server overhead (detokenize/SSE/scheduler) is a shared follow-up lever, NOT
+  lane-specific. Measure before building anything.
 
 ## Then
-1. (next workstream, #121) prefix-cache-aware admission on the lane path: admits re-pay shared system+tools prefixes; sharing the prefill across lanes is the remaining fan-out lever (TTFT with real 8-50K prompts). Design seam: LaneBatchSlots.admit re-creates the lane per request — a shared-prefix snapshot/restore (prefix cache machinery, LLMBackend.swift#generateCached idioms) could seed the lane state instead of cold prefill.
-2. (small, optional) lane chainK: batch K chained steps per CB with GPU token feedback (solo chainedStepArgmax machinery + stop flag) — kills the ~1.1ms/step wall−GPU gap at B=3 ⇒ est. +5%; trades streaming granularity. Only worth doing opportunistically.
-3. Stage 2 (per-row spec-in-batch, tinycodr DraftGate) remains the only substantial per-stream decode lever left — a DIFFERENT axis (acceptance economics, not batching efficiency); needs its own measurement before any build.
+1. L3 relaxation discussion with the user (owner asked explicitly). Assets + estimates in the
+   previous handoff's L3 section, summarized: margin-accept MTP-D1 in lanes = verify rows vanish;
+   est. B=3 46→~64 tok/s/stream (+40%); all parts exist (raw MTP-D1 port green default OFF,
+   measured D1 accepts .506-.829, lastMargin instrumentation, tinycodr DraftGate design); quality
+   must be MEASURED (token-match + task eval; bolt fidelity 88.7-98.2 = reference dial). Stacked
+   realistic ceiling B=3 ~75-85 tok/s (~1.6-1.8x). Greedy-equal-only re-canonicalization: single-digit %, not worth alone.
+2. (small, optional) lane chainK — batch K chained steps per CB (~+5% @B=3, trades streaming granularity).
+3. Server per-token overhead decomposition (see OBSERVATION above) — possibly a bigger real-world
+   lever than any remaining kernel work.
 
 ## Commands
-- gate:  `~/bin/jacquard run scripts/test_raw.sh` → RAWTESTS 91/91; `scripts/test_bench_batch.sh` PASS; `scripts/test_completion.sh` 57/57; `scripts/test_tokenizer.sh` 5/5
-- build: `cd swift && xcodebuild build -scheme qwisp -configuration Release -destination 'platform=macOS' -derivedDataPath ./.xcode-build-rel -skipPackagePluginValidation` (scheme `qwisp-poc` for the gate binary; run scripts from REPO ROOT, not swift/)
-- bench: `JACQUARD_GPU_IDLE_THRESHOLD=20 ~/bin/jacquard measure env QWISP_RUN=lane-batch-bench QWISP_MODEL="$HOME/.mtplx/models/Youssofal--Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16" swift/.xcode-build-rel/Build/Products/Release/qwisp-poc stream` (⚠ `stream` arg REQUIRED; bench prints layers-only AND full-argmax rows + gpu ms)
-- replay acceptance: see tools/opencode-repro/README.md; synthetic 6-stream trace recipe lives in this session's history — craft JSONL recs `{id,method:"POST",path:"/v1/chat/completions",tArrival:0,inflightAtArrival:6,body:"<chat JSON, stream:true>"}`, then `node tools/opencode-repro/replay_concurrent.mjs run <trace> 127.0.0.1:<port> serial|concurrent <out.json> --greedy` and `... diff ref.json cmp.json`
-- lane serve: `QWISP_LANES=<B> qwisp serve` (resident ≥32GB, greedy; `QWISP_LANE_CTX` per-lane ctx, default 16384)
+- gate:  `~/bin/jacquard run scripts/test_raw.sh` → RAWTESTS 92/92; `scripts/test_bench_batch.sh` PASS; `scripts/test_completion.sh` 67/67; `scripts/test_tokenizer.sh` 5/5
+- build: `cd swift && xcodebuild build -scheme qwisp -configuration Release -destination 'platform=macOS' -derivedDataPath ./.xcode-build-rel -skipPackagePluginValidation` (scheme `qwisp-poc` for the gate binary; run scripts from REPO ROOT)
+- replay gate: driver pattern = start `QWISP_MODEL=... QWISP_PORT=<p> [QWISP_LANES=6] qwisp serve`,
+  wait for /v1/models 200, then `node tools/opencode-repro/replay_concurrent.mjs run <trace> 127.0.0.1:<p> serial|concurrent <out.json> --greedy`, then `... diff ref.json cmp.json`. One server at a time (GPU exclusive).
+- lane serve: `QWISP_LANES=<B> qwisp serve` (resident ≥32GB, greedy; `QWISP_LANE_CTX` per-lane ctx default 16384; `QWISP_LANE_PREFIX[_MB]` see above)
 
 ## State
-- [x] DONE: mixer projection split fast path (96aa5c1) — M=B projections + offset-bound per-lane cores; zero staging copies.
-- [x] DONE: stepArgmaxBatch + locked test 91 (759c158) — 1-CB batched greedy step; total=91.
-- [x] DONE: LaneServe wiring (adbfdf4) — LaneBatchSlots on ContinuousScheduler + LaneBackend behind QWISP_LANES; step batches ACTIVE lanes only.
-- [x] DONE: canonical admit (9ae9932) — hybrid prefill@1024 + Tell first-token (engine.logits qmmTiled + MLX.argMax). Replay 6/6 byte-identical, 1.63x, TTFT 20-28ms flat (serialize ladder was 3ms→23.4s).
-- [x] MEASURED full greedy step (resident, ctx=1024): B=1 80.4 / B=2 59.6 / B=3 46.0 / B=4 36.2 / B=8 20.4 tok/s (agg 162.9). Layers-only: 86.9/62.4/49.3/40.3/21.9.
-- [x] DONE: Stage 1b decomposition probe (7b0b309) — lane-kernel-bench; all 3 B-scaling levers NO-GO (see Rejected).
-- [ ] TODO: none on this branch — PR review; next workstream = #121 (see Then).
+- [x] DONE #121: prefix-cache-aware lane admission (0bd0747) — see "What shipped".
+- [x] Locked test 92 lane_admit_restore_bitexact (total=92): blob restore + delta ≡ cold bit-exact
+      (delta rows, cache trajectories, 3 chained stepArgmaxBatch vs solo), truncated blob rejected.
+- [x] Replay gate GREEN (identity 6/6; admission 1.71x; beats serialize concurrent).
+- [ ] TODO: open PR (Closes #121); after merge → L3 discussion (do NOT start building Stage 2 before it).
 
-## Rejected
-- Stage 1b (merge per-lane sequence-coupled dispatches into B-lane kernels): lane-kernel-bench decomposition shows those kernels total only ~1.6ms/lane of the ~4.4ms increment; dispatch-tax share ~0.5ms → ceiling +2-3 tok/s @B=3. NO-GO. (Probe: `QWISP_RUN=lane-kernel-bench`, no model.)
-- Tiled (shared-dequant) projections at decode M: 9x slower than qmv rows at every M≤8 ([N=8192,K=2048]). NO-GO.
-- qmm4_rows_b (B-row qmv, weight reads shared across ≤4 rows): bit-exact by construction (byte-compare PASS) but 4-6x SLOWER at every B — x_thread[4][16] register file collapses occupancy. Kernel kept in SeedlessLaneBatch.swift as evidence, NOT wired. Do not re-propose weight-read amortization for qmv decode shapes without a zero-extra-register design.
-- Tiled lm_head (QWISP_LMHEAD_QMV=0) for the batch step: 1.7-2x SLOWER at B=2-8 (B=3 argmax 21.7→36.3ms). qmv default stays. Do not re-propose.
-- "Shared laneX/laneOut staging serializes lanes on GPU": buffer separation changed nothing. Real model: encoder-wide hazard barriers ⇒ lane cores never overlap; dispatch COUNT is the cost. Do not re-propose buffer separation as an overlap lever.
-- Raw chunk-64 prefill + solo stepArgmax first token in admit: produces the PRE-hybrid stream → diverges from the canonical serialize stream ~100+ tokens in (f16 near-tie chains). Canonical = hybrid@1024 + qmmTiled/MLX.argMax first token (TellRuntime.swift wiring, Tell.prefill).
+## Rejected / Doctrine (carried)
+- Release-time state save (prompt+generated as key): REJECTED — decode M=1 raw steps produce
+  different KV bits than hybrid prefill of the same tokens; restoring such state forks the
+  canonical stream. Only PREFILL-computed boundary states are saveable.
+- One-store design: REJECTED (supersede kills shared boundary entries — see above).
+- Ceiling verdict (PR #126/#127, Lean-certified): B-lane kernel/system speedup CLOSED; empirical
+  aggregate ceiling 233 tok/s; b2/b3 B-exact variants opt-in `QWISP_LANE_BEXACT=1` default OFF
+  (isolated-dispatch win ≠ in-chain win). Do not re-propose weight-read amortization for qmv decode
+  shapes without a zero-extra-register design.
+- Canonical stream INCLUDES steel-hybrid prefill@1024 + first token via engine.logits(qmmTiled)+MLX.argMax.
+  Any new admit path must mirror it exactly (LaneServe.makeLane + admit loop is the reference).
 
 ## Do Not Touch
-- `swift/Sources/QwispCore/SeedlessVerifyTests.swift`: WRITE-LOCKED (total=91 guard; tests 90+91 = lane lossless contract).
-- Frozen forward path (SeedlessEngine/SeedlessMetalForward/SeedlessFusedVerify/Tell/ExpertArena/ExpertSource): SeedlessLaneBatch/LaneServe reach internals (same module) — never MODIFY frozen files.
+- `swift/Sources/QwispCore/SeedlessVerifyTests.swift`: WRITE-LOCKED (total=92 guard; tests 90-92 = lane contracts).
+- Frozen forward path (SeedlessEngine/SeedlessMetalForward/SeedlessFusedVerify/Tell/ExpertArena/ExpertSource).
 - `refs/*.safetensors`: raw-greedy only.
 
-## Decisions
-- FACT: the canonical greedy stream INCLUDES steel-hybrid prefill@1024 (TellRuntime: "default ON, canonical since refs re-canonicalization"). Any new decode path must mirror Tell.prefill + first-token kernels exactly or it forks the stream.
-- FACT: lane batching is composition-independent — lane-concurrent ≡ lane-serial 6/6 on the real model (and tests 90/91 at synthetic dims).
-- DECISION: LaneServe admits with makeFused(maxM:1024) per request (~200MB transient scratch/lane, resident tier) to get canonical chunk-1024 hybrid prefill. Alternative (persistent small-maxM lanes + raw prefill): rejected, non-canonical stream.
-- DECISION: step() batches only ACTIVE lanes, rebuilt on active-set change (per-lane cost ~linear in B; idle lanes must not ride).
-- FACT (was ASSUMPTION, now measured): GDN state traffic is NOT the floor — recurrence DRAM excess is only ~0.2-0.4ms/lane; the residual ~2.8ms/lane is qmv M-scaling (~+19µs/row @[8192,2048]) across projections/MoE, the kernel family floor.
-- DECISION: PR #126 opened referencing #120/#121 (not closing #121 — prefix-sharing on lanes is a real remaining lever).
-
 ## Gotchas & Blockers
-- `qwisp-poc` needs the `stream` positional arg (env alone silently no-ops). Run scripts from repo root (relative paths break from swift/).
-- The replay harness now collects `delta.reasoning_content` too (thinking models emit content late; without it len=0 and identity is vacuous).
-- gh token lacks `notifications` scope — updateSubscription mutation fails; PR author is auto-subscribed anyway.
-- kv.len/gc.swapState() at ENCODE time per lane per layer exactly once; in the fast path swapState sits after that lane's recurrence encode.
+- Lane replay TTFT ≈ SSE connection ack (~300ms), NOT first token — the lane server yields the
+  role chunk before admit; do not read lane TTFT as prefill time (serialize TTFT ≈ real first token).
+- `qwisp-poc` needs the `stream` positional arg. Run scripts from repo root.
+- kv.len/gc.swapState() at ENCODE time per lane per layer exactly once (fast path: after that lane's recurrence encode).
 - MLXRandom.seed once in runAll — do not reorder tests. SourceKit "No such module MLX" = noise. zsh eats `===`.
+- gh token lacks `notifications` scope — updateSubscription mutation fails; PR author is auto-subscribed anyway.
 
 ## Pointers
-- Read first: swift/Sources/QwispCore/SeedlessLaneBatch.swift (batch core, fast/staged paths, offset wrappers); swift/Sources/QwispCore/LaneServe.swift (slots + backend, canonical admit); tools/opencode-repro/replay_concurrent.mjs (acceptance harness).
-- Canonical prefill pattern: swift/Sources/QwispCore/TellRuntime.swift#prefill + the hybrid wiring block (~line 184).
-- PR: https://github.com/penta2himajin/qwisp/pull/126 · Issues: #120 (verdict), #121 (parked follow-up).
-- Memory: latest-handoff, opencode-parallel-repro-verdict, issue6-batching-validated.
+- Read first: swift/Sources/QwispCore/LaneServe.swift (admitPlan + admit + makeLane); swift/Sources/QwispCore/PrefixPersist.swift (PrefixRAMStore + maxCommonPrefix); SeedlessVerifyTests.swift test 92.
+- Issues: #121 (this, closes on merge) · #120 (repro harness) · #117/#89/#112 (prefix cache tiers this builds on).
+- Memory: latest-handoff, opencode-parallel-repro-verdict, prefix-cache-progress.

--- a/swift/Sources/QwispCore/LaneServe.swift
+++ b/swift/Sources/QwispCore/LaneServe.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Metal
 import MLX
 
 // Lane-batched serving path (Stage 1 wiring, parallel sub-agent fan-out).
@@ -29,6 +30,18 @@ public final class LaneBatchSlots: BatchSlots {
     private var lanes: [SeedlessFusedVerify.SeedlessFusedForward?]
     private var batch: SeedlessLaneBatch? = nil
     private var batchLanes: [ObjectIdentifier] = []   // active-set key for rebuild
+    // #121 prefix-cache-aware admission: cross-request decode states (persistentStateData
+    // blobs) so same-prefix fan-out and multi-turn extensions prefill only the delta.
+    // Two tiers (one PrefixRAMStore each — mixing them is wrong: save()'s supersede
+    // semantics would drop a shared-harness boundary entry every time a longer
+    // full-prompt key lands, re-paying the shared prefill on alternate requests):
+    //   sharedStore — recurrence-detected harness prefixes (fan-out sharing)
+    //   convStore   — per-conversation last-boundary states (multi-turn extension)
+    // Decode-thread only (ContinuousScheduler admits serially) → no lock.
+    private var sharedStore: PrefixRAMStore
+    private var convStore: PrefixRAMStore
+    /// Gate observability (mirrors SeedlessBackend.prefixRAMHits): warm restores this process.
+    public private(set) var restoreHits = 0
 
     public init?(store: WeightStore, slots: Int, maxSeqLen: Int) {
         self.engine = SeedlessEngine.build(store: store)
@@ -38,18 +51,73 @@ public final class LaneBatchSlots: BatchSlots {
         self.slotCount = slots
         self.maxSeqLen = maxSeqLen
         self.lanes = Array(repeating: nil, count: slots)
+        // One knob: QWISP_LANE_PREFIX_MB total budget (default 3072, resident tier) —
+        // 1/3 recurrence tier, 2/3 conversation tier. 0 disables.
+        let mb = Swift.max(0, Tell.envInt("QWISP_LANE_PREFIX_MB", 3072))
+        self.sharedStore = PrefixRAMStore(budget: mb / 3 * 1_048_576)
+        self.convStore = PrefixRAMStore(budget: mb * 2 / 3 * 1_048_576)
     }
 
-    public func admit(prompt: [Int32], slot: Int) -> Int? {
-        // maxM 1024 = the canonical steel-hybrid prefill chunk (the shipped serialize
-        // path prefills hybrid@1024; the canonical greedy stream is defined WITH it —
-        // raw chunked prefill produces the pre-hybrid stream and diverges ~100 tokens
-        // in on f16 near-ties). Costs ~200MB scratch per active lane, resident tier.
-        guard slot >= 0, slot < slotCount, !prompt.isEmpty, prompt.count < maxSeqLen,
-              let (fwd, fnBuf) = engine.makeFused(maxM: 1024, maxSeqLen: maxSeqLen) else { return nil }
-        let hybrid = ProcessInfo.processInfo.environment["QWISP_HYBRID_PREFILL"] != "0"
+    // ── #121 admission plan (pure logic; COMPTEST laneadmit_*) ────────────────
+    /// Every cache boundary (restore, capture, save) is an ABSOLUTE chunk-aligned
+    /// position. The delta prefill then reproduces the cold path's chunk boundaries
+    /// exactly, so restore+delta is bit-identical to cold BY CONSTRUCTION — no
+    /// assumption about the hybrid kernels' chunk-composition invariance is needed
+    /// (the serialize path's arbitrary-boundary restores lean on the PREFIXE2E gate;
+    /// the lane path removes the assumption instead).
+    public struct LaneAdmitPlan: Equatable {
+        public var restoreLen: Int   // aligned cached prefix to restore (0 = cold admit)
+        public var captureAt: Int?   // aligned recurrence boundary → sharedStore save
+        public var saveAt: Int?      // aligned last boundary → convStore save
+        public init(restoreLen: Int, captureAt: Int?, saveAt: Int?) {
+            self.restoreLen = restoreLen; self.captureAt = captureAt; self.saveAt = saveAt
+        }
+    }
+    /// hitLen = longest whole-entry store hit over prompt.dropLast() (aligned by
+    /// construction — stores only ever receive aligned keys); lcp = longest PARTIAL
+    /// key match (recurrence evidence: two different conversations sharing ≥minShared
+    /// tokens define a harness prefix, same operational definition as PrefixPersist #112).
+    public static func admitPlan(promptLen: Int, chunk: Int, hitLen: Int, lcp: Int,
+                                 minShared: Int) -> LaneAdmitPlan {
+        let restoreLen = hitLen
+        var capture: Int? = (lcp / chunk) * chunk             // floor to the chunk grid
+        if let c = capture, c < minShared || c <= restoreLen { capture = nil }
+        var save: Int? = ((promptLen - 1) / chunk) * chunk    // ≥1 token always re-prefilled
+        if let s = save, s <= restoreLen || s == capture { save = nil }
+        return LaneAdmitPlan(restoreLen: restoreLen, captureAt: capture, saveAt: save)
+    }
+
+    /// Pure self-check (no GPU, no model): boundary arithmetic of the admission plan.
+    public static func admitSelfCheck() -> [(String, Bool)] {
+        func p(_ len: Int, _ hit: Int, _ lcp: Int) -> LaneAdmitPlan {
+            admitPlan(promptLen: len, chunk: 1024, hitLen: hit, lcp: lcp, minShared: 1024)
+        }
+        return [
+            // cold first request: no evidence, save the last aligned boundary
+            ("cold", p(9000, 0, 0) == LaneAdmitPlan(restoreLen: 0, captureAt: nil, saveAt: 8192)),
+            // second same-prefix request: partial match ⇒ capture the shared boundary too
+            ("recurrence_capture", p(12000, 0, 9000) == LaneAdmitPlan(restoreLen: 0, captureAt: 8192, saveAt: 11264)),
+            // third request: warm restore at the shared boundary, no re-capture
+            ("restore_no_recapture", p(12000, 8192, 8192) == LaneAdmitPlan(restoreLen: 8192, captureAt: nil, saveAt: 11264)),
+            // shared prefix below minShared: never capture
+            ("min_shared", p(4000, 0, 900) == LaneAdmitPlan(restoreLen: 0, captureAt: nil, saveAt: 3072)),
+            // capture and save on the same boundary: conv save skipped (one blob, one tier)
+            ("save_capture_dedup", p(9000, 0, 8500) == LaneAdmitPlan(restoreLen: 0, captureAt: 8192, saveAt: nil)),
+            // prompt shorter than one chunk: no boundary at all
+            ("short_prompt", p(800, 0, 0) == LaneAdmitPlan(restoreLen: 0, captureAt: nil, saveAt: nil)),
+            // restore already at the last boundary: nothing new to save
+            ("restore_covers_save", p(9000, 8192, 8192) == LaneAdmitPlan(restoreLen: 8192, captureAt: nil, saveAt: nil)),
+        ]
+    }
+
+    /// Fresh lane forward with the canonical hybrid wiring (same trios as TellRuntime's
+    /// hybrid setup). maxM 1024 = the canonical steel-hybrid prefill chunk (the shipped
+    /// serialize path prefills hybrid@1024; the canonical greedy stream is defined WITH
+    /// it — raw chunked prefill produces the pre-hybrid stream and diverges ~100 tokens
+    /// in on f16 near-ties). Costs ~200MB scratch per active lane, resident tier.
+    private func makeLane(hybrid: Bool) -> (SeedlessFusedVerify.SeedlessFusedForward, MTLBuffer)? {
+        guard let (fwd, fnBuf) = engine.makeFused(maxM: 1024, maxSeqLen: maxSeqLen) else { return nil }
         if hybrid {
-            // Same wiring as TellRuntime's hybrid setup: per-layer MLX weight trios.
             var hw: [Int: (qkv: (MLXArray, MLXArray, MLXArray), z: (MLXArray, MLXArray, MLXArray), out: (MLXArray, MLXArray, MLXArray))] = [:]
             var aw: [Int: (q: (MLXArray, MLXArray, MLXArray), k: (MLXArray, MLXArray, MLXArray), v: (MLXArray, MLXArray, MLXArray), o: (MLXArray, MLXArray, MLXArray))] = [:]
             for (i, spec) in engine.layers.enumerated() {
@@ -70,13 +138,49 @@ public final class LaneBatchSlots: BatchSlots {
                 fwd.hybridMoEW = mw
             }
         }
+        return (fwd, fnBuf)
+    }
+
+    public func admit(prompt: [Int32], slot: Int) -> Int? {
+        guard slot >= 0, slot < slotCount, !prompt.isEmpty, prompt.count < maxSeqLen else { return nil }
+        let hybrid = ProcessInfo.processInfo.environment["QWISP_HYBRID_PREFILL"] != "0"
+        let chunkSize = hybrid ? 1024 : 64
+        guard var (fwd, fnBuf) = makeLane(hybrid: hybrid) else { return nil }
+        // #121: restore the longest cached aligned prefix, prefill only the delta.
+        // Default ON; QWISP_LANE_PREFIX=0 (or _MB=0) opts out. dropLast ⇒ a hit never
+        // swallows the whole prompt (the last position is always recomputed for the
+        // first-token argmax).
+        var plan = LaneAdmitPlan(restoreLen: 0, captureAt: nil, saveAt: nil)
+        if Tell.envInt("QWISP_LANE_PREFIX", 1) != 0,
+           sharedStore.budget + convStore.budget > 0 {
+            let matchable = Array(prompt.dropLast())
+            let hs = sharedStore.bestMatch(content: matchable)
+            let hc = convStore.bestMatch(content: matchable)
+            let hit = [hs, hc].compactMap { $0 }.max { $0.tokens.count < $1.tokens.count }
+            let lcp = Swift.max(sharedStore.maxCommonPrefix(with: prompt),
+                                convStore.maxCommonPrefix(with: prompt))
+            plan = Self.admitPlan(promptLen: prompt.count, chunk: chunkSize,
+                                  hitLen: hit?.tokens.count ?? 0, lcp: lcp,
+                                  minShared: PrefixPersist.stableMinTokens)
+            if plan.restoreLen > 0, let hit {
+                if fwd.restorePersistentState(hit.state) {
+                    restoreHits += 1
+                } else {
+                    // Shape/format mismatch half-writes the arena — this lane is unusable.
+                    // Cannot happen with same-engine blobs; rebuild fresh and go cold.
+                    guard let fresh = makeLane(hybrid: hybrid) else { return nil }
+                    (fwd, fnBuf) = fresh
+                    plan.restoreLen = 0
+                }
+            }
+        }
         // Canonical prefill + first token, mirroring Tell.prefill + the spec-loop
-        // entry EXACTLY (kernel choice and tie-break included): full prompt through
+        // entry EXACTLY (kernel choice and tie-break included): prompt through
         // chunked (hybrid) forward with final norm, then first token =
         // MLX.argMax(engine.logits(lastNormed)) — qmmTiled lm_head, MLX argmax.
-        let chunkSize = hybrid ? 1024 : 64
+        // restoreLen is chunk-aligned, so the loop's boundaries match a cold run's.
         var lastNormed: MLXArray? = nil
-        var pos = 0
+        var pos = plan.restoreLen
         while pos < prompt.count {
             let end = Swift.min(pos + chunkSize, prompt.count)
             let x = engine.embed(tokens: Array(prompt[pos ..< end]))
@@ -85,6 +189,13 @@ public final class LaneBatchSlots: BatchSlots {
             else { return nil }
             lastNormed = normed[end - pos - 1]
             pos = end
+            // Boundary states (blob = CPU memcpy of KV used slice + GDN state, ~24KB/token).
+            if pos == plan.captureAt {
+                sharedStore.save(tokens: Array(prompt[0 ..< pos]), state: fwd.persistentStateData())
+            }
+            if pos == plan.saveAt {
+                convStore.save(tokens: Array(prompt[0 ..< pos]), state: fwd.persistentStateData())
+            }
         }
         guard let ln = lastNormed?.reshaped([1, SeedlessEngine.H]),
               let lg = engine.logits(ln, M: 1) else { return nil }

--- a/swift/Sources/QwispCore/PrefixPersist.swift
+++ b/swift/Sources/QwispCore/PrefixPersist.swift
@@ -233,6 +233,20 @@ public struct PrefixRAMStore {
 
     public mutating func removeAll() { entries.removeAll() }
 
+    /// Longest common token prefix between `content` and ANY stored key (a partial match,
+    /// unlike bestMatch's whole-entry match) — recurrence evidence for the lane path's
+    /// shared-prefix capture (#121). Non-mutating; O(entries × lcp) token compares.
+    public func maxCommonPrefix(with content: [Int32]) -> Int {
+        var best = 0
+        for e in entries {
+            let n = Swift.min(e.tokens.count, content.count)
+            var i = 0
+            while i < n && e.tokens[i] == content[i] { i += 1 }
+            best = Swift.max(best, i)
+        }
+        return best
+    }
+
     /// Pure self-check (no GPU): longest match, supersede, LRU byte eviction, budget gates.
     public static func selfCheck() -> [(String, Bool)] {
         func blob(_ n: Int, _ b: UInt8) -> Data { Data(repeating: b, count: n) }
@@ -260,6 +274,12 @@ public struct PrefixRAMStore {
         var o = PrefixRAMStore(budget: 100)
         o.save(tokens: [1], state: blob(200, 1))                  // entry larger than the whole budget
         checks.append(("oversize_skip", o.bestMatch(content: [1]) == nil))
+        // #121: partial-match LCP (recurrence evidence), vs bestMatch's whole-entry match.
+        var m = PrefixRAMStore(budget: 1000)
+        m.save(tokens: [1, 2, 3, 4], state: blob(10, 1))
+        checks.append(("maxlcp_partial", m.maxCommonPrefix(with: [1, 2, 9, 9, 9]) == 2))
+        checks.append(("maxlcp_full_key", m.maxCommonPrefix(with: [1, 2, 3, 4, 5]) == 4))
+        checks.append(("maxlcp_empty", PrefixRAMStore(budget: 1000).maxCommonPrefix(with: [1, 2]) == 0))
         return checks
     }
 }

--- a/swift/Sources/QwispCore/SeedlessVerifyTests.swift
+++ b/swift/Sources/QwispCore/SeedlessVerifyTests.swift
@@ -49,7 +49,7 @@ public enum SeedlessVerifyTests {
         MLXRandom.seed(UInt64(42))
         var lines: [String] = []
         var passed = 0
-        let total = 91
+        let total = 92
 
         // Nested runner: records result and increments counter
         func run(_ name: String, body: () -> (Bool, String)) {
@@ -5637,6 +5637,142 @@ public enum SeedlessVerifyTests {
                 guard let got = batch.stepArgmaxBatch(toks) else { return (false, "batch nil step=\(step)") }
                 if got != refs { return (false, "tokens step=\(step): got \(got) want \(refs)") }
                 toks = got.map { Int32($0) }
+            }
+            return (true, "ok")
+        }
+
+        // WRITE-LOCKED (guarded by total = 92). Do not weaken/skip/delete.
+        //
+        // Test 92: lane_admit_restore_bitexact
+        // #121 prefix-cache-aware lane admission, mechanism contract: a lane whose
+        // prefix state was RESTORED from a persistentStateData blob (captured on a
+        // DIFFERENT forward instance at a chunk boundary) and then delta-prefilled
+        // must be BIT-identical to a lane that computed the whole history itself —
+        // delta outputs, cache trajectories, and token ids through 3 chained
+        // stepArgmaxBatch steps against solo stepArgmax. Truncated blobs must be
+        // rejected (restore returns false; the lane is then discarded, never used).
+        run("lane_admit_restore_bitexact") {
+            let H = 2048, E = 16, I = 512, vocab = 1024
+            func q4(_ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine); return (q, s, b!)
+            }
+            func q8(_ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 8, mode: .affine); return (q, s, b!)
+            }
+            func q4e(_ e: Int, _ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([e, n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine); return (q, s, b!)
+            }
+            func mkMoE() -> SeedlessVerifyForward.MoEBlockW {
+                let (gW, gS, gB) = q8(E, H); let (sgW, sgS, sgB) = q8(8, H)
+                let (a0, a1, a2) = q4e(E, I, H); let (b0, b1, b2) = q4e(E, I, H); let (c0, c1, c2) = q4e(E, H, I)
+                let (d0, d1, d2) = q4(I, H); let (e0, e1, e2) = q4(I, H); let (f0, f1, f2) = q4(H, I)
+                return SeedlessVerifyForward.MoEBlockW(gateWq: gW, gateSc: gS, gateBi: gB,
+                    swGWq: a0, swGSc: a1, swGBi: a2, swUWq: b0, swUSc: b1, swUBi: b2,
+                    swDWq: c0, swDSc: c1, swDBi: c2, shGWq: d0, shGSc: d1, shGBi: d2,
+                    shUWq: e0, shUSc: e1, shUBi: e2, shDWq: f0, shDSc: f1, shDBi: f2,
+                    sharedGateWq: sgW, sharedGateSc: sgS, sharedGateBi: sgB)
+            }
+            let Hk = 16, Dk = 128, Hv = 32, Dv = 128, cK = 4
+            let convDim = Hk * Dk * 2 + Hv * Dv
+            let (qkvW, qkvS, qkvB) = q4(convDim, H); let (zW, zS, zB) = q4(Hv * Dv, H)
+            let (bW, bS, bB) = q4(Hv, H); let (aW, aS, aB) = q4(Hv, H); let (oW, oS, oB) = q4(H, Hv * Dv)
+            let gdnW = SeedlessVerifyForward.GDNLayerW(qkvWq: qkvW, qkvSc: qkvS, qkvBi: qkvB,
+                zWq: zW, zSc: zS, zBi: zB, bWq: bW, bSc: bS, bBi: bB, aWq: aW, aSc: aS, aBi: aB,
+                outWq: oW, outSc: oS, outBi: oB,
+                conv1dW: MLXRandom.normal([convDim, cK]).asType(.float16),
+                normWeight: MLXRandom.normal([Dv]).asType(.float16),
+                aLog: MLXRandom.normal([Hv]).asType(.float32), dtBias: MLXRandom.normal([Hv]).asType(.float32))
+            let nH = 16, nKV = 2, hD = 256
+            let (aqW, aqS, aqB) = q4(nH * 2 * hD, H); let (akW, akS, akB) = q4(nKV * hD, H)
+            let (avW, avS, avB) = q4(nKV * hD, H); let (aoW, aoS, aoB) = q4(H, nH * hD)
+            let attnW = SeedlessVerifyForward.AttnLayerW(qWq: aqW, qSc: aqS, qBi: aqB, kWq: akW, kSc: akS, kBi: akB,
+                vWq: avW, vSc: avS, vBi: avB, oWq: aoW, oSc: aoS, oBi: aoB,
+                qNorm: MLXRandom.normal([hD]).asType(.float16), kNorm: MLXRandom.normal([hD]).asType(.float16))
+            let layers = [
+                SeedlessVerifyForward.LayerSpec(isLinear: true,
+                    inputLN: MLXRandom.normal([H]).asType(.float16), postLN: MLXRandom.normal([H]).asType(.float16),
+                    gdn: gdnW, attn: nil, moe: mkMoE(), moeE: E, moeI: I),
+                SeedlessVerifyForward.LayerSpec(isLinear: false,
+                    inputLN: MLXRandom.normal([H]).asType(.float16), postLN: MLXRandom.normal([H]).asType(.float16),
+                    gdn: nil, attn: attnW, moe: mkMoE(), moeE: E, moeI: I),
+            ]
+            let (eW, eS, eB) = q4(vocab, H)
+            let (lW, lS, lB) = q4(vocab, H)
+            let fnW = MLXRandom.normal([H]).asType(.float16)
+            let cs0 = MLXRandom.normal([cK - 1, convDim]).asType(.float16)
+            let rs0 = MLXRandom.normal([1, Hv, Dv, Dk]).asType(.float32)
+            let kC0 = MLXRandom.normal([nKV, 16, hD]).asType(.float16)
+            let vC0 = MLXRandom.normal([nKV, 16, hD]).asType(.float16)
+            MLX.eval([cs0, rs0, kC0, vC0, eW, eS, eB, lW, lS, lB, fnW])
+            func freshCaches() -> [SeedlessVerifyForward.LayerCaches] {
+                [SeedlessVerifyForward.LayerCaches(convState: cs0, recState: rs0),
+                 SeedlessVerifyForward.LayerCaches(kCache: kC0, vCache: vC0)]
+            }
+            func mkFwd() -> SeedlessFusedVerify.SeedlessFusedForward? {
+                SeedlessFusedVerify.SeedlessFusedForward(layers: layers, caches: freshCaches(),
+                                                         maxM: 4, H: H, maxSeqLen: 64)
+            }
+            // Shared history: prefix W (one M=3 chunk) + delta Dx (one M=2 chunk) —
+            // the SAME chunking on both paths (aligned-boundary contract: the lane
+            // admission only ever restores at chunk boundaries, so the delta chunking
+            // always matches the cold path's).
+            let W3 = MLXRandom.normal([3, H]).asType(.float16)
+            let Dx = MLXRandom.normal([2, H]).asType(.float16)
+            MLX.eval([W3, Dx])
+            // Donor: compute the prefix, capture the blob at its boundary.
+            guard let donor = mkFwd(), donor.forwardRows(W3, M: 3) != nil
+            else { return (false, "donor init/forward nil") }
+            let blob = donor.persistentStateData()
+            // Truncated blob must be rejected; the half-written forward is discarded.
+            guard let trunc = mkFwd() else { return (false, "trunc init nil") }
+            if trunc.restorePersistentState(Data(blob.prefix(16))) {
+                return (false, "truncated blob accepted")
+            }
+            // Cold lane: computes prefix + delta itself. Restored lane: blob + delta.
+            guard let cold = mkFwd(), cold.forwardRows(W3, M: 3) != nil
+            else { return (false, "cold init/forward nil") }
+            guard let rest = mkFwd() else { return (false, "restored init nil") }
+            guard rest.restorePersistentState(blob) else { return (false, "restore false") }
+            guard let outC = cold.forwardRows(Dx, M: 2), let outR = rest.forwardRows(Dx, M: 2)
+            else { return (false, "delta forward nil") }
+            outC.eval(); outR.eval()
+            let (hOk, hD2) = bitEqual(outR, outC)
+            if !hOk { return (false, "delta h: \(hD2)") }
+            for (li, names) in [(0, ("convState", "recState")), (1, ("kCache", "vCache"))] {
+                let (ra, rb) = rest.readLayerCache(li)
+                let (ca, cb) = cold.readLayerCache(li)
+                for (x, y, nm) in [(ra, ca, names.0), (rb, cb, names.1)] {
+                    guard let xx = x, let yy = y else { return (false, "\(nm) nil") }
+                    let (ok, d) = bitEqual(xx, yy)
+                    if !ok { return (false, "\(nm): \(d)") }
+                }
+            }
+            // Batch composition: the restored lane and the cold lane advance through
+            // stepArgmaxBatch identically, and identically to a solo cold stepArgmax.
+            guard let solo = mkFwd(),
+                  solo.attachHead(embedW: eW, embedS: eS, embedB: eB, lmW: lW, lmS: lS, lmB: lB,
+                                  fnW: fnW, vocab: vocab),
+                  solo.forwardRows(W3, M: 3) != nil, solo.forwardRows(Dx, M: 2) != nil
+            else { return (false, "solo init/forward nil") }
+            guard let drv = SeedlessFusedVerify.SeedlessFusedForward(layers: layers, caches: freshCaches(),
+                                                                     maxM: 8, H: H, maxSeqLen: 64),
+                  drv.attachHead(embedW: eW, embedS: eS, embedB: eB, lmW: lW, lmS: lS, lmB: lB,
+                                 fnW: fnW, vocab: vocab),
+                  let batch = SeedlessLaneBatch(driver: drv, lanes: [rest, cold])
+            else { return (false, "driver/batch init nil") }
+            var tok: Int32 = 7
+            for step in 0 ..< 3 {
+                guard let r = solo.stepArgmax([tok]), r.count == 1
+                else { return (false, "solo stepArgmax nil step=\(step)") }
+                guard let got = batch.stepArgmaxBatch([tok, tok])
+                else { return (false, "batch nil step=\(step)") }
+                if got[0] != got[1] || got[0] != r[0] {
+                    return (false, "tokens step=\(step): got \(got) want \(r[0])")
+                }
+                tok = Int32(got[0])
             }
             return (true, "ok")
         }

--- a/swift/Sources/qwisp/Selftest.swift
+++ b/swift/Sources/qwisp/Selftest.swift
@@ -104,6 +104,9 @@ func runCompletionSelftest(modelDir: String) async -> String {
     // continuous-batching scheduler (issue #6; pure logic over a scripted fake engine).
     for (name, ok) in ContinuousScheduler.selfCheck() { check("batch_\(name)", ok) }
 
+    // lane admission plan (#121; pure boundary arithmetic, no GPU).
+    for (name, ok) in LaneBatchSlots.admitSelfCheck() { check("laneadmit_\(name)", ok) }
+
     return lines.joined(separator: "\n") + "\nCOMPTEST \(passed)/\(total)"
 }
 


### PR DESCRIPTION
## Summary

`LaneBatchSlots.admit` now restores the longest cached prefix into the fresh lane and prefills only the delta, instead of re-paying the full prompt prefill per request — the missing admission half of lane batching that made the old batch path lose 2.6x to serialize on agentic shared-prefix traffic (#120).

- **Two `PrefixRAMStore` tiers**: `sharedStore` (recurrence-detected harness prefixes, fan-out sharing) + `convStore` (per-conversation last-boundary states, multi-turn extension). Two stores because `save()`'s supersede semantics would drop a shared-harness boundary entry whenever a longer full-prompt key lands.
- **All restore/capture/save boundaries are absolute chunk-aligned (1024)** ⇒ the delta prefill reproduces the cold path's chunk boundaries exactly ⇒ restore+delta is bit-identical to cold **by construction** — no chunk-composition invariance assumption on the steel-hybrid kernels.
- Default ON; `QWISP_LANE_PREFIX=0` / `QWISP_LANE_PREFIX_MB=0` opts out (budget default 3072MB, 1/3 shared / 2/3 conv, resident tier).

## Measured (synthetic 6-stream fan-out, 12.4K-char shared system prefix, QWISP_LANES=6, M1 Max 64GB)

| run | identity vs strict serial ref | total wall |
|---|---|---|
| serialize serial (reference) | — | 42.6s |
| serialize concurrent | 6/6 | 38.1s |
| lanes, prefix admission OFF | 6/6 | 56.2s |
| **lanes, prefix admission ON** | **6/6** | **32.8s** |

Admission lever isolated: **1.71x** (cold admit ~3.9s/req → restore+delta ~0.15s). Streams are short (256 tok, decode-dominated); the admission win scales with prompt length on real 8-50K traces.

## Gates

- RAWTESTS **92/92** — new WRITE-LOCKED test 92 `lane_admit_restore_bitexact` (blob restore + delta ≡ cold bit-exact: delta rows, cache trajectories, chained `stepArgmaxBatch` vs solo; truncated blob rejected)
- COMPTEST **67/67** (new `laneadmit_*` plan arithmetic ×7, `prefixram_maxlcp_*` ×3)
- BENCHBATCHTEST PASS · TOKTEST 5/5

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)