### PR TITLE
WS-A archive: sdpa_prefill_mma probe kernel (flag-off) + NO-GO verdict

### DIFF
--- a/notes/20-attn-prefill-mma-spec.md
+++ b/notes/20-attn-prefill-mma-spec.md
@@ -1,0 +1,80 @@
+# 20 — Probe spec: matrix-unit (MMA) attention-prefill kernel `sdpa_prefill_mma`
+
+Phase 1 of WS-A (issue #137). ADDITIVE, flag-off probe — refs are NOT touched in
+this phase. GO bar and the re-canonicalization decision live in the issue.
+
+## Why (measured, notes/19 §8)
+
+`long-context-decay`: the attention term owns the prefill decay — 0.42s→17.72s per
+1024-chunk from pos 0→47K (76% of chunk time at depth) while steel-hybrid GDN/MoE
+stay near-flat. The current kernel (`sdpa_rows`, SeedlessMetalForward.swift ~L4893)
+is a GEMV-style decode kernel stretched to M rows: one threadgroup per (head, row),
+per-position `simd_sum` dot products, ZERO K/V reuse across the M query rows.
+
+Physical plausibility (doctrine gate): at pos 47K, chunk 1024, H=16, D=256,
+10 full-attn layers: QK^T+PV ≈ 7.9 TFLOP/chunk → ≥7x headroom at 25% MMA
+utilization (~2.3s vs 17.7s). Bandwidth floor with TQ=16 row tiles: ~60GB KV
+re-reads/chunk ≈ 0.3s at >200GB/s. The 2x GO bar is conservative.
+
+## Contract
+
+New kernel `sdpa_prefill_mma` (SeedlessMetalForward, additive) + encode-only
+variant (pattern: `encodeSdpaRows`, SeedlessFusedVerify.swift ~L1978), wired ONLY
+into the prefill-scoped forward (`forwardRowsHybrid` — the same seam
+QWISP_HYBRID_PREFILL uses; TellRuntime ~L96 "Decode/verify NEVER use this").
+
+Semantics identical to `sdpa_rows`: q[M*H, D], k/v shared cache buffers
+[KV, totalSeq, D] (strides passed in), out[M*H, D] half; per-row causal prefix
+N = baseN + m; gqa_factor = H/KV = 8; D = 256 fixed; fp32 accumulation.
+
+Flag: `QWISP_ATTN_MMA_PREFILL` — **default OFF this phase**. OFF ⇒ every code path
+byte-identical to today (RAWTESTS 92/92 must stay green with the flag unset).
+
+## Kernel design constraints (load-bearing — from notes/19 §1)
+
+1. **Fixed tile geometry, always.** TQ×TK compile-time constants (start TQ=16,
+   TK=32; tune freely but ONE configuration ships). No shape-adaptive dispatch —
+   that is the batch-invariance trap every CUDA engine fell into.
+2. **Chunk-composition invariance** (the property `sdpa_rows` has by construction
+   and PREFIXE2E depends on): row m's output bits must depend only on (q_m, KV
+   prefix of length N_m) — never on which chunk/tile it sits in or on M. Partial
+   tiles are handled by PADDING (pad q rows point at content-irrelevant data,
+   outputs discarded — steelMoEGather precedent, SeedlessFusedVerify ~L3935).
+3. **Fixed accumulation order.** Sequential KV-tile loop (ascending positions),
+   fixed k-fragment order inside each 8x8 MMA chain, fp32 accumulators
+   (simdgroup_float8x8 / BlockMMA-style). Online softmax per ROW in fp32, update
+   order = KV-tile order. No atomics; any cross-simdgroup combine has a fixed
+   order independent of timing.
+4. Causal mask: position j participates for row m iff j < baseN + m. Masked
+   positions must have ZERO influence on the row's bits (not just ~0 weight —
+   exclude them from max/sum/PV entirely).
+5. Bit-exactness to `sdpa_rows` is NOT required (this becomes a new canonical on
+   GO). Required instead: determinism + the invariances above + numeric sanity.
+
+## Locked tests (RAWTESTS 92 → 96; WRITE-LOCKED total bumps to 96)
+
+93. `mma_prefill_determinism`: same inputs twice → bit-identical out (random
+    q/k/v, M=33, baseN=277 — deliberately non-multiples of tiles).
+94. `mma_prefill_composition_invariant`: rows computed as one M=33 call vs split
+    calls (M=16 at baseN, M=17 at baseN+16) → per-row bit-identical.
+95. `mma_prefill_causal_and_pad`: (a) mutate k/v at positions ≥ N_m → row m bits
+    unchanged; (b) fill pad-row q slots with NaN/garbage → real rows unchanged.
+96. `mma_prefill_reference_sanity`: vs float64 CPU reference on random inputs
+    (M=8, N≤512): max |Δ| ≤ 2e-2 on half outputs AND argmax over a random
+    [D→vocab-proxy] projection agrees ≥ 99% of rows (guards sign/off-by-one bugs
+    that tolerance alone misses).
+
+Tests call the kernel DIRECTLY (unit level, like existing sdpa_rows tests); no
+model needed. Flag-off integration invariance is covered by the existing 92.
+
+## Bench verification (driver runs after GREEN, GPU-exclusive)
+
+`QWISP_RUN=long-context-decay` with `QWISP_ATTN_MMA_PREFILL=1` vs unset:
+attn_ms at pos 47104 (baseline 17,718ms). **GO ≥ 2x** on the attention term;
+record the full table in this file's addendum.
+
+## Prohibitions (this phase)
+
+- Do NOT modify `sdpa_rows`, the verify path, decode path, or any existing kernel.
+- Do NOT regenerate refs/ or flip any default.
+- Do NOT weaken/skip existing WRITE-LOCKED tests (total goes 92→96 by ADDITION).

--- a/notes/20-attn-prefill-mma-spec.md
+++ b/notes/20-attn-prefill-mma-spec.md
@@ -78,3 +78,48 @@ record the full table in this file's addendum.
 - Do NOT modify `sdpa_rows`, the verify path, decode path, or any existing kernel.
 - Do NOT regenerate refs/ or flip any default.
 - Do NOT weaken/skip existing WRITE-LOCKED tests (total goes 92→96 by ADDITION).
+
+---
+
+## VERDICT (2026-07-25): NO-GO on M1-class hardware — phase 2 does not proceed
+
+Correctness fully landed (RAWTESTS 96/96: determinism / chunk-composition
+invariance / causal+pad zero-influence / f64 reference sanity). Performance
+failed the bar, twice, on the only valid instrument (same-session paired 24K
+decay A/B, scripts/bench_decay_ab.sh):
+
+| pos | run1 OFF/ON | run2 OFF/ON | speedup |
+|---|---|---|---|
+| 4096 | 1885 / 7632 | 1305 / 6206 | 0.21-0.25x |
+| 8192 | 2781 / 13778 | 2587 / 10708 | 0.20-0.24x |
+| 16384 | 6676 / 14528 | 4421 / 15583 | 0.28-0.46x |
+
+Mechanism (control-bounded, kernel doc header has details): the kernel is
+BIMODAL — a fast mode (~0.011 ms/pos, the source of the misleading isolated
+502ms probe) appears only on repeated identical dispatches; the encode path
+always runs the deterministic slow mode (~0.13 ms/pos/layer). Pure MMA in the
+identical grid sustains 10.1 TFLOPS; adding TG memory, barriers, and device
+streams keeps 9-10; only the full kernel's dependency-chained per-lane
+fragment gathers collapse it to ~½ core-equivalent. No structural variant
+(register blocking / tile sizes / load vectorization / residency) recovered
+it. sdpa_rows' 1024-wide coalesced GEMV sustains ~1 TFLOPS deterministically
+— that shape wins this op on M1-class.
+
+Measurement doctrine bought by this phase:
+1. Isolated kernel probes on repeated identical dispatches are INVALID for
+   this class of kernel (bimodality; SLC flattery). Only same-session paired
+   in-situ A/B counts.
+2. Cross-day decay comparisons are void (~45% drift on untouched stages).
+3. Apple-GPU MMA in latency-bound contexts is fragment-gather-limited;
+   residency/blocking cannot rescue it. Matches Rigel's finding (notes/19 §2)
+   that Metal4 MPP is only 1.05-1.21x over simdgroup_matrix.
+
+Door left open: M5-class NAX (16x16 tensor ops, different feed path) may
+change the verdict — the kernel + locked tests are preserved flag-off as the
+re-entry point. BaseRT's claimed simdgroup_matrix prefill win (notes/19 §5)
+is on M4 Pro with different shapes; unverified, not evidence against this
+measurement.
+
+Consequence: the prefill-decay attack shifts to WS-B (scheduler: hide the
+cliff) + the already-shipped cache tiers (never pay twice) + harness-side
+ingestion reduction. The attention term itself stays on sdpa_rows.

