### PR TITLE
fix(server): SSE stream stalled forever after a multibyte char split across tokens

### DIFF
--- a/swift/Sources/qwisp/ChatCompletion.swift
+++ b/swift/Sources/qwisp/ChatCompletion.swift
@@ -209,11 +209,18 @@ func runGeneration(promptIds: [Int], maxTokens: Int, stopIds: [Int],
         // Defensive: the backend must already honor stopTokens/maxTokens, but guard here too.
         if stopIds.contains(id) { finish = "stop"; break }
         outIds.append(id)
-        let full = detok.push(id)
+        detok.push(id)
+        // Deltas from the FINALIZED text only (append-only, no dangling U+FFFD) — a
+        // split multibyte char used to emit a replacement char here and then re-send
+        // the whole text once the char completed (see StreamDetok.finalized).
+        let full = detok.finalized
         let delta = full.hasPrefix(emitted) ? String(full[emitted.endIndex...]) : full
         emitted = full
         if !delta.isEmpty { onDelta(delta) }
         if maxTokens >= 0 && outIds.count >= maxTokens { finish = "length"; break }  // <0 = until EOS/context
     }
-    return CompletionResult(text: emitted, completionTokens: outIds.count, finishReason: finish)
+    // Flush anything still held in the pending window (finalized ⊆ text always).
+    let final = detok.text
+    if final.count > emitted.count, final.hasPrefix(emitted) { onDelta(String(final[emitted.endIndex...])) }
+    return CompletionResult(text: final, completionTokens: outIds.count, finishReason: finish)
 }