--- a/scripts/bench_decay_ab.sh
+++ b/scripts/bench_decay_ab.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Paired same-session decay A/B for the MMA attention-prefill kernel (WS-A #137).
+#
+# Motivation: cross-day decay comparisons are VOID — 2026-07-24 measured ~45%
+# drift on the untouched GDN/MoE stages vs the 07-23 baseline run. The only
+# valid comparison is OFF→ON back-to-back in one session (same thermal/DVFS
+# environment), which this script does.
+#
+# Usage:  scripts/bench_decay_ab.sh [maxCtx]     # default 24576 (diagnostic);
+#                                                # use 49152 for the formal GO run
+# Env:    QWISP_MODEL as usual. Requires AC power + no other GPU process
+#         (the qwisp server counts as one).
+# Output: two logs under /tmp + a side-by-side attn_ms table on stdout.
+#         GO bar (formal run only): attn@47104 ON ≤ half of OFF.
+set -euo pipefail
+
+MAX="${1:-24576}"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+POC="$REPO/swift/.xcode-build-rel/Build/Products/Release/qwisp-poc"
+[ -x "$POC" ] || { echo "ERROR: build qwisp-poc first"; exit 1; }
+if pgrep -x qwisp >/dev/null; then echo "ERROR: qwisp server running — stop it first (GPU exclusive)"; exit 1; fi
+if ! pmset -g batt | head -1 | grep -q "AC Power"; then
+    echo "WARNING: on battery — DVFS makes reps spike; results are diagnostic only"
+fi
+
+TS=$(date +%H%M%S)
+OFFLOG="/tmp/decay-ab-$TS-off.log"; ONLOG="/tmp/decay-ab-$TS-on.log"
+
+echo "== pass 1/2: flag OFF (baseline), maxCtx=$MAX =="
+QWISP_DECAY_MAX="$MAX" QWISP_RUN=long-context-decay \
+    ~/bin/jacquard measure "$POC" stream 2>&1 | tee "$OFFLOG" | grep -E "^\s+[0-9]+ " || true
+echo "== pass 2/2: flag ON (sdpa_prefill_mma) =="
+QWISP_ATTN_MMA_PREFILL=1 QWISP_DECAY_MAX="$MAX" QWISP_RUN=long-context-decay \
+    ~/bin/jacquard measure "$POC" stream 2>&1 | tee "$ONLOG" | grep -E "^\s+[0-9]+ " || true
+
+echo ""
+echo "== paired attn_ms (prefill chunks; decode rows excluded — flag is M>1 only) =="
+python3 - "$OFFLOG" "$ONLOG" << 'EOF'
+import re, sys
+def prefill_rows(path):
+    rows, in_prefill = {}, False
+    for line in open(path):
+        if "prefill: per-chunk" in line: in_prefill = True; continue
+        if "decode (M=1)" in line: in_prefill = False
+        m = re.match(r"\s+(\d+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+(\d+)", line)
+        if in_prefill and m:
+            rows[int(m.group(1))] = float(m.group(2))
+    return rows
+off, on = prefill_rows(sys.argv[1]), prefill_rows(sys.argv[2])
+print(f"{'pos':>8} {'attn OFF':>10} {'attn ON':>10} {'speedup':>8}")
+for pos in sorted(off):
+    if pos in on and on[pos] > 0:
+        print(f"{pos:>8} {off[pos]:>10.0f} {on[pos]:>10.0f} {off[pos]/on[pos]:>7.2f}x")
+EOF
+echo ""
+echo "logs: $OFFLOG / $ONLOG"

--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -1993,6 +1993,31 @@ public enum SeedlessFusedVerify {
                                  threadsPerThreadgroup: MTLSize(width: 1024, height: 1, depth: 1))
     }
 
+    /// sdpa_prefill_mma(既存 _sdpaPrefillMmaPipeline, notes/20)を encode-only で提供。
+    /// Pattern/param list mirrors encodeSdpaRows exactly (same call-site shape) so callers
+    /// can swap between the two behind a flag. ADDITIVE — only used when
+    /// QWISP_ATTN_MMA_PREFILL=1 (encodeAttnLayerRows' useMmaPrefill branch).
+    static func encodeSdpaPrefillMma(_ enc: MTLComputeCommandEncoder, q: MTLBuffer, k: MTLBuffer, v: MTLBuffer, out: MTLBuffer,
+                               H: Int, KV: Int, D: Int, baseLenPlus1: Int, M: Int, scale: Float, maxLen: Int) {
+        let p = SeedlessMetalForward._sdpaPrefillMmaPipeline!
+        enc.setComputePipelineState(p)
+        enc.setBuffer(q, offset: 0, index: 0); enc.setBuffer(k, offset: 0, index: 1)
+        enc.setBuffer(v, offset: 0, index: 2); enc.setBuffer(out, offset: 0, index: 3)
+        var gqa = Int32(H / KV), bn = Int32(baseLenPlus1)
+        var khs = Int32(maxLen * D), kss = Int32(D), vhs = Int32(maxLen * D), vss = Int32(D), sc = scale
+        var mRows = Int32(M), totalSeq = Int32(baseLenPlus1 + M - 1), hh = Int32(H)
+        enc.setBytes(&gqa, length: 4, index: 4); enc.setBytes(&bn, length: 4, index: 5)
+        enc.setBytes(&khs, length: 4, index: 6); enc.setBytes(&kss, length: 4, index: 7)
+        enc.setBytes(&vhs, length: 4, index: 8); enc.setBytes(&vss, length: 4, index: 9)
+        enc.setBytes(&sc, length: 4, index: 10)
+        enc.setBytes(&mRows, length: 4, index: 11); enc.setBytes(&totalSeq, length: 4, index: 12)
+        enc.setBytes(&hh, length: 4, index: 13)
+        // Grid mirrors sdpaPrefillMma: one tg per (kv_head, 8-row q-tile), 8 simdgroups.
+        let numQTiles = max((M + 7) / 8, 1)
+        enc.dispatchThreadgroups(MTLSize(width: KV, height: numQTiles, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+    }
+
     /// extract_q(既存 aux kernel, 純コピー)を encode-only で提供。qOut[R,qd2] の先頭 headDim 列 → q[R,headDim]。
     static func encodeExtractQ(_ enc: MTLComputeCommandEncoder, qOut: MTLBuffer, q: MTLBuffer,
                                headDim: Int, qd2: Int, total: Int) {
@@ -2273,7 +2298,7 @@ public enum SeedlessFusedVerify {
                                     M: Int, H: Int,
                                     numHeads: Int = 16, numKV: Int = 2, headDim: Int = 256,
                                     ropeDim: Int = 64, ropeBase: Float = 1e7, eps: Float = 1e-6,
-                                    hybridDense: Bool = false) {
+                                    hybridDense: Bool = false, useMmaPrefill: Bool = false) {
         let baseLen = kv.len
         let qd2 = 2 * headDim
         let scale = Float(pow(Double(headDim), -0.5))
@@ -2321,8 +2346,16 @@ public enum SeedlessFusedVerify {
         // v-cache 散布(raw v, always unfused)
         encodeWriteKVRows(enc, src: sc.vOut, cache: kv.vCache, KV: numKV, D: headDim, maxLen: kv.maxLen, pos: baseLen, M: M)
         // ⑤ SDPA(行 m は先頭 baseLen+m+1 key)
-        encodeSdpaRows(enc, q: sc.qRot, k: kv.kCache, v: kv.vCache, out: sc.attnOut,
-                       H: numHeads, KV: numKV, D: headDim, baseLenPlus1: baseLen + 1, M: M, scale: scale, maxLen: kv.maxLen)
+        // WS-A #137: QWISP_ATTN_MMA_PREFILL default OFF ⇒ always the sdpaRows branch below
+        // (byte-identical to before this kernel existed). ON swaps in the additive
+        // flash-style MMA kernel — ONLY reachable via forwardRowsHybrid's prefill seam.
+        if useMmaPrefill, SeedlessMetalForward._sdpaPrefillMmaPipeline != nil {
+            encodeSdpaPrefillMma(enc, q: sc.qRot, k: kv.kCache, v: kv.vCache, out: sc.attnOut,
+                           H: numHeads, KV: numKV, D: headDim, baseLenPlus1: baseLen + 1, M: M, scale: scale, maxLen: kv.maxLen)
+        } else {
+            encodeSdpaRows(enc, q: sc.qRot, k: kv.kCache, v: kv.vCache, out: sc.attnOut,
+                           H: numHeads, KV: numKV, D: headDim, baseLenPlus1: baseLen + 1, M: M, scale: scale, maxLen: kv.maxLen)
+        }
         // ⑥ sigmoid gate → o_proj
         encodeSigmoidMul(enc, attnOut: sc.attnOut, qOut: sc.qOut, gated: sc.gated,
                          headDim: headDim, qd2: qd2, total: M * numHeads * headDim)
@@ -2349,6 +2382,16 @@ public enum SeedlessFusedVerify {
             let v = MLXRandom.normal([1, 2, 256]).asType(.float16)
             MLX.eval([q, k, v])
             _ = SeedlessMetalForward.sdpaRows(q, k, v, H: 1, KV: 1, D: 256, baseLen: 2, M: 1, scale: 1.0)
+        }
+        // WS-A #137: warm the MMA-prefill pipeline ONLY when the flag is on — flag-off
+        // must not compile/touch this additive kernel at all (byte-identical guarantee).
+        if ProcessInfo.processInfo.environment["QWISP_ATTN_MMA_PREFILL"] == "1",
+           SeedlessMetalForward._sdpaPrefillMmaPipeline == nil {
+            let q = MLXRandom.normal([16, 256]).asType(.float16)
+            let k = MLXRandom.normal([1, 16, 256]).asType(.float16)
+            let v = MLXRandom.normal([1, 16, 256]).asType(.float16)
+            MLX.eval([q, k, v])
+            _ = SeedlessMetalForward.sdpaPrefillMma(q, k, v, H: 1, KV: 1, D: 256, baseLen: 1, M: 16, scale: 1.0)
         }
         return SeedlessMetalForward._rmsPipeline != nil && SeedlessMetalForward._ropeRowsPipeline != nil
             && SeedlessMetalForward._sdpaRowsPipeline != nil
@@ -4065,7 +4108,8 @@ public enum SeedlessFusedVerify {
                     arrToBuf(yV, attnSc.vOut, M * numKV * headDim)
                     SeedlessFusedVerify.encodeAttnLayerRows(enc(), x: normed, out: mixerOut, w: aw, sc: attnSc, kv: kv,
                                                        M: M, H: H, numHeads: numHeads, numKV: numKV, headDim: headDim,
-                                                       ropeDim: ropeDim, ropeBase: ropeBase, eps: eps, hybridDense: true)
+                                                       ropeDim: ropeDim, ropeBase: ropeBase, eps: eps, hybridDense: true,
+                                                       useMmaPrefill: ProcessInfo.processInfo.environment["QWISP_ATTN_MMA_PREFILL"] == "1")
                     kv.len += M
                     flush()
                     arrToBuf(steelQmm(bufToArr(attnSc.gated, M, numHeads * headDim), hwA.o, M: M), mixerOut, M * H)

--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -3396,7 +3396,10 @@ public enum SeedlessFusedVerify {
         }
 
         /// MoE 前半 encode: norm → mixer(+cache bookkeeping) → resid → postNorm。
-        func encodePreMoE(_ enc: MTLComputeCommandEncoder, _ L: Layer, M: Int) {
+        // useMmaPrefill: default false everywhere; ONLY forwardRowsProfiled threads the env flag
+        // through so the decay bench can A/B the MMA prefill kernel (WS-A #137). The strict
+        // forwardRows/verify call sites never pass it — their bytes are unchanged.
+        func encodePreMoE(_ enc: MTLComputeCommandEncoder, _ L: Layer, M: Int, useMmaPrefill: Bool = false) {
             SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: L.inputLN, out: normed, rows: M, D: H, eps: eps)
             if L.isLinear, let gw = L.gdn, let gc = L.gdnCache {
                 SeedlessFusedVerify.encodeGdnLayerRows(enc, x: normed, out: mixerOut, w: gw, sc: gdnSc, cache: gc,
@@ -3407,7 +3410,8 @@ public enum SeedlessFusedVerify {
             } else if let aw = L.attn, let kv = L.kvCache {
                 SeedlessFusedVerify.encodeAttnLayerRows(enc, x: normed, out: mixerOut, w: aw, sc: attnSc, kv: kv,
                                                    M: M, H: H, numHeads: numHeads, numKV: numKV, headDim: headDim,
-                                                   ropeDim: ropeDim, ropeBase: ropeBase, eps: eps)
+                                                   ropeDim: ropeDim, ropeBase: ropeBase, eps: eps,
+                                                   useMmaPrefill: useMmaPrefill)
                 kv.len += M
             }
             // F5 (notes/07 §3 Wave 2): fuseGDN 時は gdn_resid_postnorm_rows 1 dispatch で
@@ -4170,8 +4174,9 @@ public enum SeedlessFusedVerify {
                 enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
                 return (cb.gpuEndTime - cb.gpuStartTime) * 1000.0
             }
+            let mmaPrefill = ProcessInfo.processInfo.environment["QWISP_ATTN_MMA_PREFILL"] == "1"
             for L in layers {
-                let t1 = timed { enc in self.encodePreMoE(enc, L, M: M) }
+                let t1 = timed { enc in self.encodePreMoE(enc, L, M: M, useMmaPrefill: mmaPrefill) }
                 if L.isLinear { tGdn += t1 } else { tAttn += t1 }
                 tMoe += timed { enc in
                     SeedlessFusedVerify.encodeMoEBlockRows(enc, x: self.postNorm, out: self.moeOut, w: L.moe, sc: self.moeSc,

--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -4174,7 +4174,9 @@ public enum SeedlessFusedVerify {
                 enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
                 return (cb.gpuEndTime - cb.gpuStartTime) * 1000.0
             }
-            let mmaPrefill = ProcessInfo.processInfo.environment["QWISP_ATTN_MMA_PREFILL"] == "1"
+            // M > 1 only: the decay runner also profiles M=1 decode steps through this
+            // function — the MMA kernel is a prefill-tile kernel and must never see decode.
+            let mmaPrefill = M > 1 && ProcessInfo.processInfo.environment["QWISP_ATTN_MMA_PREFILL"] == "1"
             for L in layers {
                 let t1 = timed { enc in self.encodePreMoE(enc, L, M: M, useMmaPrefill: mmaPrefill) }
                 if L.isLinear { tGdn += t1 } else { tAttn += t1 }

--- a/swift/Sources/QwispCore/SeedlessMetalForward.swift
+++ b/swift/Sources/QwispCore/SeedlessMetalForward.swift
@@ -5036,13 +5036,22 @@ public enum SeedlessMetalForward {
     /// (e.g. the H=1 pipeline warm-up) leaves the surplus simdgroups computing a
     /// clamped duplicate head that is never stored, so barriers stay uniform.
     ///
-    /// Perf status (isolated single-layer probe, M=1024 @ baseN=47104, GPU-time
-    /// on pre-uploaded buffers): ~505-525ms vs sdpa_rows ~820ms probe / ~1772ms
-    /// per layer in the 10-layer decay bench at 47K (where sdpa_rows is
-    /// DRAM-crushed while this kernel's 64-way K/V reuse keeps it compute-bound
-    /// and decay-flat) — ≈3.4x on the decay attention term if the driver's AC
-    /// measurement confirms. History: round-2 TK=16 variant ~1.69s; round-3
-    /// d-sliced RB×CB register blocking (4 sgs/core) ~3.2s = NO-GO.
+    /// Perf status — NO-GO evidence (round 4, AC power, paired in-situ A/B +
+    /// isolated probes): the kernel is BIMODAL. Deterministic slow mode
+    /// ≈0.12-0.155 ms/pos/layer (all in-situ chunks, all isolated runs at
+    /// ctx ≤8K, and first/most reps at 47K) ⇒ in-situ ON = 0.20-0.46x of
+    /// sdpa_rows — SLOWER. A fast mode ≈0.011 ms/pos appears only on repeated
+    /// identical dispatches with >SLC buffers, unreliably; the encode path
+    /// never enters it. Mechanism bounding (controls in the same 2×128 grid):
+    /// pure-MMA 10.1 TFLOPS stable; +12.7KB TG mem, +per-tile barriers,
+    /// +per-tile 16B/thread device streams — all still ~9-10 TFLOPS. Only the
+    /// full kernel's dependency-chained per-lane fragment gathers collapse
+    /// aggregate throughput to ~½ core-equivalent; no structural variant
+    /// (register blocking, tile sizes, load vectorization, residency) moved it
+    /// past ~2x. sdpa_rows' 1024-wide coalesced GEMV sustains ~1 TFLOPS
+    /// deterministically — on M1-class hardware that shape wins for this op.
+    /// History: round-2 TK=16 ~1.69s@47K; round-3 d-sliced RB×CB blocking
+    /// ~3.2s = NO-GO; round-4 uint4 staging kept (strict improvement).
     public static func sdpaPrefillMma(_ q: MLXArray, _ k: MLXArray, _ v: MLXArray,
                                        H: Int, KV: Int, D: Int,
                                        baseLen: Int, M: Int, scale: Float) -> MLXArray? {
@@ -5150,14 +5159,30 @@ public enum SeedlessMetalForward {
                 while (kvStart < nMax) {
                     const int kvCount = min(TK, nMax - kvStart);
 
-                    // ---- stage this KV-tile's K/V once (coalesced, all 256 threads);
-                    //      consumed by all NSG q-heads × TQ rows ----
-                    for (int i = flatTid; i < TK * D; i += 32 * NSG) {
-                        const int pos = i / D, d = i - pos * D;
+                    // ---- stage this KV-tile's K/V once, consumed by all NSG q-heads ----
+                    // Exactly one 16B uint4 device read per thread per array (256
+                    // threads × 8 halves = the whole 4KB tile): collapses the round-2
+                    // 8-deep scalar-load chain per thread into one transaction
+                    // (measured: 8K-ctx layer 1345→1015ms). 16B alignment holds — the
+                    // seq/head strides are multiples of D=256 halves and d is a
+                    // multiple of 8. K scatter-writes into its transposed TG layout
+                    // stay scalar (TG SRAM, cheap).
+                    {
+                        const int e8 = flatTid * 8;
+                        const int pos = e8 / D, d = e8 - pos * D;
                         const int gpos = kvStart + pos;
-                        const bool valid = pos < kvCount;
-                        kStage[d * TKS + pos] = valid ? keys[kv_head * k_head_stride + gpos * k_seq_stride + d] : (half)0;
-                        vStage[pos * KSTRIDE + d] = valid ? values[kv_head * v_head_stride + gpos * v_seq_stride + d] : (half)0;
+                        if (pos < kvCount) {
+                            const uint4 kw = *(device const uint4*)(keys + kv_head * k_head_stride + gpos * k_seq_stride + d);
+                            const uint4 vw = *(device const uint4*)(values + kv_head * v_head_stride + gpos * v_seq_stride + d);
+                            *(threadgroup uint4*)(vStage + pos * KSTRIDE + d) = vw;
+                            thread const half* kh = (thread const half*)&kw;
+                            #pragma unroll
+                            for (int j = 0; j < 8; j++) kStage[(d + j) * TKS + pos] = kh[j];
+                        } else {
+                            *(threadgroup uint4*)(vStage + pos * KSTRIDE + d) = uint4(0);
+                            #pragma unroll
+                            for (int j = 0; j < 8; j++) kStage[(d + j) * TKS + pos] = (half)0;
+                        }
                     }
                     threadgroup_barrier(mem_flags::mem_threadgroup);
 

--- a/swift/Sources/QwispCore/SeedlessMetalForward.swift
+++ b/swift/Sources/QwispCore/SeedlessMetalForward.swift
@@ -5009,14 +5009,20 @@ public enum SeedlessMetalForward {
     /// fp32 accumulation. Fixed tile geometry always: one threadgroup =
     /// (kv_head, tile of TQ=8 query rows) with NSG=8 simdgroups, one per q-head
     /// of that kv_head (grid = KV × ceil(M/TQ), 256 threads/tg). Each KV tile
-    /// (TK=16 positions) is staged ONCE into threadgroup memory and consumed by
+    /// (TK=8 positions) is staged ONCE into threadgroup memory and consumed by
     /// all 8 q-heads × 8 rows — 64-way K/V reuse, which is what pulls the 47K
     /// DRAM re-read floor under the notes/20 GO budget. Per-head fp32 output
     /// accumulators live in REGISTERS (32 simdgroup_float8x8 fragments per
-    /// simdgroup), not threadgroup memory: with a >16KB TG footprint only one
-    /// threadgroup fits per core, so 8 resident simdgroups (not 1) are also what
-    /// give the core any latency hiding at all (round-2 lesson: the 1-simdgroup
-    /// variant was 4x SLOWER than round 1 from serialized TG-memory chains).
+    /// simdgroup), not threadgroup memory.
+    ///
+    /// TK=8 is deliberate and load-bearing (round 3): with loads in the stream a
+    /// simdgroup is LATENCY-bound (~85 cyc/MMA vs ~4 for a pure-MMA control), so
+    /// throughput ∝ resident simdgroups per core. Apple caps ~8 threadgroups per
+    /// core; TK=8 keeps the TG footprint at ~12.7KB so TWO 8-simdgroup tgs fit
+    /// per core (16 resident sgs) — measured 3.2x over the identical kernel at
+    /// TK=16 (22.7KB, 1 tg/core). Bigger tiles, more register blocking (RB×CB≥4
+    /// d-sliced, round 3), fewer sgs, q-hoisting, and load vectorization all
+    /// measured neutral-to-worse; residency is the only lever that moved.
     /// Bit-exactness to sdpa_rows is NOT required (hardware matrix-unit rounding
     /// differs) — required instead: determinism, chunk-composition invariance,
     /// causal/pad zero-influence, numeric sanity (locked tests 93–96, notes/20).
@@ -5030,16 +5036,13 @@ public enum SeedlessMetalForward {
     /// (e.g. the H=1 pipeline warm-up) leaves the surplus simdgroups computing a
     /// clamped duplicate head that is never stored, so barriers stay uniform.
     ///
-    /// Round-2 perf status (isolated single-layer probe, M=1024 @ baseN=47104,
-    /// GPU-time only): this kernel ~1.7s vs sdpa_rows ~0.8s probe / ~1.77s in the
-    /// 10-layer decay bench (where sdpa_rows is DRAM-crushed and this kernel is
-    /// compute-bound ⇒ decay-flat). A pure-MMA control in the identical grid hits
-    /// 10.1 TFLOPS, so the gap is per-fragment operand handling (~6 loads + 6
-    /// element writes per 2 MMAs), not MMA rate, occupancy, banks, or barriers —
-    /// measured: bank-padding, K-transpose+half2 loads, q-hoist, and 4-way split
-    /// accumulators were all neutral-to-negative. Closing it needs steel-style
-    /// register blocking (RB×CB≥4 operand reuse), which conflicts with the
-    /// register-resident O at D=256 unless output columns are sliced per-simdgroup.
+    /// Perf status (isolated single-layer probe, M=1024 @ baseN=47104, GPU-time
+    /// on pre-uploaded buffers): ~505-525ms vs sdpa_rows ~820ms probe / ~1772ms
+    /// per layer in the 10-layer decay bench at 47K (where sdpa_rows is
+    /// DRAM-crushed while this kernel's 64-way K/V reuse keeps it compute-bound
+    /// and decay-flat) — ≈3.4x on the decay attention term if the driver's AC
+    /// measurement confirms. History: round-2 TK=16 variant ~1.69s; round-3
+    /// d-sliced RB×CB register blocking (4 sgs/core) ~3.2s = NO-GO.
     public static func sdpaPrefillMma(_ q: MLXArray, _ k: MLXArray, _ v: MLXArray,
                                        H: Int, KV: Int, D: Int,
                                        baseLen: Int, M: Int, scale: Float) -> MLXArray? {
@@ -5070,7 +5073,7 @@ public enum SeedlessMetalForward {
                 ushort sgid [[simdgroup_index_in_threadgroup]],
                 ushort simd_lid [[thread_index_in_simdgroup]])
             {
-                constexpr int TQ = 8, TK = 16, D = 256;   // rows/sg, KV positions/tile
+                constexpr int TQ = 8, TK = 8, D = 256;   // rows/sg, KV positions/tile
                 constexpr int NSG = 8;       // simdgroups per tg = q-heads served per kv_head
                 constexpr int CB = TK / 8;   // 2 KV-position fragments (QK^T cols / PV contraction)
                 constexpr int KF = D / 8;    // 32 contraction fragments (QK^T, over d)
@@ -5086,12 +5089,12 @@ public enum SeedlessMetalForward {
                 const bool active = sg < gqa_factor;
                 const int h = kv_head * gqa_factor + min(sg, gqa_factor - 1);
 
-                // Shared staged K/V (~9K+8K) + per-simdgroup score slices (~4.5K) +
-                // row state (<1K) ≈ 22.7KB. Output accumulators are per-lane REGISTERS.
-                // Row strides are PADDED off the 128B threadgroup-bank period (an
-                // unpadded D*2=512B / TK*4=64B stride would alias every fragment-lane
-                // of a load onto the same banks; padding measured perf-neutral in the
-                // isolated probe but costs ~700B — kept as cheap insurance).
+                // Shared staged K/V (~5K+4.2K) + per-simdgroup score slices (2.5K) +
+                // row state (<1K) ≈ 12.7KB — deliberately ≤16KB so TWO threadgroups
+                // stay resident per core (see header: residency is THE perf lever).
+                // Output accumulators are per-lane REGISTERS. Row strides are PADDED
+                // off the 128B threadgroup-bank period (cheap insurance; measured
+                // perf-neutral).
                 constexpr int KSTRIDE = D + 8;    // half elements per staged V row (pos-major)
                 constexpr int TKS = TK + 2;       // half elements per transposed-K row (d-major)
                 constexpr int SSTRIDE = TK + 2;   // float elements per sBuf row
@@ -5160,9 +5163,8 @@ public enum SeedlessMetalForward {
 
                     // ---- QK^T via simdgroup MMA, fp32 accumulate (K from stage) ----
                     {
-                        simdgroup_float8x8 acc0, acc1;
+                        simdgroup_float8x8 acc0;
                         acc0.thread_elements()[0] = 0.0f; acc0.thread_elements()[1] = 0.0f;
-                        acc1.thread_elements()[0] = 0.0f; acc1.thread_elements()[1] = 0.0f;
                         #pragma unroll
                         for (int kf = 0; kf < KF; kf++) {
                             device const half* qp = queries + qElemBase + kf * 8;
@@ -5175,21 +5177,13 @@ public enum SeedlessMetalForward {
                             // half2 vector load per fragment instead of two scalars.
                             const int dRow = (kf * 8 + (int)fm) * TKS;
                             const half2 b0 = *(threadgroup const half2*)(kStage + dRow + fn);
-                            const half2 b1 = *(threadgroup const half2*)(kStage + dRow + 8 + fn);
                             simdgroup_float8x8 B0;
                             B0.thread_elements()[0] = (float)b0.x;
                             B0.thread_elements()[1] = (float)b0.y;
                             simdgroup_multiply_accumulate(acc0, A, B0, acc0);
-
-                            simdgroup_float8x8 B1;
-                            B1.thread_elements()[0] = (float)b1.x;
-                            B1.thread_elements()[1] = (float)b1.y;
-                            simdgroup_multiply_accumulate(acc1, A, B1, acc1);
                         }
                         sBuf[(int)fm * SSTRIDE + fn]     = acc0.thread_elements()[0];
                         sBuf[(int)fm * SSTRIDE + fn + 1] = acc0.thread_elements()[1];
-                        sBuf[(int)fm * SSTRIDE + 8 + fn]     = acc1.thread_elements()[0];
-                        sBuf[(int)fm * SSTRIDE + 8 + fn + 1] = acc1.thread_elements()[1];
                     }
                     simdgroup_barrier(mem_flags::mem_threadgroup);   // sBuf is sg-private
 
@@ -5240,31 +5234,23 @@ public enum SeedlessMetalForward {
                     }
 
                     // ---- PV via simdgroup MMA into register accumulators ----
-                    // Fixed order: ascending KV-tile (outer while), then cb=0, cb=1
-                    // inside each accumulator — fully determined by loop structure,
-                    // independent of timing. Pad q rows' sBuf holds raw (finite)
-                    // scores; they only touch pad rows' lanes (row independence of
-                    // MMA), which are never stored.
+                    // Fixed order: ascending KV-tile (outer while), single 8-wide
+                    // contraction fragment per tile — fully determined by loop
+                    // structure, independent of timing. Pad q rows' sBuf holds raw
+                    // (finite) scores; they only touch pad rows' lanes (row
+                    // independence of MMA), which are never stored.
                     {
-                        simdgroup_float8x8 P0, P1;   // P[row, pos]
+                        simdgroup_float8x8 P0;   // P[row, pos]
                         const float2 p0 = *(threadgroup const float2*)(sBuf + (int)fm * SSTRIDE + fn);
-                        const float2 p1 = *(threadgroup const float2*)(sBuf + (int)fm * SSTRIDE + 8 + fn);
                         P0.thread_elements()[0] = p0.x; P0.thread_elements()[1] = p0.y;
-                        P1.thread_elements()[0] = p1.x; P1.thread_elements()[1] = p1.y;
                         #pragma unroll
                         for (int db = 0; db < DB; db++) {
                             const int outCol = db * 8 + (int)fn;
                             const half2 v0 = *(threadgroup const half2*)(vStage + (int)fm * KSTRIDE + outCol);
-                            const half2 v1 = *(threadgroup const half2*)(vStage + (8 + (int)fm) * KSTRIDE + outCol);
                             simdgroup_float8x8 V0;   // V[pos, d]: row = pos, col = d
                             V0.thread_elements()[0] = (float)v0.x;
                             V0.thread_elements()[1] = (float)v0.y;
                             simdgroup_multiply_accumulate(oFrag[db], P0, V0, oFrag[db]);
-
-                            simdgroup_float8x8 V1;
-                            V1.thread_elements()[0] = (float)v1.x;
-                            V1.thread_elements()[1] = (float)v1.y;
-                            simdgroup_multiply_accumulate(oFrag[db], P1, V1, oFrag[db]);
                         }
                     }
                     threadgroup_barrier(mem_flags::mem_threadgroup);   // kStage/vStage reused next tile

--- a/swift/Sources/QwispCore/SeedlessMetalForward.swift
+++ b/swift/Sources/QwispCore/SeedlessMetalForward.swift
@@ -4999,6 +4999,329 @@ public enum SeedlessMetalForward {
         return MLXArray(Array(UnsafeBufferPointer(start: ptr, count: M * H * D)), [M * H, D])
     }
 
+    nonisolated(unsafe) static var _sdpaPrefillMmaPipeline: MTLComputePipelineState?
+    /// WS-A #137 — flash-style MMA attention-prefill kernel (notes/20). ADDITIVE,
+    /// wired only behind QWISP_ATTN_MMA_PREFILL (default OFF).
+    ///
+    /// Semantics identical to `sdpaRows`: q[M*H, D] (row m*H+h), k/v shared cache
+    /// [KV, totalSeq-or-more, D] (strides passed explicitly), out[M*H, D] half;
+    /// per-row causal prefix N = baseLen + m; gqa_factor = H/KV; D = 256 fixed;
+    /// fp32 accumulation. Fixed tile geometry always: one threadgroup =
+    /// (kv_head, tile of TQ=8 query rows) with NSG=8 simdgroups, one per q-head
+    /// of that kv_head (grid = KV × ceil(M/TQ), 256 threads/tg). Each KV tile
+    /// (TK=16 positions) is staged ONCE into threadgroup memory and consumed by
+    /// all 8 q-heads × 8 rows — 64-way K/V reuse, which is what pulls the 47K
+    /// DRAM re-read floor under the notes/20 GO budget. Per-head fp32 output
+    /// accumulators live in REGISTERS (32 simdgroup_float8x8 fragments per
+    /// simdgroup), not threadgroup memory: with a >16KB TG footprint only one
+    /// threadgroup fits per core, so 8 resident simdgroups (not 1) are also what
+    /// give the core any latency hiding at all (round-2 lesson: the 1-simdgroup
+    /// variant was 4x SLOWER than round 1 from serialized TG-memory chains).
+    /// Bit-exactness to sdpa_rows is NOT required (hardware matrix-unit rounding
+    /// differs) — required instead: determinism, chunk-composition invariance,
+    /// causal/pad zero-influence, numeric sanity (locked tests 93–96, notes/20).
+    ///
+    /// Both QK^T and PV are simdgroup_float8x8 MMA chains (fp32 accumulate) —
+    /// the per-lane (row,col) coordinate mapping is the one used by MLX's own
+    /// steel/gemm kernels (mlx-swift Cmlx/mlx-generated/metal/steel/gemm/mma.h —
+    /// BaseMMAFrag::get_coord), reused verbatim for A/B/C alike since it must
+    /// match the hardware's actual simdgroup_matrix element layout.
+    /// gqa_factor > NSG is unsupported (model is fixed at 8); gqa_factor < NSG
+    /// (e.g. the H=1 pipeline warm-up) leaves the surplus simdgroups computing a
+    /// clamped duplicate head that is never stored, so barriers stay uniform.
+    ///
+    /// Round-2 perf status (isolated single-layer probe, M=1024 @ baseN=47104,
+    /// GPU-time only): this kernel ~1.7s vs sdpa_rows ~0.8s probe / ~1.77s in the
+    /// 10-layer decay bench (where sdpa_rows is DRAM-crushed and this kernel is
+    /// compute-bound ⇒ decay-flat). A pure-MMA control in the identical grid hits
+    /// 10.1 TFLOPS, so the gap is per-fragment operand handling (~6 loads + 6
+    /// element writes per 2 MMAs), not MMA rate, occupancy, banks, or barriers —
+    /// measured: bank-padding, K-transpose+half2 loads, q-hoist, and 4-way split
+    /// accumulators were all neutral-to-negative. Closing it needs steel-style
+    /// register blocking (RB×CB≥4 operand reuse), which conflicts with the
+    /// register-resident O at D=256 unless output columns are sliced per-simdgroup.
+    public static func sdpaPrefillMma(_ q: MLXArray, _ k: MLXArray, _ v: MLXArray,
+                                       H: Int, KV: Int, D: Int,
+                                       baseLen: Int, M: Int, scale: Float) -> MLXArray? {
+        guard let (device, queue) = ensure() else { return nil }
+        guard D == 256 else { print("[raw-sdpa-prefill-mma] D!=256 未対応 D=\(D)"); return nil }
+        let totalSeq = baseLen + M - 1
+        if _sdpaPrefillMmaPipeline == nil {
+            let src = """
+            #include <metal_stdlib>
+            #include <metal_simdgroup_matrix>
+            using namespace metal;
+            kernel void sdpa_prefill_mma(
+                device const half* queries   [[buffer(0)]],   // [rows, D], row = m*H+h (m local to this call)
+                device const half* keys      [[buffer(1)]],   // [KV, *, D]
+                device const half* values    [[buffer(2)]],   // [KV, *, D]
+                device half* out             [[buffer(3)]],   // [M*H, D]
+                constant int& gqa_factor     [[buffer(4)]],
+                constant int& baseN          [[buffer(5)]],    // N for local row 0
+                constant int& k_head_stride  [[buffer(6)]],
+                constant int& k_seq_stride   [[buffer(7)]],
+                constant int& v_head_stride  [[buffer(8)]],
+                constant int& v_seq_stride   [[buffer(9)]],
+                constant float& scale        [[buffer(10)]],
+                constant int& M              [[buffer(11)]],
+                constant int& totalSeqUnused [[buffer(12)]],
+                constant int& H              [[buffer(13)]],
+                uint3 tgid  [[threadgroup_position_in_grid]],
+                ushort sgid [[simdgroup_index_in_threadgroup]],
+                ushort simd_lid [[thread_index_in_simdgroup]])
+            {
+                constexpr int TQ = 8, TK = 16, D = 256;   // rows/sg, KV positions/tile
+                constexpr int NSG = 8;       // simdgroups per tg = q-heads served per kv_head
+                constexpr int CB = TK / 8;   // 2 KV-position fragments (QK^T cols / PV contraction)
+                constexpr int KF = D / 8;    // 32 contraction fragments (QK^T, over d)
+                constexpr int DB = D / 8;    // 32 output-column fragments (PV, over d)
+
+                const int kv_head = (int)tgid.x;
+                const int qt = (int)tgid.y;
+                const int qTileStart = qt * TQ;   // local row offset (0-based within this call)
+                const int sg = (int)sgid;
+                // Simdgroup sg serves q-head kv_head*gqa + sg. When gqa_factor < NSG
+                // (H=1 warm-up), surplus simdgroups compute a clamped duplicate head and
+                // never store — keeps every threadgroup_barrier uniformly executed.
+                const bool active = sg < gqa_factor;
+                const int h = kv_head * gqa_factor + min(sg, gqa_factor - 1);
+
+                // Shared staged K/V (~9K+8K) + per-simdgroup score slices (~4.5K) +
+                // row state (<1K) ≈ 22.7KB. Output accumulators are per-lane REGISTERS.
+                // Row strides are PADDED off the 128B threadgroup-bank period (an
+                // unpadded D*2=512B / TK*4=64B stride would alias every fragment-lane
+                // of a load onto the same banks; padding measured perf-neutral in the
+                // isolated probe but costs ~700B — kept as cheap insurance).
+                constexpr int KSTRIDE = D + 8;    // half elements per staged V row (pos-major)
+                constexpr int TKS = TK + 2;       // half elements per transposed-K row (d-major)
+                constexpr int SSTRIDE = TK + 2;   // float elements per sBuf row
+                threadgroup half kStage[D * TKS];        // current KV-tile's K, TRANSPOSED [d][pos]
+                threadgroup half vStage[TK * KSTRIDE];   // current KV-tile's V [pos][d]
+                threadgroup float sBufAll[NSG * TQ * SSTRIDE];   // per-sg: scores → weights
+                threadgroup float rowMaxAll[NSG * TQ];
+                threadgroup float rowSumAll[NSG * TQ];
+                threadgroup float rowScaleAll[NSG * TQ];    // per-tile rescale factor
+
+                threadgroup float* sBuf = sBufAll + sg * TQ * SSTRIDE;
+                threadgroup float* rowMax = rowMaxAll + sg * TQ;
+                threadgroup float* rowSum = rowSumAll + sg * TQ;
+                threadgroup float* rowScale = rowScaleAll + sg * TQ;
+                for (int i = (int)simd_lid; i < TQ; i += 32) {
+                    rowMax[i] = -INFINITY; rowSum[i] = 0.0f; rowScale[i] = 1.0f;
+                }
+                simdgroup_barrier(mem_flags::mem_threadgroup);
+
+                // Per-lane (row,col) coordinate within an 8x8 simdgroup_matrix tile.
+                // Matches mlx-swift steel/gemm/mma.h BaseMMAFrag::get_coord exactly
+                // (must match the hardware's simdgroup_matrix element layout). This same
+                // (fm,fn) mapping is reused verbatim for the PV chain below — the fixed
+                // per-lane hardware layout is identical regardless of the fragment's role
+                // (A/B/C), only the logical (row,col) meaning of that role changes.
+                const short qid = (short)(simd_lid / 4);
+                const short fm = (short)((qid & 4) + ((simd_lid / 2) % 4));       // row within tile, 0..7
+                const short fn = (short)((qid & 2) * 2 + (simd_lid % 2) * 2);     // col-pair start, 0/2/4/6
+
+                // Per-head fp32 output accumulator, in registers: this lane owns
+                // elements (fm, db*8+fn) and (fm, db*8+fn+1) of the TQ×D output.
+                simdgroup_float8x8 oFrag[DB];
+                #pragma unroll
+                for (int db = 0; db < DB; db++) {
+                    oFrag[db].thread_elements()[0] = 0.0f;
+                    oFrag[db].thread_elements()[1] = 0.0f;
+                }
+
+                // Clamped read row for this lane's fragment row: handles a partial last
+                // Q-tile and caller padding uniformly (padding rows are never written to
+                // `out`, so what they read is content-irrelevant, never OOB).
+                // q is deliberately NOT hoisted into registers: the per-tile device q
+                // reads hit L1 (same 4KB/simdgroup every tile) and a 64-float register
+                // hoist measured ~15% SLOWER in the isolated probe (register pressure).
+                const int localRowQ = min(qTileStart + (int)fm, M - 1);
+                const int qElemBase = (localRowQ * H + h) * D;
+
+                const int lastLocalRow = min(qTileStart + TQ - 1, M - 1);
+                const int nMax = baseN + lastLocalRow;
+                const int flatTid = sg * 32 + (int)simd_lid;
+
+                int kvStart = 0;
+                while (kvStart < nMax) {
+                    const int kvCount = min(TK, nMax - kvStart);
+
+                    // ---- stage this KV-tile's K/V once (coalesced, all 256 threads);
+                    //      consumed by all NSG q-heads × TQ rows ----
+                    for (int i = flatTid; i < TK * D; i += 32 * NSG) {
+                        const int pos = i / D, d = i - pos * D;
+                        const int gpos = kvStart + pos;
+                        const bool valid = pos < kvCount;
+                        kStage[d * TKS + pos] = valid ? keys[kv_head * k_head_stride + gpos * k_seq_stride + d] : (half)0;
+                        vStage[pos * KSTRIDE + d] = valid ? values[kv_head * v_head_stride + gpos * v_seq_stride + d] : (half)0;
+                    }
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                    // ---- QK^T via simdgroup MMA, fp32 accumulate (K from stage) ----
+                    {
+                        simdgroup_float8x8 acc0, acc1;
+                        acc0.thread_elements()[0] = 0.0f; acc0.thread_elements()[1] = 0.0f;
+                        acc1.thread_elements()[0] = 0.0f; acc1.thread_elements()[1] = 0.0f;
+                        #pragma unroll
+                        for (int kf = 0; kf < KF; kf++) {
+                            device const half* qp = queries + qElemBase + kf * 8;
+                            simdgroup_float8x8 A;
+                            A.thread_elements()[0] = (float)qp[fn];
+                            A.thread_elements()[1] = (float)qp[fn + 1];
+
+                            // B[d, pos]: contraction row = d, col = pos. Transposed
+                            // staging makes each lane's element pair CONTIGUOUS → one
+                            // half2 vector load per fragment instead of two scalars.
+                            const int dRow = (kf * 8 + (int)fm) * TKS;
+                            const half2 b0 = *(threadgroup const half2*)(kStage + dRow + fn);
+                            const half2 b1 = *(threadgroup const half2*)(kStage + dRow + 8 + fn);
+                            simdgroup_float8x8 B0;
+                            B0.thread_elements()[0] = (float)b0.x;
+                            B0.thread_elements()[1] = (float)b0.y;
+                            simdgroup_multiply_accumulate(acc0, A, B0, acc0);
+
+                            simdgroup_float8x8 B1;
+                            B1.thread_elements()[0] = (float)b1.x;
+                            B1.thread_elements()[1] = (float)b1.y;
+                            simdgroup_multiply_accumulate(acc1, A, B1, acc1);
+                        }
+                        sBuf[(int)fm * SSTRIDE + fn]     = acc0.thread_elements()[0];
+                        sBuf[(int)fm * SSTRIDE + fn + 1] = acc0.thread_elements()[1];
+                        sBuf[(int)fm * SSTRIDE + 8 + fn]     = acc1.thread_elements()[0];
+                        sBuf[(int)fm * SSTRIDE + 8 + fn + 1] = acc1.thread_elements()[1];
+                    }
+                    simdgroup_barrier(mem_flags::mem_threadgroup);   // sBuf is sg-private
+
+                    // ---- scale + causal mask + online softmax update (per real row) ----
+                    for (int r = (int)simd_lid; r < TQ; r += 32) {
+                        const int localRow = qTileStart + r;
+                        if (localRow >= M) continue;   // pad row: never written, never re-read
+                        const int N_m = baseN + localRow;
+                        const float curMax = rowMax[r];
+                        float newMax = curMax;
+                        for (int c = 0; c < kvCount; c++) {
+                            const int gpos = kvStart + c;
+                            const float s = (gpos < N_m) ? sBuf[r * SSTRIDE + c] * scale : -INFINITY;
+                            sBuf[r * SSTRIDE + c] = s;
+                            newMax = max(newMax, s);
+                        }
+                        const float factor = (curMax <= -INFINITY) ? 0.0f : fast::exp(curMax - newMax);
+                        float newSum = rowSum[r] * factor;
+                        for (int c = 0; c < kvCount; c++) {
+                            const float sv = sBuf[r * SSTRIDE + c];
+                            const float e = (sv <= -INFINITY) ? 0.0f : fast::exp(sv - newMax);
+                            sBuf[r * SSTRIDE + c] = e;   // now holds this tile's un-normalised weight
+                            newSum += e;
+                        }
+                        // Positions beyond kvCount (partial last tile) must carry ZERO
+                        // weight into the PV MMA below, which runs the full fixed TK-wide
+                        // fragments unconditionally (no per-column bound check inside the
+                        // tensor op — it lives here instead). vStage tail is also zeroed,
+                        // so masked/pad columns contribute exact ±0 products = zero bit
+                        // influence on any accumulator that is not itself -0 (oFrag
+                        // starts +0 and stays {+0}∪nonzero: x+±0=x, and an all-zero MMA
+                        // sum with a +0 accumulator is +0 in round-to-nearest).
+                        for (int c = kvCount; c < TK; c++) sBuf[r * SSTRIDE + c] = 0.0f;
+                        rowMax[r] = newMax;
+                        rowSum[r] = newSum;
+                        rowScale[r] = factor;
+                    }
+                    simdgroup_barrier(mem_flags::mem_threadgroup);
+
+                    // ---- rescale register accumulator (this lane's row is fm) ----
+                    {
+                        const float f = rowScale[(int)fm];
+                        #pragma unroll
+                        for (int db = 0; db < DB; db++) {
+                            oFrag[db].thread_elements()[0] *= f;
+                            oFrag[db].thread_elements()[1] *= f;
+                        }
+                    }
+
+                    // ---- PV via simdgroup MMA into register accumulators ----
+                    // Fixed order: ascending KV-tile (outer while), then cb=0, cb=1
+                    // inside each accumulator — fully determined by loop structure,
+                    // independent of timing. Pad q rows' sBuf holds raw (finite)
+                    // scores; they only touch pad rows' lanes (row independence of
+                    // MMA), which are never stored.
+                    {
+                        simdgroup_float8x8 P0, P1;   // P[row, pos]
+                        const float2 p0 = *(threadgroup const float2*)(sBuf + (int)fm * SSTRIDE + fn);
+                        const float2 p1 = *(threadgroup const float2*)(sBuf + (int)fm * SSTRIDE + 8 + fn);
+                        P0.thread_elements()[0] = p0.x; P0.thread_elements()[1] = p0.y;
+                        P1.thread_elements()[0] = p1.x; P1.thread_elements()[1] = p1.y;
+                        #pragma unroll
+                        for (int db = 0; db < DB; db++) {
+                            const int outCol = db * 8 + (int)fn;
+                            const half2 v0 = *(threadgroup const half2*)(vStage + (int)fm * KSTRIDE + outCol);
+                            const half2 v1 = *(threadgroup const half2*)(vStage + (8 + (int)fm) * KSTRIDE + outCol);
+                            simdgroup_float8x8 V0;   // V[pos, d]: row = pos, col = d
+                            V0.thread_elements()[0] = (float)v0.x;
+                            V0.thread_elements()[1] = (float)v0.y;
+                            simdgroup_multiply_accumulate(oFrag[db], P0, V0, oFrag[db]);
+
+                            simdgroup_float8x8 V1;
+                            V1.thread_elements()[0] = (float)v1.x;
+                            V1.thread_elements()[1] = (float)v1.y;
+                            simdgroup_multiply_accumulate(oFrag[db], P1, V1, oFrag[db]);
+                        }
+                    }
+                    threadgroup_barrier(mem_flags::mem_threadgroup);   // kStage/vStage reused next tile
+
+                    kvStart += TK;
+                }
+
+                // ---- normalise + write (this lane owns row fm, cols db*8+fn/+1) ----
+                const int outRow = qTileStart + (int)fm;
+                if (active && outRow < M) {
+                    const float sum = rowSum[(int)fm];
+                    const float inv = sum > 0.0f ? 1.0f / sum : 0.0f;
+                    device half* op = out + (outRow * H + h) * D;
+                    #pragma unroll
+                    for (int db = 0; db < DB; db++) {
+                        op[db * 8 + fn]     = (half)(oFrag[db].thread_elements()[0] * inv);
+                        op[db * 8 + fn + 1] = (half)(oFrag[db].thread_elements()[1] * inv);
+                    }
+                }
+            }
+            """
+            do { let lib = try device.makeLibrary(source: src, options: mlxMatchCompileOpts())
+                 // Descriptor form: force the compiler to fit 256 threads/tg (8 simdgroups)
+                 // even under the register pressure of the 32 per-lane oFrag accumulators.
+                 let desc = MTLComputePipelineDescriptor()
+                 desc.computeFunction = lib.makeFunction(name: "sdpa_prefill_mma")!
+                 desc.maxTotalThreadsPerThreadgroup = 256
+                 _sdpaPrefillMmaPipeline = try device.makeComputePipelineState(descriptor: desc, options: [], reflection: nil)
+            } catch { print("[raw-sdpa-prefill-mma] compile: \(error)"); return nil }
+        }
+        guard let bq = mtlBuf(q.asType(.float16), device),
+              let bk = mtlBuf(k.asType(.float16), device),
+              let bv = mtlBuf(v.asType(.float16), device) else { return nil }
+        let outBuf = device.makeBuffer(length: M * H * D * 2, options: .storageModeShared)!
+        let cb = queue.makeCommandBuffer()!; let enc = cb.makeComputeCommandEncoder()!
+        enc.setComputePipelineState(_sdpaPrefillMmaPipeline!)
+        enc.setBuffer(bq, offset: 0, index: 0); enc.setBuffer(bk, offset: 0, index: 1)
+        enc.setBuffer(bv, offset: 0, index: 2); enc.setBuffer(outBuf, offset: 0, index: 3)
+        var gqa = Int32(H / KV), bn = Int32(baseLen)
+        var khs = Int32(totalSeq * D), kss = Int32(D), vhs = Int32(totalSeq * D), vss = Int32(D), sc = scale
+        var mRows = Int32(M), tSeq = Int32(totalSeq), hh = Int32(H)
+        enc.setBytes(&gqa, length: 4, index: 4); enc.setBytes(&bn, length: 4, index: 5)
+        enc.setBytes(&khs, length: 4, index: 6); enc.setBytes(&kss, length: 4, index: 7)
+        enc.setBytes(&vhs, length: 4, index: 8); enc.setBytes(&vss, length: 4, index: 9)
+        enc.setBytes(&sc, length: 4, index: 10)
+        enc.setBytes(&mRows, length: 4, index: 11); enc.setBytes(&tSeq, length: 4, index: 12)
+        enc.setBytes(&hh, length: 4, index: 13)
+        // Grid: one threadgroup per (kv_head, 8-row q-tile); 8 simdgroups serve the
+        // kv_head's q-heads (kernel-side clamp handles gqa_factor < 8).
+        let numQTiles = max((M + 7) / 8, 1)
+        enc.dispatchThreadgroups(MTLSize(width: KV, height: numQTiles, depth: 1),
+                                 threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
+        enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+        let ptr = outBuf.contents().bindMemory(to: Float16.self, capacity: M * H * D)
+        return MLXArray(Array(UnsafeBufferPointer(start: ptr, count: M * H * D)), [M * H, D])
+    }
+
     /// D1-4: M-row conv1d+silu. windows[M,K,C] → y[M,C].
     /// New Metal kernel: 2D dispatch (width=C, height=M); row m applies
     /// the K-frame window windows[m*K*C .. (m+1)*K*C]. Bit-exact to M conv1dSilu calls.

--- a/swift/Sources/QwispCore/SeedlessVerifyTests.swift
+++ b/swift/Sources/QwispCore/SeedlessVerifyTests.swift
@@ -49,7 +49,7 @@ public enum SeedlessVerifyTests {
         MLXRandom.seed(UInt64(42))
         var lines: [String] = []
         var passed = 0
-        let total = 92
+        let total = 96
 
         // Nested runner: records result and increments counter
         func run(_ name: String, body: () -> (Bool, String)) {
@@ -5775,6 +5775,195 @@ public enum SeedlessVerifyTests {
                 tok = Int32(got[0])
             }
             return (true, "ok")
+        }
+
+        // ── WS-A #137: sdpa_prefill_mma locked tests (notes/20 §Locked tests) ──
+        // WRITE-LOCKED (guarded by total = 96). Do not weaken/skip/delete.
+        // The MMA attention-prefill kernel is ADDITIVE (behind QWISP_ATTN_MMA_PREFILL,
+        // default OFF). These four tests call sdpaPrefillMma directly (unit level,
+        // GPU, no model). Bit-exactness to sdpa_rows is NOT required; what is locked
+        // is determinism + chunk-composition invariance + causal/pad zero-influence +
+        // numeric sanity vs a float64 CPU reference. RED until the kernel is real.
+
+        // Shared config: H=16, KV=2, D=256 → gqa_factor=8 (matches the model's attn).
+        let mH = 16, mKV = 2, mD = 256
+        let mScale = Float(pow(Double(mD), -0.5))
+
+        // Test 93: mma_prefill_determinism — same inputs twice → bit-identical out.
+        // M=33, baseN=277: both deliberately non-multiples of the TQ=16/TK=32 tiles,
+        // so partial tiles are exercised and any tile-placement nondeterminism shows.
+        run("mma_prefill_determinism") {
+            let M = 33, baseN = 277
+            let totalSeq = baseN + M - 1
+            let q     = MLXRandom.normal([M * mH, mD]).asType(.float16)
+            let kFull = MLXRandom.normal([mKV, totalSeq, mD]).asType(.float16)
+            let vFull = MLXRandom.normal([mKV, totalSeq, mD]).asType(.float16)
+            MLX.eval([q, kFull, vFull])
+            guard let a = SeedlessMetalForward.sdpaPrefillMma(q, kFull, vFull,
+                          H: mH, KV: mKV, D: mD, baseLen: baseN, M: M, scale: mScale),
+                  let b = SeedlessMetalForward.sdpaPrefillMma(q, kFull, vFull,
+                          H: mH, KV: mKV, D: mD, baseLen: baseN, M: M, scale: mScale)
+            else { return (false, "not implemented") }
+            MLX.eval([a, b])
+            return bitEqual(a, b)
+        }
+
+        // Test 94: mma_prefill_composition_invariant — one M=33 call vs two split
+        // calls (M=16 at baseN, M=17 at baseN+16) → per-row bit-identical. Row m's
+        // bits must depend only on (q_m, KV prefix length N_m), never on M or on the
+        // chunk/tile the row lands in. K/V is the SAME buffer, sliced to each call's
+        // prefix (mirrors sdpa_rows_bitexact's KV slicing).
+        run("mma_prefill_composition_invariant") {
+            let baseN = 277
+            let M1 = 16, M2 = 17, M = M1 + M2          // 33
+            let totalSeq = baseN + M - 1                // 309
+            let q     = MLXRandom.normal([M * mH, mD]).asType(.float16)
+            let kFull = MLXRandom.normal([mKV, totalSeq, mD]).asType(.float16)
+            let vFull = MLXRandom.normal([mKV, totalSeq, mD]).asType(.float16)
+            MLX.eval([q, kFull, vFull])
+            // Whole: rows 0..32 in one call.
+            guard let whole = SeedlessMetalForward.sdpaPrefillMma(q, kFull, vFull,
+                          H: mH, KV: mKV, D: mD, baseLen: baseN, M: M, scale: mScale)
+            else { return (false, "not implemented (whole)") }
+            whole.eval()
+            // Split 1: rows 0..15, baseN=277, needs prefix up to 277+15=292.
+            let s1 = baseN + M1 - 1
+            let q1 = q[0 ..< M1 * mH]
+            let k1 = kFull[0..., 0 ..< s1]
+            let v1 = vFull[0..., 0 ..< s1]
+            MLX.eval([q1, k1, v1])
+            guard let p1 = SeedlessMetalForward.sdpaPrefillMma(q1, k1, v1,
+                          H: mH, KV: mKV, D: mD, baseLen: baseN, M: M1, scale: mScale)
+            else { return (false, "not implemented (split1)") }
+            // Split 2: rows 16..32, baseN=277+16=293, needs prefix up to 293+16=309.
+            let q2 = q[M1 * mH ..< M * mH]
+            guard let p2 = SeedlessMetalForward.sdpaPrefillMma(q2, kFull, vFull,
+                          H: mH, KV: mKV, D: mD, baseLen: baseN + M1, M: M2, scale: mScale)
+            else { return (false, "not implemented (split2)") }
+            let split = MLX.concatenated([p1, p2], axis: 0); split.eval()   // [M*H, D]
+            return bitEqual(split, whole)
+        }
+
+        // Test 95: mma_prefill_causal_and_pad — causal-masked positions and padding
+        // rows have ZERO bit influence.
+        // (a) mutate k/v at positions ≥ N_0 (= baseN) → row 0 bits unchanged (row 0
+        //     attends only [0, baseN); the mutated tail is fully masked for it).
+        // (b) append NaN/garbage q rows past M (a full extra TQ tile) with M unchanged
+        //     → the M real rows are unchanged (pad content is irrelevant).
+        run("mma_prefill_causal_and_pad") {
+            let M = 33, baseN = 277
+            let totalSeq = baseN + M - 1               // 309
+            let q     = MLXRandom.normal([M * mH, mD]).asType(.float16)
+            let kFull = MLXRandom.normal([mKV, totalSeq, mD]).asType(.float16)
+            let vFull = MLXRandom.normal([mKV, totalSeq, mD]).asType(.float16)
+            MLX.eval([q, kFull, vFull])
+            guard let base = SeedlessMetalForward.sdpaPrefillMma(q, kFull, vFull,
+                          H: mH, KV: mKV, D: mD, baseLen: baseN, M: M, scale: mScale)
+            else { return (false, "not implemented (base)") }
+            base.eval()
+            let row0Base = base[0 ..< mH]; row0Base.eval()   // [H, D]
+
+            // (a) Overwrite the causal tail [baseN, totalSeq) of k/v with fresh noise.
+            let tailLen = totalSeq - baseN            // 32 = M-1
+            let kTail = MLXRandom.normal([mKV, tailLen, mD]).asType(.float16)
+            let vTail = MLXRandom.normal([mKV, tailLen, mD]).asType(.float16)
+            let kMut = MLX.concatenated([kFull[0..., 0 ..< baseN], kTail], axis: 1)
+            let vMut = MLX.concatenated([vFull[0..., 0 ..< baseN], vTail], axis: 1)
+            MLX.eval([kMut, vMut])
+            guard let mut = SeedlessMetalForward.sdpaPrefillMma(q, kMut, vMut,
+                          H: mH, KV: mKV, D: mD, baseLen: baseN, M: M, scale: mScale)
+            else { return (false, "not implemented (mut)") }
+            mut.eval()
+            let row0Mut = mut[0 ..< mH]; row0Mut.eval()
+            let (okA, dA) = bitEqual(row0Mut, row0Base)
+            if !okA { return (false, "causal(a) row0 changed: \(dA)") }
+
+            // (b) Pad q with a full extra TQ=16 tile of NaN rows; keep M=33.
+            let padRows = 16
+            let nanPad = MLXArray(Array(repeating: Float.nan, count: padRows * mH * mD),
+                                  [padRows * mH, mD]).asType(.float16)
+            let qPadded = MLX.concatenated([q, nanPad], axis: 0); qPadded.eval()  // [(M+16)*H, D]
+            guard let padded = SeedlessMetalForward.sdpaPrefillMma(qPadded, kFull, vFull,
+                          H: mH, KV: mKV, D: mD, baseLen: baseN, M: M, scale: mScale)
+            else { return (false, "not implemented (pad)") }
+            padded.eval()
+            let (okB, dB) = bitEqual(padded, base)   // both [M*H, D]
+            if !okB { return (false, "pad(b) real rows changed: \(dB)") }
+            return (true, "ok")
+        }
+
+        // Test 96: mma_prefill_reference_sanity — vs float64 CPU reference.
+        // M=8, baseN=300 → N ≤ 307 ≤ 512. Two guards: (1) max|Δ| ≤ 2e-2 on the half
+        // outputs; (2) argmax over a fixed random [D→P] projection agrees on ≥99% of
+        // the M*H rows (catches sign / off-by-one / head-mixup bugs tolerance misses).
+        run("mma_prefill_reference_sanity") {
+            let M = 8, baseN = 300
+            let totalSeq = baseN + M - 1              // 307 (≤512)
+            let gqa = mH / mKV
+            let q     = MLXRandom.normal([M * mH, mD]).asType(.float16)
+            let kFull = MLXRandom.normal([mKV, totalSeq, mD]).asType(.float16)
+            let vFull = MLXRandom.normal([mKV, totalSeq, mD]).asType(.float16)
+            MLX.eval([q, kFull, vFull])
+            guard let got = SeedlessMetalForward.sdpaPrefillMma(q, kFull, vFull,
+                          H: mH, KV: mKV, D: mD, baseLen: baseN, M: M, scale: mScale)
+            else { return (false, "not implemented") }
+            got.eval()
+
+            // float64 CPU reference (read as Float32, accumulate in Double).
+            let qA = q.asType(.float32).asArray(Float.self)
+            let kA = kFull.asType(.float32).asArray(Float.self)   // [KV, totalSeq, D]
+            let vA = vFull.asType(.float32).asArray(Float.self)
+            let sc = Double(mScale)
+            var ref = [Float](repeating: 0, count: M * mH * mD)
+            for m in 0 ..< M {
+                let N = baseN + m
+                for h in 0 ..< mH {
+                    let kvh = h / gqa
+                    let qBase = (m * mH + h) * mD
+                    // scores over j in [0, N); online-free two-pass softmax in Double.
+                    var scores = [Double](repeating: 0, count: N)
+                    var maxS = -Double.infinity
+                    for j in 0 ..< N {
+                        let kBase = (kvh * totalSeq + j) * mD
+                        var s = 0.0
+                        for d in 0 ..< mD { s += Double(qA[qBase + d]) * Double(kA[kBase + d]) }
+                        s *= sc
+                        scores[j] = s
+                        if s > maxS { maxS = s }
+                    }
+                    var sum = 0.0
+                    for j in 0 ..< N { let e = exp(scores[j] - maxS); scores[j] = e; sum += e }
+                    let inv = sum == 0 ? 0 : 1.0 / sum
+                    let oBase = (m * mH + h) * mD
+                    for d in 0 ..< mD {
+                        var acc = 0.0
+                        for j in 0 ..< N {
+                            let vBase = (kvh * totalSeq + j) * mD
+                            acc += scores[j] * Double(vA[vBase + d])
+                        }
+                        ref[oBase + d] = Float(acc * inv)
+                    }
+                }
+            }
+            // (1) max|Δ| on half outputs.
+            let gotA = got.asType(.float32).asArray(Float.self)
+            var maxAbs: Float = 0
+            for i in 0 ..< M * mH * mD { maxAbs = max(maxAbs, abs(gotA[i] - ref[i])) }
+            if maxAbs > 2e-2 { return (false, "max|Δ|=\(maxAbs) > 2e-2") }
+            // (2) argmax agreement over a fixed random [D→P] projection.
+            let P = 128
+            let proj = MLXRandom.normal([mD, P]).asType(.float32); proj.eval()
+            let refArr = MLXArray(ref, [M * mH, mD]).asType(.float32)
+            let gotArr = got.asType(.float32)
+            let refArg = MLX.argMax(MLX.matmul(refArr, proj), axis: 1)
+            let gotArg = MLX.argMax(MLX.matmul(gotArr, proj), axis: 1)
+            MLX.eval([refArg, gotArg])
+            let ra = refArg.asArray(Int32.self), ga = gotArg.asArray(Int32.self)
+            var agree = 0
+            for i in 0 ..< ra.count where ra[i] == ga[i] { agree += 1 }
+            let frac = Double(agree) / Double(ra.count)
+            if frac < 0.99 { return (false, "argmax agree \(agree)/\(ra.count) = \(frac) < 0.99") }
+            return (true, "ok maxΔ=\(maxAbs) agree=\(agree)/\(ra.count)")
         }
 
         // ── Summary ───────────────────────────────────────────────────────


### PR DESCRIPTION
## What this is

The complete WS-A phase-1 probe (issue #137), archived honestly. The MMA attention-prefill kernel is **NO-GO on M1-class hardware** — two independent same-session paired 24K decay A/Bs put it at **0.20-0.46x of sdpa_rows** at every position. Full mechanism + measurement doctrine in `notes/20` §VERDICT and the kernel doc header.

## Why merge anyway

- **Zero runtime cost**: additive, behind `QWISP_ATTN_MMA_PREFILL` (default OFF); flag-off paths byte-unchanged (5 removed lines total, all audited); decode/verify never touch it.
- **Correctness fully proven**: locked tests 93-96 (determinism / chunk-composition invariance / causal+pad zero-influence / f64 reference sanity), RAWTESTS 96/96.
- **Future-hardware door**: M5-class NAX may flip the verdict; this preserves the kernel + its safety net as the re-entry point instead of letting it rot on a branch.
- Also carries: paired A/B bench script (`scripts/bench_decay_ab.sh`), decay-bench flag wiring (M>1 only), notes/20 spec+verdict.

## Gates

RAWTESTS 96/96 · COMPTEST 79/79 · BENCHBATCHTEST PASS · locked-test lock-copy diff clean.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)