--- a/swift/Sources/qwisp/QwispTokenizer.swift
+++ b/swift/Sources/qwisp/QwispTokenizer.swift
@@ -66,7 +66,17 @@ struct StreamDetok {
     private var stable = ""          // finalized text — never changes retroactively
     private var pending: [Int] = []  // ids not yet safely cut
     init(decode: @escaping ([Int]) -> String) { self.decode = decode }
+    /// Finalized text: append-only, never ends in a dangling U+FFFD. Streaming deltas
+    /// MUST be derived from THIS, not from the full view — a view's trailing
+    /// replacement char gets rewritten by the next token, and a prefix-guarded delta
+    /// stream then stalls (streamSSE suppressed every later delta once `sent` held a
+    /// U+FFFD — the OpenCode mid-stream stall, 2026-07-22) or duplicates
+    /// (runGeneration re-sent the full text).
+    var finalized: String { stable }
+    /// Full text so far (== decode(all ids pushed)) — final-result use only.
+    var text: String { pending.isEmpty ? stable : stable + decode(pending) }
     /// Push one id; returns the full text so far (== decode(all ids pushed)).
+    @discardableResult
     mutating func push(_ id: Int) -> String {
         pending.append(id)
         let tail = decode(pending)

--- a/swift/Sources/qwisp/Selftest.swift
+++ b/swift/Sources/qwisp/Selftest.swift
@@ -63,6 +63,18 @@ func runCompletionSelftest(modelDir: String) async -> String {
                                  decode: decode, backend: FakeBackend(script: helloIds)) { streamed += $0 }
     check("delta_concat", streamed == r4.text && !streamed.isEmpty)
 
+    // 4b. multibyte character SPLIT across tokens (the OpenCode mid-stream stall,
+    // 2026-07-22): the half-char step must not emit U+FFFD — once a replacement char
+    // is emitted and later rewritten, prefix-guarded delta streams either stall
+    // (streamSSE) or duplicate (this path). Deltas must concat to the exact text.
+    let frags: [[UInt8]] = [Array("a".utf8) + [0xF0, 0x9F], [0x9A, 0x80] + Array("x".utf8)]
+    var mbStreamed = ""
+    let r4b = await runGeneration(promptIds: [], maxTokens: 8, stopIds: [],
+                                  decode: { ids in String(decoding: ids.flatMap { frags[$0] }, as: UTF8.self) },
+                                  backend: FakeBackend(script: [0, 1])) { mbStreamed += $0 }
+    check("delta_multibyte_split", mbStreamed == "a🚀x" && r4b.text == "a🚀x")
+    check("delta_no_replacement_char", !mbStreamed.contains("\u{FFFD}"))
+
     // 5-7. splitThink: reasoning/content separation (pure; Qwen3.6 <think> handling).
     let sp = splitThink("weighing options</think>\n\nThe answer is 42.")
     check("think_split_content", sp.content == "The answer is 42.")

--- a/swift/Sources/qwisp/Server.swift
+++ b/swift/Sources/qwisp/Server.swift
@@ -195,8 +195,12 @@ final class QwispEngine: @unchecked Sendable {
             if p.stop.contains(tok) { finish = "stop"; break }
             outIds.append(tok)
             if tFirst == nil { tFirst = Date() }
-            // Split thinking from answer: reasoning → delta.reasoning_content, answer → delta.content.
-            let (r, afterThink) = splitOutput(detok.push(tok), thinkingDisabled: req.thinkingDisabled)
+            detok.push(tok)
+            // Deltas derive from the FINALIZED text only (append-only, no dangling
+            // U+FFFD) — deriving them from the full view stalled the stream forever
+            // once a split multibyte char emitted a replacement char that the next
+            // token rewrote (hasPrefix(sent) never held again). See StreamDetok.
+            let (r, afterThink) = splitOutput(detok.finalized, thinkingDisabled: req.thinkingDisabled)
             if r.count > sentR.count, r.hasPrefix(sentR) {
                 try await send(Delta(reasoning_content: String(r.dropFirst(sentR.count))), nil); sentR = r
             }
@@ -207,8 +211,19 @@ final class QwispEngine: @unchecked Sendable {
             }
             if p.maxTokens >= 0 && outIds.count >= p.maxTokens { finish = "length"; break }  // <0 = until EOS/context
         }
+        // End-of-stream flush from the authoritative full decode: anything still held
+        // back (pending window) or trailing bytes goes out here; finalized is always a
+        // prefix of the full text, so the prefix guards hold by construction.
+        let (rEnd, afterEnd) = splitOutput(tokenizer.decode(outIds), thinkingDisabled: req.thinkingDisabled)
+        if rEnd.count > sentR.count, rEnd.hasPrefix(sentR) {
+            try await send(Delta(reasoning_content: String(rEnd.dropFirst(sentR.count))), nil); sentR = rEnd
+        }
+        let visEnd = afterEnd.range(of: "<tool_call>").map { String(afterEnd[..<$0.lowerBound]) } ?? afterEnd
+        if visEnd.count > sentC.count, visEnd.hasPrefix(sentC) {
+            try await send(Delta(content: String(visEnd.dropFirst(sentC.count))), nil); sentC = visEnd
+        }
         // Buffered tool calls: parse the completed output and emit them as tool_calls deltas.
-        let (_, toolCalls) = ToolParse.parse(splitOutput(tokenizer.decode(outIds), thinkingDisabled: req.thinkingDisabled).content)
+        let (_, toolCalls) = ToolParse.parse(afterEnd)
         for (i, tc) in toolCalls.enumerated() {
             try await send(Delta(tool_calls: [ToolCallDelta(index: i, id: tc.id, type: "function", function: tc.function)]), nil)
         }


### PR DESCRIPTION
## Bug

A CJK/emoji character split across two BPE tokens decodes to a trailing U+FFFD on the first half. `streamSSE` emitted it; when the next token completed the character, the full text no longer had the sent text as a prefix — the `hasPrefix(sent)` guard then suppressed **every later delta**. The server keeps decoding to completion while the client sees the output freeze mid-stream. Japanese output makes this near-inevitable.

Evidence from the reporting OpenCode session (stored part ends exactly at the replacement char):

```
1. **ローカル開発者のマシンで使う** — macOS �
```

The CLI path (`runGeneration`) hit the same rewrite and re-sent the full text instead — duplication, not stall. **Pre-existing in all shipped builds (≤0.3.8)**; today's StreamDetok (#130) made the clean fix possible.

## Fix

Deltas now derive from `StreamDetok.finalized` — append-only, never ends in a dangling U+FFFD — so the prefix guards hold **by construction**. A final flush from the authoritative full decode covers the pending window at end-of-stream (both SSE and CLI paths).

## Verification

- Real server, the reporting session's own prompt: thinking 700 deltas + content 600 deltas (816 Japanese chars), zero U+FFFD, runs to `[DONE]`.
- New COMPTEST checks `delta_multibyte_split` / `delta_no_replacement_char`: fake tokenizer splitting 🚀 across two ids — exact concat, no FFFD, no duplication.
- COMPTEST 73/73 · TOKTEST 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)