### PR TITLE
WS-B Stage B: ctx-adaptive lane admission + KV memory gate

### DIFF
--- a/notes/22-ws-b-stage-b-ctx-adaptive-spec.md
+++ b/notes/22-ws-b-stage-b-ctx-adaptive-spec.md
@@ -1,0 +1,268 @@
+# 22 — Spec: WS-B Stage B — ctx-adaptive lane admission (lift the 16K cap)
+
+Stage B of WS-B (roadmap settled with owner 2026-07-23; Stage A = token-budget
+scheduler, shipped default-ON in PR #140 / notes/21). Scheduling + allocation
+only: zero numeric/kernel changes, lane decode stays bit-exact.
+
+**Audience note**: this spec is written for a Sonnet implementation session.
+Every design ambiguity is resolved here (see "Resolved ambiguities — binding");
+do not re-open them. For engine-physics questions not covered here, consult
+Fable read-only (`/askfable`) rather than guessing.
+
+## Preconditions (check before starting)
+
+1. PR #140 merged (Stage A on main, `QWISP_TOKEN_BUDGET_SCHED` default ON). ✓ 2026-07-25.
+2. **PR #138 (WS-A archive) must be merged first.** On main RAWTESTS total=92
+   (SeedlessVerifyTests.swift:52); PR #138 adds locked tests 93–96. Stage B adds
+   locked test **97** — starting before #138 merges creates a numbering collision.
+   If #138 is closed unmerged instead (owner's call), renumber Stage B's test to 93.
+3. Baselines green on main: RAWTESTS 92/92 (96/96 post-#138), COMPTEST 83/83,
+   BENCHBATCHTEST PASS.
+
+## Why (measured)
+
+- The real workload (HANDOFF, OpenCode trial): explore subagents ingest ~35K
+  tok/turn; OpenCode sends full history every turn. `QWISP_LANE_CTX` default
+  16384 (LaneServe.swift:313-314) makes those prompts **silently unservable**
+  in lane mode: `generate()` computes `headroom = laneCtx - prompt.count - 1`
+  → ≤ 0 → ceiling 0 → the scheduler's `maxTokens > 0` guard finishes the
+  request with an **empty stream, no error** (LaneServe.swift:333-336 +
+  ContinuousBatch.swift `budgetedStep` pend-creation guard). This exact silent
+  no-op burned two false-started bench passes on 2026-07-25 (notes/21 "Failed
+  approaches" in issue #139) — it is a real trap, not a theoretical one.
+- The serialize path already fought and won this same battle (PR #135, the
+  64K cliff): unbounded arena sizing collapsed the box (observed 2026-07-22:
+  41GB footprint, prefill 138→41 tok/s), fixed by a bounded gen budget
+  (`QWISP_PREFIX_GEN_MAX` default 16384) + eligibility cap at model context.
+  Stage B mirrors that shipped, validated policy onto lanes.
+- Memory arithmetic (why per-request sizing is cheap): KV cost is ~20KB/token
+  (10 full-attn layers × KV=2 heads × D=256 × 2 bytes × K+V; the
+  LLMBackend.swift:152 comment's "10 full-attn layers ≈ 20KB/token" and the
+  alloc at SeedlessFusedVerify.swift:4825 agree). A 35K-token admit with a 16K
+  gen budget ≈ 1.0GB per lane — fine on the resident tier (≥32GB) lanes
+  require, IF bounded. Unbounded (model ctx 262K × B lanes) is the PR #135
+  collapse again — hence the aggregate gate below.
+
+## Verified load-bearing facts (do not re-derive; cite these)
+
+1. **Heterogeneous arena sizes across lanes are safe by construction.** Every
+   batched-step kernel takes `maxLen` from the LANE'S OWN cache object
+   (`lanes[b].layers[li].kvCache!` → `kv.maxLen`, SeedlessLaneBatch.swift
+   ~697-710), and `SeedlessLaneBatch.init` requires only `layers.count`
+   equality across lanes (SeedlessLaneBatch.swift:483-487) — no uniform
+   maxSeqLen assumption anywhere. Lanes with different arena sizes can ride
+   in one batch today.
+2. **Persist blobs are arena-size-independent.** `persistentStateData()` saves
+   only the USED slice (`kv.len` rows/head); `restorePersistentState()`
+   validates `KV`/`D` and `len <= kv.maxLen`, then writes at the DESTINATION's
+   stride (`base + h * kv.maxLen * kv.D * 2`) (SeedlessFusedVerify.swift:
+   3849-3921). A blob saved from a 16K-arena lane restores bit-correctly into
+   a 32K-arena lane. Oversized blob → `false` → existing cold-prefill fallback
+   at the LaneServe restore site. Nothing to change in the format.
+3. **The sizing policy already exists as a pure function.**
+   `SeedlessBackend.cachedGenBudget(promptLen:ceiling:arenaMax:genCap:)` =
+   `max(1, min(ceiling, min(genCap, arenaMax - promptLen)))`
+   (LLMBackend.swift:161-163, public static, self-checked). REUSE it — do not
+   reimplement.
+4. **Arena allocation is already per-admit.** `makeLane` calls
+   `engine.makeFused(maxM: 1024, maxSeqLen: maxSeqLen)` on every admission
+   (LaneServe.swift:169) — per-request sizing is a parameter change, not a
+   lifecycle change. Idle slots hold no arena.
+5. `readContextLen` (LLMBackend.swift:190) reads
+   `text_config.max_position_embeddings`, fallback 32768.
+
+## Contract — B1: ctx-adaptive admission
+
+### Sizing policy (LaneBackend.generate, LaneServe.swift:333-336)
+
+```
+ctxMax     = min(readContextLen(modelDir), QWISP_LANE_CTX if explicitly set)
+             // NEW default: model context. QWISP_LANE_CTX stays honored as an
+             // override; its old 16384 default is GONE (that was the cap).
+genCap     = max(1024, QWISP_LANE_GEN_MAX default 16384)
+             // NEW knob, mirrors QWISP_PREFIX_GEN_MAX; separate knob because
+             // lanes multiply the cost by B.
+headroom   = max(0, ctxMax - prompt.count - 1)
+ceiling    = maxTokens < 0 ? headroom : min(maxTokens, headroom)
+genBudget  = SeedlessBackend.cachedGenBudget(promptLen: prompt.count,
+                 ceiling: ceiling, arenaMax: ctxMax, genCap: genCap)   // reuse (fact 3)
+seqBudget  = prompt.count + 1 + genBudget      // the arena size this request needs
+```
+
+`generate()` submits with `maxTokens: genBudget` (was: ceiling). Env reads stay
+in `LaneBackend.init`/`generate` ONLY — never inside `ContinuousScheduler` or
+`LaneBatchSlots` (Stage A discipline; keeps COMPTEST deterministic).
+
+### Plumbing seqBudget to the arena (protocol change, Stage A's pattern)
+
+- `ContinuousScheduler.Request` already carries `maxTokens`; `budgetedStep`
+  computes `seqBudget = req.prompt.count + 1 + req.maxTokens` (pure arithmetic
+  on fields it has) and passes it to a new `admitStep` overload:
+  `admitStep(prompt:slot:tokenBudget:seqBudget:)`.
+- **`seqBudget = 0` is the legacy sentinel**: size the arena at the init-time
+  `maxSeqLen`, exactly today's behavior. The default protocol extension (which
+  keeps `ContinuousBatchEngine`/`BatchBackend` untouched — same trick as Stage
+  A) and `LaneBatchSlots.admit()`'s atomic wrapper both pass 0.
+- Consequence (deliberate, see Resolved #1): ctx-adaptive sizing is a feature
+  of the budgeted-scheduler path only. `QWISP_TOKEN_BUDGET_SCHED=0` keeps the
+  legacy fixed-cap path **bit-for-bit untouched** — the escape hatch stays a
+  true escape hatch. The frozen `loop()` tokenBudget==0 body is NOT edited.
+- `LaneBatchSlots.admitStep` first-call setup: `makeLane(hybrid:seqLen:)` where
+  `seqLen = seqBudget > 0 ? min(seqBudget, ctxMaxFromInit) : maxSeqLen`. The
+  guard at LaneServe.swift:185 becomes `prompt.count < seqLen`.
+
+### Aggregate memory gate (the PR #135 collapse guard)
+
+- `LaneBatchSlots` gains `func kvBytesPerToken() -> Int` computed once from
+  `engine.layers` (Σ over attn layers of `numKV × headDim × 2 × 2`) and tracks
+  `activeArenaBytes` = Σ over non-nil lanes/prefills of `seqLen × kvBytesPerToken()`.
+- New protocol member `func canAdmit(promptLen: Int, seqBudget: Int) -> Bool`
+  (default extension: `true` — MLX engines unaffected). LaneBatchSlots returns
+  whether `activeArenaBytes + candidate ≤ QWISP_LANE_KV_MB × 1MB` — budget knob
+  read in `LaneBackend.init` and passed into `LaneBatchSlots.init` as a plain
+  `Int` (env discipline), default `physicalMemory ≥ 48GB ? 8192 : 4096`.
+- Scheduler (budgeted path only): before creating a Pend for the queue head,
+  check `canAdmit`. If false, **stop admitting this round — do NOT skip ahead**
+  (FCFS head-of-line wait, vLLM semantics; preserves `tokenbudget_fifo_fairness`).
+  Memory frees when lanes release; the head retries every round.
+- Clamp-to-fit: if the candidate ALONE exceeds the whole budget, clamp its
+  `seqBudget` down to fit (floor: `prompt.count + 2` — at least 1 generated
+  token). If even the floor doesn't fit, fail the request (return `.failed` /
+  today's nil-admit path) and `FileHandle.standardError.write` ONE clear line —
+  never the silent empty stream.
+
+## Contract — B2: hardening carried from the Stage A Fable review
+
+Small, low-risk items recorded in PR #140 comments; fold them in here rather
+than leaving them as lore:
+
+1. `Prefill.lastNormed` gets a one-line comment: "must never be consumed across
+   a pause — the final chunk and its logits always execute in the same
+   admitStep call" (implicit invariant today, verified true; noCopy-lifetime
+   history says make it explicit).
+2. The #121 fan-out restore ordering under the budgeted scheduler is an
+   EMERGENT property of ceil-grant semantics (pendings serialize because any
+   `.prefilling` grant drives pool ≤ 0). Add a comment at the `budgetedStep`
+   grant site saying exactly that, so a future grant-policy change knows what
+   it silently breaks.
+3. The self-check `Fake`'s floor-grant semantics intentionally differ from the
+   real ceil-grant `LaneBatchSlots.admitStep`; comment both sides so nobody
+   "fixes" one to match the other.
+
+## Explicitly REJECTED for Stage B (do not implement; reasons are terminal)
+
+- **Live warm-lane reuse** (keep released lanes' state alive; adopt on prefix
+  match): L1-incompatible. The lane's end-of-decode KV rows for generated
+  tokens are produced by the M=1 decode kernels, NOT by the canonical hybrid
+  chunked prefill — restoring/continuing from them diverges from the canonical
+  greedy stream (same physics as the makeLane comment: "raw chunked prefill
+  produces the pre-hybrid stream and diverges ~100 tokens in"). Rewinding to
+  the prompt boundary is impossible: GDN state is a recurrence, it cannot be
+  truncated. #121's blob-at-prompt-boundary design (pure-prefill-produced
+  state, exact-boundary replay-gated) is the correct and only L1-safe shape.
+- **Warmth-based admission reordering** (admit best-prefix-match pendings
+  first): breaks FCFS (`tokenbudget_fifo_fairness` is locked), diverges from
+  vLLM's default, and the aggregate win is speculative. Not without a
+  measurement first, and not this stage.
+- **PrefixPersist (disk) tier for lanes**: real value (lane warmth across
+  restarts) but scope-coupled to the owner's pending "PrefixPersist
+  default-ON" decision — explicitly backlog (HANDOFF "Then" §4), not Stage B.
+
+## Locked tests
+
+### RAWTESTS (SeedlessVerifyTests.swift; total bumps 96 → 97 post-#138)
+
+97. `lane_admit_restore_cross_arena_bitexact`: save `persistentStateData` from
+    a lane forward built with `maxSeqLen = S1`, restore into a fresh lane
+    forward built with `maxSeqLen = S2 > S1`, decode N steps on each (same
+    tokens, same synthetic weights as the test-90/91/92 lane family), assert
+    bit-identical output streams AND that restore into `S3 < len` correctly
+    returns false (cold-fallback path). Pattern/harness: extend the test-92
+    (`lane_admit_restore_bitexact`) fixture, ADD a new test — never modify 92.
+
+### COMPTEST (pure logic, no GPU/model; wire after the `tokenbudget_*` block, Selftest.swift:142)
+
+`lanesize_*` — pure-function checks on the sizing chain (extract the sizing
+into a testable static, e.g. `LaneBackend.sizePlan(promptLen:maxTokens:ctxMax:genCap:) -> (genBudget: Int, seqBudget: Int)`):
+- `lanesize_unset_maxtokens`: maxTokens=-1, prompt 35_000, ctxMax 262_144,
+  genCap 16_384 → genBudget 16_384, seqBudget 51_385.
+- `lanesize_explicit_capped`: maxTokens 100_000, prompt 1_000, ctxMax 32_768 →
+  genBudget ≤ min(16_384, 31_767); assert exact value via cachedGenBudget.
+- `lanesize_prompt_too_big`: prompt ≥ ctxMax → genBudget floor behavior
+  (headroom 0 → the request must NOT silently succeed; assert the plan flags it).
+- `lanesize_legacy_sentinel`: seqBudget 0 → init maxSeqLen used (document via
+  the LaneBatchSlots seam, or assert in the scheduler fake below).
+
+`lanemem_*` — scheduler gate via the Stage A `Fake` extended with
+`canAdmit`/per-slot seqBudget recording:
+- `lanemem_head_of_line_wait`: head request too big for the fake budget while
+  a smaller one queues behind → NEITHER admits this round (FCFS preserved);
+  head admits after a release frees budget.
+- `lanemem_seqbudget_passthrough`: the fake records
+  `seqBudget == prompt.count + 1 + maxTokens` for a budgeted-path admit.
+- `lanemem_atomic_legacy`: the tokenBudget==0 path never passes a non-zero
+  seqBudget (legacy sentinel honored).
+
+All existing `tokenbudget_*` cases stay byte-untouched and green.
+
+## Bench verification (driver/owner runs after GREEN; GPU-exclusive, paired same-session per notes/20 doctrine)
+
+1. **The motivating E2E**: `QWISP_LANES=2`, default env, a ~35K-token prompt
+   (reuse `tools/lane_budget_probe.mjs`'s filler generator — mind its
+   sentence-repeat units bugfix, notes/21) → must ADMIT and stream a correct
+   completion (today: silent empty). Record TTFT. PASS = completes.
+2. **No-regression paired A/B**: same session, same binary, short-prompt
+   workload (well under 16K so sizing is immaterial):
+   `QWISP_TOKEN_BUDGET_SCHED=0` (legacy arena) vs `=1` (adaptive) at B=1..4 —
+   per-stream tok/s Δ within noise (±5%). Isolates sizing overhead.
+3. **Footprint gate**: during 2 concurrent 35K admits, `footprint <pid>`
+   (NOT `ps rss` — HANDOFF gotcha) stays within QWISP_LANE_KV_MB + model
+   residency + ~200MB×B scratch expectation. No swap storm.
+
+## Resolved ambiguities (binding — do not re-litigate in-session)
+
+1. **Adaptive sizing is budgeted-path-only.** The `QWISP_TOKEN_BUDGET_SCHED=0`
+   opt-out keeps the ENTIRE legacy behavior including the fixed 16K cap. Reason:
+   Stage A froze `loop()`'s tokenBudget==0 body byte-for-byte as the escape
+   hatch; threading seqBudget through it would void that guarantee. The default
+   is ON, so real users get the lift.
+2. **`QWISP_LANE_CTX` semantics change**: from "cap AND arena size, default
+   16384" to "eligibility cap override, default = model context". This is
+   deliberate (the 16K default IS the bug). Update the main.swift help text
+   (~L43-46) accordingly.
+3. **Memory gate is FCFS with head-of-line wait**, not skip-ahead. Matches
+   vLLM, preserves the locked fairness test. Head-of-line blocking on a huge
+   request is accepted behavior, not a bug to fix this stage.
+4. **`cachedGenBudget` is reused as-is** (rung 2 of the ladder). If its
+   semantics need to differ for lanes, that is a spec change — stop and ask.
+5. **seqBudget flows scheduler→admitStep as a parameter**; the arena-size
+   decision lives in LaneBatchSlots (it owns the engine facts), the POLICY
+   (genCap/ctxMax) lives in LaneBackend (it owns the env). Nothing reads env
+   in between.
+6. **The silent-empty-stream path must die** for oversized prompts: fail
+   visibly (one stderr line + failed stream), never an empty 200.
+
+## Prohibitions (Stage B)
+
+- Frozen forward path (CLAUDE.md #3) — untouched; this is allocation/scheduling.
+- Do not modify: `ContinuousBatchEngine` / `BatchBackend`, chunk sizes
+  (1024/64), `LaneAdmitPlan`/`admitPlan`/`admitSelfCheck` semantics, the
+  `loop()` tokenBudget==0 body, any existing locked test (RAWTESTS 90-96,
+  `tokenbudget_*`, `laneadmit_*`).
+- No cloud offload of anything (memory `qwisp-no-cloud-principle`).
+- No default flips beyond the specified `QWISP_LANE_CTX` semantic change.
+- Commit convention: `feat(seedless):` / `test(bench):`, Co-Authored-By
+  trailer, push after every commit, branch `claude/lane-ctx-adaptive`.
+
+## Suggested session shape (mirrors Stage A's, which converged in 1 round)
+
+1. Recon (Opus or careful Sonnet read): verify facts 1-4 above against HEAD
+   line numbers (they WILL have drifted post-#138 merge); confirm
+   `SeedlessLaneBatch` has no other uniform-maxLen assumption
+   (`grep -n maxSeqLen swift/Sources/QwispCore/SeedlessLaneBatch.swift`).
+2. devloop loop phase: locked tests RED (RAWTESTS 97 + the COMPTEST cases
+   above) → implement → adversarial review. Gates green at every commit.
+3. Driver runs the bench section, records results in an addendum to THIS file
+   (same shape as notes/21's "Bench verification results"), then owner decides
+   the default (nothing to flip here — adaptive sizing has no separate flag;
+   it rides the Stage A scheduler flag).

--- a/notes/22-ws-b-stage-b-ctx-adaptive-spec.md
+++ b/notes/22-ws-b-stage-b-ctx-adaptive-spec.md
@@ -342,3 +342,56 @@ prefill/MoE scratch, not KV. The envelope estimate in "Bench verification" item 
 is simply too small; no failure was observed. `vm.swapusage` showed 5.6GB used
 but that is boot-cumulative and NOT attributable to this run — inconclusive, not
 evidence of a swap storm.
+
+---
+
+## Bench verification — post-fix re-run (2026-07-25, after `d4f7e27`)
+
+Finding 3 above is FIXED (`arenaSeqLen`, legacy sentinel → 16384). Re-measured
+paired same-session; artifacts `/tmp/lane-stage-b-153909` (full) and
+`/tmp/lane-stage-b-154552` (warmed tps A/B).
+
+### 1. Motivating E2E — now properly controlled
+
+| pass | result |
+|---|---|
+| ON (default) | 32 deltas, TTFT 152,673ms, 29.6 tok/s — **admits and streams** |
+| cap16k (`QWISP_LANE_CTX=16384`, the real control) | **0 deltas in 816ms**, stderr `NOTE: prompt (30778 tokens) leaves no room to generate in the 16384-token lane context — request dropped.` |
+| OFF (`..._SCHED=0`) | 0 deltas in 812ms — legacy 16K arena refuses it, as pre-Stage-B |
+
+The cap16k pass is the control the first run lacked. It also gives the only
+evidence for Resolved-ambiguity 6: the refusal IS visible on stderr. **Partial**,
+though — the HTTP response is still an empty 200, not an error status. If "failed
+stream" was meant to include a non-200/`error` SSE frame, that half is NOT done.
+
+### 2. No-regression A/B (warmed, one-sided bar)
+
+The first run's tps rows were invalid: post-fix, OFF's e2e short-circuits in <1s
+while ON's runs a 155s prefill, so the rows compared warm-vs-cold and printed a
+bogus 26.8% "regression". `run_pass` now issues an identical warmup before the
+tps rows. Re-measured:
+
+| B | OFF | ON | Δ |
+|---|---|---|---|
+| 1 | 84.22 | 82.35 | −2.2% |
+| 2 | 51.34 | 52.34 | +1.9% |
+| 3 | 38.55 | 40.81 | +5.9% |
+| 4 | 30.07 | 32.85 | +9.2% |
+
+**PASS.** Worst regression is −2.2%; the rest favour ON (smaller per-request
+arenas → better locality). The bar is one-sided — the summary printed `|Δ|`,
+which conflated "ON slower" with "ON faster"; fixed to report them separately.
+
+### 3. Footprint gate — PASS (unchanged)
+
+3 simultaneous 30.8K admits all stream (TTFT ~155.2s, within 3ms of each other),
+peak `footprint` **37,888 MB**. ON tps is reproducible across runs: 82.79/59.60/
+39.12/30.73 (run 1) vs 84.79/60.99/40.04/34.42 (run 2), ≤2.4% apart at B=1..3.
+
+### Still open
+
+- Resolved-ambiguities 1 and 2 in this file contradict each other (1 says flag-off
+  keeps the 16K cap, 2 says the 16384 default is gone). The code now implements
+  BOTH correctly by splitting eligibility cap from allocation size — but the prose
+  must be reconciled so the next session does not re-derive the same bug.
+- The oversized-prompt HTTP surface (empty 200 vs a real error) per item 6 above.

--- a/notes/22-ws-b-stage-b-ctx-adaptive-spec.md
+++ b/notes/22-ws-b-stage-b-ctx-adaptive-spec.md
@@ -230,6 +230,18 @@ All existing `tokenbudget_*` cases stay byte-untouched and green.
    16384" to "eligibility cap override, default = model context". This is
    deliberate (the 16K default IS the bug). Update the main.swift help text
    (~L43-46) accordingly.
+
+   **1 and 2 as originally written contradict each other, and that contradiction
+   shipped a bug** (addendum finding 3): the old 16384 was ONE number doing TWO
+   jobs — the eligibility cap AND the arena allocation size. 2 removes it as a
+   cap; 1 requires it as the flag-off allocation size. Reading only 2, round 1
+   made the legacy path allocate at the 262144 eligibility cap = 5.37GB/lane,
+   ungated. **Binding reconciliation**: they are separate quantities.
+   - *eligibility cap* = `laneCtx` = model context (or `QWISP_LANE_CTX`), BOTH paths.
+   - *allocation size* = per-request `seqBudget` on the budgeted path;
+     `LaneBatchSlots.legacyArenaCap` (16384) on the flag-off path.
+   `LaneBatchSlots.arenaSeqLen(seqBudget:maxSeqLen:)` is the single place this is
+   decided, locked by COMPTEST `lanesize_legacy_arena_*`. Never re-merge them.
 3. **Memory gate is FCFS with head-of-line wait**, not skip-ahead. Matches
    vLLM, preserves the locked fairness test. Head-of-line blocking on a huge
    request is accepted behavior, not a bug to fix this stage.

--- a/notes/22-ws-b-stage-b-ctx-adaptive-spec.md
+++ b/notes/22-ws-b-stage-b-ctx-adaptive-spec.md
@@ -266,3 +266,79 @@ All existing `tokenbudget_*` cases stay byte-untouched and green.
    (same shape as notes/21's "Bench verification results"), then owner decides
    the default (nothing to flip here — adaptive sizing has no separate flag;
    it rides the Stage A scheduler flag).
+
+---
+
+## Bench verification results (2026-07-25, `scripts/bench_lane_stage_b.sh 35000`, real model)
+
+Model `Youssofal--Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16` (modelCtx 262144),
+64GB M-series, AC power, GPU-exclusive, paired same-session. Filler prompt
+tokenised to **30778 tokens** (serve-log `prompt=`, not the nominal 35000 —
+`makeFiller`'s ~1.3 tok/word estimate runs ~12% optimistic; the number that
+matters is that it is ~1.9x the old 16384 cap). Artifacts: `/tmp/lane-stage-b-151409`.
+
+### 1. The motivating E2E — PASS (on), but the control was INVALID
+
+| pass | deltas | TTFT | decode |
+|---|---|---|---|
+| OFF (`QWISP_TOKEN_BUDGET_SCHED=0`) | 32 | 159,575ms | 27.5 tok/s |
+| ON (default) | 32 | 153,418ms | 34.8 tok/s |
+
+A 30.8K-token prompt now admits and streams a correct completion. **But OFF
+admitted it too**, so this pair does NOT demonstrate the fix. Reason: the
+`QWISP_LANE_CTX` default flip (16384 → modelCtx) is applied in `LaneBackend.init`
+**unconditionally**, not gated on the scheduler flag — so both paths get the cap
+lift. The valid control is `QWISP_LANE_CTX=16384` on the same binary; it is also
+the only way to exercise Resolved-ambiguity 6 (oversized ⇒ visible failure, never
+an empty 200), which NOTHING currently tests. **Still owed.**
+
+### 2. No-regression A/B, short prompts (mean tok/s per stream)
+
+| B | OFF | ON | Δ |
+|---|---|---|---|
+| 1 | 83.89 | 82.79 | **−1.3%** |
+| 2 | 4.88 | 59.60 | +1121% |
+| 3 | 7.22 | 39.12 | +442% |
+| 4 | 4.80 | 30.73 | +540% |
+
+**Only the B=1 row measures what this gate was designed to measure**, and it
+passes: adaptive sizing's own overhead is −1.3%, inside the ±5% bar. The B≥2 rows
+do not show a Stage B win — they show finding 3 below, i.e. the OFF baseline is
+itself broken by this branch. Do not quote them as a speedup.
+
+### 3. REGRESSION (blocking): the flag-off path allocates model-context arenas
+
+`LaneBatchSlots.admitStep`'s legacy 3-arg entry (`seqBudget: 0`) sizes the lane
+arena at `maxSeqLen` verbatim (LaneServe.swift ~270). `maxSeqLen` IS `laneCtx`,
+which this branch changed from 16384 to modelCtx = 262144. With
+`kvBytesPerToken` = 10 attn layers × 2 KV × 256 dim × 2 B × 2 (k+v) = 20,480 B:
+
+- before: 16384 tok × 20KB = **335 MB per lane**
+- after:  262144 tok × 20KB = **5.37 GB per lane** — 16x, and `canAdmit` is
+  called ONLY from `budgetedStep` (ContinuousBatch.swift:217), so the legacy path
+  has no KV byte gate at all.
+
+That is the measured B≥2 collapse above (the wired-page-exhaustion signature of
+memory `strict-streaming-collapse-fix`), and it violates the binding rule that
+`QWISP_TOKEN_BUDGET_SCHED=0` stays bit-for-bit legacy INCLUDING the fixed-cap
+arena path (CLAUDE.md / HANDOFF Do-Not-Touch; this spec's own Resolved-ambiguity
+1, which contradicts its Resolved-ambiguity 2 — the implementation followed 2).
+
+Proposed fix (NOT applied — round 1 is committed; owner decision): decouple the
+eligibility cap from the legacy allocation size, i.e. `seqBudget == 0` sizes at
+`min(16384, maxSeqLen)` rather than `maxSeqLen`. Resolved-ambiguity 1 and 2 must
+also be reconciled in this file so they stop contradicting.
+
+### 4. Footprint gate with 3 simultaneous admits — PASS
+
+3 concurrent 30.8K admits all streamed (`ok=true`, TTFT ~153.9s each, finishing
+within 3ms of one another — the budgeted round-robin). This is the N≥3 case the
+round-1 `reservedBytes` TOCTOU guard needs; no over-admit, no collapse.
+
+Peak `footprint` (never `ps rss`): **39,936 MB** on a 64GB box. That is ~10GB
+ABOVE this spec's stated envelope (8GB KV budget + ~20GB model + ~200MB×B) —
+the arenas themselves are only 3 × 30795 × 20KB ≈ 1.9GB, so the excess is
+prefill/MoE scratch, not KV. The envelope estimate in "Bench verification" item 3
+is simply too small; no failure was observed. `vm.swapusage` showed 5.6GB used
+but that is boot-cumulative and NOT attributable to this run — inconclusive, not
+evidence of a swap storm.

--- a/notes/22b-rawtests97-plan.md
+++ b/notes/22b-rawtests97-plan.md
@@ -1,0 +1,99 @@
+# WS-B Stage B round 2 plan — RAWTESTS 97 `lane_admit_restore_cross_arena_bitexact`
+
+Round 1 (B1 core: sizing policy + seqBudget threading + canAdmit memory gate)
+is DONE and pushed (`6d36aa7` on `claude/lane-ctx-adaptive`). This file is the
+plan for round 2, the last correctness item before the GPU bench.
+
+## Why this test exists
+
+Stage B's central claim is notes/22 "Verified load-bearing fact 2": a
+`persistentStateData()` blob captured from a lane whose arena was allocated at
+size S1 restores **bit-correctly** into a lane whose arena is size S2 > S1.
+Before Stage B every lane shared one arena size, so this cross-size path was
+never exercised; after Stage B (per-request arena sizing) it is the NORMAL
+case for #121 prefix-cache fan-out — a small-prompt lane's blob routinely
+lands in a bigger lane. The wire format already supports it (used-slice save,
+destination-stride write, `len <= kv.maxLen` validation, verified in recon),
+but nothing LOCKS it. This test locks it.
+
+## Contract
+
+Extend `swift/Sources/QwispCore/SeedlessVerifyTests.swift`, bumping the
+WRITE-LOCKED counter `let total = 96` → **97** (line ~52). ADD a new test;
+never modify tests 90-96.
+
+Model the new test on **test 92 `lane_admit_restore_bitexact`** (same file,
+~line 5646) — reuse its whole synthetic-weight fixture verbatim (the `q4`/`q8`/
+`q4e`/`mkMoE` helpers, the 2-layer GDN+attn `layers` array, `eW/lW/fnW`,
+`freshCaches()`). The ONLY structural change is that `mkFwd()` becomes
+parameterised on arena size:
+
+```swift
+func mkFwd(_ seqLen: Int) -> SeedlessFusedVerify.SeedlessFusedForward? {
+    SeedlessFusedVerify.SeedlessFusedForward(layers: layers, caches: freshCaches(),
+                                             maxM: 4, H: H, maxSeqLen: seqLen)
+}
+```
+(test 92 hardcodes `maxSeqLen: 64`.)
+
+### Assertions (all must hold)
+
+Pick `S1 = 32`, `S2 = 128` (S2 > S1, both comfortably above the 5-token
+history), and `S3 = 4` (deliberately smaller than the 3-token saved `len`).
+
+1. **Cross-size restore is bit-exact.** Donor at `S1` computes prefix `W3`
+   (M=3) → `persistentStateData()`. A cold lane at `S2` computes `W3` itself.
+   A restored lane at `S2` restores the S1 blob. Both then run the SAME delta
+   `Dx` (M=2). Assert `bitEqual` on the delta output AND on every layer cache
+   via `readLayerCache(li)` for li in 0...1 (conv/rec on the GDN layer,
+   k/v on the attn layer) — exactly test 92's comparison set.
+2. **Reverse direction also holds.** Donor at `S2`, restore into `S1`
+   (still valid: saved `len` 3 ≤ 32). Same bit-exact assertions. This is the
+   direction that would break if restore ever wrote at the SOURCE's stride
+   instead of the destination's.
+3. **Oversized restore is refused, not silently truncated.** A blob whose
+   saved `len` exceeds the destination's `maxLen` must make
+   `restorePersistentState` return `false` (destination at `S3 = 4`, blob
+   holding 3 tokens is fine — so instead build the donor with a LONGER history:
+   e.g. donor at `S1` runs `W3` then another chunk so `len` > `S3`). The
+   caller then discards that lane (cold fallback). Assert `false` is returned.
+4. **Batch composition across mixed arena sizes.** Reuse test 92's tail: build
+   `SeedlessLaneBatch(driver:lanes:)` over `[restoredAtS2, coldAtS1]` — i.e.
+   lanes with DIFFERENT `maxSeqLen` riding one batch — and step 3 tokens via
+   `stepArgmaxBatch`, asserting both lanes agree with each other and with a
+   solo `stepArgmax` reference. This is the direct locked proof of notes/22
+   "fact 1" (heterogeneous arena sizes are kernel-safe), which today rests
+   only on code reading.
+
+## Prohibitions
+
+- Do not modify tests 90-96 or any `tokenbudget_*`/`lanesize_*`/`lanemem_*`
+  COMPTEST case. The counter goes 96 → 97 by ADDITION only.
+- Do not touch the frozen forward path, `persistentStateData`/
+  `restorePersistentState` themselves (this round only LOCKS their existing
+  behavior), chunk sizes, or `ContinuousBatchEngine`/`BatchBackend`.
+- Do not touch round 1's B1 code — if a genuine bug in it surfaces, stop and
+  report rather than silently patching, since round 1 is already committed.
+
+## Gates
+
+- Build: `cd swift && xcodebuild build -scheme qwisp-poc -configuration Release
+  -destination 'platform=macOS' -derivedDataPath ./.xcode-build-rel
+  -skipPackagePluginValidation` (RAWTESTS lives in the **qwisp-poc** scheme —
+  rebuild it, not just `qwisp`, or the gate runs a stale binary).
+- `~/bin/jacquard run scripts/test_raw.sh` → RAWTESTS **97/97**.
+- COMPTEST stays 90/90, BENCHBATCHTEST PASS (neither should be affected).
+
+## After this round
+
+The correctness half of Stage B is complete. Remaining: the GPU bench from
+notes/22 "Bench verification" (driver/owner-run, GPU-exclusive):
+1. 35K-token prompt admits and streams correctly (today: silent empty) — the
+   motivating E2E. Reuse `tools/lane_budget_probe.mjs`'s filler generator.
+2. Paired no-regression A/B at B=1..4 on short prompts (sizing overhead within
+   noise, ±5%).
+3. Footprint gate with **≥3** simultaneous large admits (not just 2 — the
+   round-1 review's `reservedBytes` TOCTOU fix specifically needs ≥3 free
+   slots contending in one round to be exercised; 2 passed even with the bug).
+   Use `footprint <pid>`, never `ps rss`.
+Then open the PR (branch `claude/lane-ctx-adaptive`, issue #141).

--- a/scripts/bench_lane_stage_b.sh
+++ b/scripts/bench_lane_stage_b.sh
@@ -7,10 +7,11 @@
 #   OFF = QWISP_TOKEN_BUDGET_SCHED=0 (legacy atomic path, fixed 16K lane cap)
 #   ON  = default (Stage A scheduler + Stage B adaptive sizing)
 # Each pass runs:
-#   1. e2e   — a ~35K prompt. OFF is the POSITIVE CONTROL: it must come back empty
-#              (the silent no-op Stage B fixes). ON must stream real content.
-#   2. tps   — B=1..4 concurrent SHORT prompts; per-B mean tok/s must match within
-#              ±5% (isolates adaptive-sizing overhead; short prompts never resize).
+#   1. e2e   — a ~35K prompt; ON must stream real content. NOTE: OFF is NOT a control
+#              for this — QWISP_LANE_CTX's default flip is unconditional. The real
+#              control is the cap16k pass at the bottom.
+#   2. tps   — B=1..4 concurrent SHORT prompts, after an identical warmup; ON must not
+#              be >5% SLOWER (one-sided bar; ON being faster is not a failure).
 #   3. conc  — ON pass only: 3 SIMULTANEOUS large admits with `footprint` sampled
 #              throughout. 3, not 2: the round-1 reservedBytes TOCTOU guard only
 #              bites when budgetedStep peeks at >=3 free slots in one round.
@@ -24,6 +25,9 @@ BIN="$REPO/swift/.xcode-build-rel/Build/Products/Release/qwisp"
 MODEL="${QWISP_MODEL:-$HOME/.mtplx/models/Youssofal--Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16}"
 PORT="${QWISP_PORT:-8099}"
 LANES="${QWISP_LANES:-4}"
+# STAGE_B_PHASES=tps runs ONLY the paired tps rows (skips e2e, conc and the cap16k
+# control) — a ~5min re-measure of the +/-5% gate without re-paying two 155s prefills.
+PHASES="${STAGE_B_PHASES:-all}"
 
 [ -x "$BIN" ] || { echo "ERROR: build the qwisp scheme first"; exit 1; }
 [ -d "$MODEL" ] || { echo "ERROR: model not found at $MODEL (set QWISP_MODEL)"; exit 1; }
@@ -77,10 +81,19 @@ run_pass() {
         sleep 2
     done
 
-    echo "-- e2e ($BIG tok)"
-    node "$REPO/tools/lane_stage_b_probe.mjs" e2e "127.0.0.1:$PORT" "$BIG" 32 \
-        > "$OUT/$label.e2e.json" || echo '{"error":"probe failed"}' > "$OUT/$label.e2e.json"
-    cat "$OUT/$label.e2e.json"
+    if [ "$PHASES" = "all" ]; then
+        echo "-- e2e ($BIG tok)"
+        node "$REPO/tools/lane_stage_b_probe.mjs" e2e "127.0.0.1:$PORT" "$BIG" 32 \
+            > "$OUT/$label.e2e.json" || echo '{"error":"probe failed"}' > "$OUT/$label.e2e.json"
+        cat "$OUT/$label.e2e.json"
+    fi
+
+    # Warm the engine IDENTICALLY in both passes before the tps rows. Without this the
+    # comparison is invalid: post-fix, OFF's e2e short-circuits in <1s (legacy 16K cap
+    # refuses the big prompt) while ON's runs a full ~155s prefill, so the tps rows would
+    # measure warm-vs-cold, not sizing overhead. Observed as a bogus 26.8% "regression".
+    echo "-- warmup"
+    node "$REPO/tools/lane_stage_b_probe.mjs" tps "127.0.0.1:$PORT" 1 32 > /dev/null 2>&1 || true
 
     local b
     for b in 1 2 3 4; do
@@ -90,7 +103,7 @@ run_pass() {
         cat "$OUT/$label.tps$b.json"
     done
 
-    if [ "$label" = "on" ]; then
+    if [ "$label" = "on" ] && [ "$PHASES" = "all" ]; then
         echo "-- conc N=3 ($BIG tok each) + footprint"
         sample_footprint "$pid" "$OUT/footprint.txt" &
         local sampler
@@ -115,6 +128,7 @@ run_pass on  ""
 # restoring the old 16384 eligibility cap is the only way to reproduce the pre-Stage-B
 # state, and it is also the only test of Resolved-ambiguity 6 — an oversized prompt must
 # fail VISIBLY (stderr NOTE + no content), never as a silent empty 200.
+if [ "$PHASES" = "all" ]; then
 echo ""
 echo "== pass: cap16k (control: QWISP_LANE_CTX=16384, expect VISIBLE refusal) =="
 env QWISP_LANE_CTX=16384 QWISP_MODEL="$MODEL" QWISP_LANES="$LANES" QWISP_PORT="$PORT" "$BIN" serve \
@@ -131,6 +145,7 @@ echo "-- stderr NOTE (visible-failure requirement):"
 grep -c "leaves no room to generate" "$OUT/cap16k.server.log" || true
 kill "$CAPPID" 2>/dev/null || true
 wait "$CAPPID" 2>/dev/null || true
+fi
 
 echo ""
 echo "== summary =="
@@ -148,16 +163,21 @@ for lbl in ("off", "on"):
           f"status={d.get('status')} sample={d.get('sample','')!r}")
 print("\n2) No-regression A/B, short prompts (mean tok/s per stream)")
 print(f"  {'B':>2} {'OFF':>8} {'ON':>8} {'Δ%':>7}")
-worst = 0.0
+worstReg = 0.0
+bestImp = 0.0
 for b in (1, 2, 3, 4):
     o, n = load(f"off.tps{b}.json").get("meanTps"), load(f"on.tps{b}.json").get("meanTps")
     if o and n:
         d = (n - o) / o * 100
-        worst = max(worst, abs(d))
+        if d < 0: worstReg = max(worstReg, -d)
+        else: bestImp = max(bestImp, d)
         print(f"  {b:>2} {o:>8.2f} {n:>8.2f} {d:>+6.1f}%")
     else:
         print(f"  {b:>2} {str(o):>8} {str(n):>8} {'n/a':>7}")
-print(f"  worst |Δ| = {worst:.1f}%  (bar: <=5%)")
+    # The bar is one-sided: it asks whether ON (adaptive sizing) is SLOWER. A large
+    # positive delta is ON winning, not a gate failure — reporting |Δ| conflated the two.
+    print(f"  worst REGRESSION (ON slower) = {worstReg:.1f}%  (bar: <=5%)  "
+          f"| best improvement = {bestImp:+.1f}%")
 c = load("on.conc.json")
 print(f"\n3) 3 simultaneous {c.get('promptTokens')}-tok admits: ok={c.get('ok')}")
 for i, s in enumerate(c.get("streams", [])):

--- a/scripts/bench_lane_stage_b.sh
+++ b/scripts/bench_lane_stage_b.sh
@@ -110,6 +110,28 @@ run_pass() {
 run_pass off "QWISP_TOKEN_BUDGET_SCHED=0"
 run_pass on  ""
 
+# The VALID control for the motivating E2E. The OFF pass is not one: QWISP_LANE_CTX's
+# default flip is unconditional, so flag-off admits the big prompt too. Explicitly
+# restoring the old 16384 eligibility cap is the only way to reproduce the pre-Stage-B
+# state, and it is also the only test of Resolved-ambiguity 6 — an oversized prompt must
+# fail VISIBLY (stderr NOTE + no content), never as a silent empty 200.
+echo ""
+echo "== pass: cap16k (control: QWISP_LANE_CTX=16384, expect VISIBLE refusal) =="
+env QWISP_LANE_CTX=16384 QWISP_MODEL="$MODEL" QWISP_LANES="$LANES" QWISP_PORT="$PORT" "$BIN" serve \
+    > "$OUT/cap16k.server.log" 2>&1 &
+CAPPID=$!
+for _ in $(seq 1 180); do
+    curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1 && break
+    sleep 2
+done
+node "$REPO/tools/lane_stage_b_probe.mjs" e2e "127.0.0.1:$PORT" "$BIG" 32 \
+    > "$OUT/cap16k.e2e.json" || echo '{"error":"probe failed"}' > "$OUT/cap16k.e2e.json"
+cat "$OUT/cap16k.e2e.json"
+echo "-- stderr NOTE (visible-failure requirement):"
+grep -c "leaves no room to generate" "$OUT/cap16k.server.log" || true
+kill "$CAPPID" 2>/dev/null || true
+wait "$CAPPID" 2>/dev/null || true
+
 echo ""
 echo "== summary =="
 python3 - "$OUT" << 'EOF'

--- a/scripts/bench_lane_stage_b.sh
+++ b/scripts/bench_lane_stage_b.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# WS-B Stage B bench (notes/22 "Bench verification"): the three Stage B measurements,
+# paired same-session, GPU-exclusive. Mirrors scripts/bench_lane_budget_ab.sh's
+# server lifecycle discipline (AC power, kill between passes, refuse if qwisp runs).
+#
+# Two passes over ONE binary, one model load each:
+#   OFF = QWISP_TOKEN_BUDGET_SCHED=0 (legacy atomic path, fixed 16K lane cap)
+#   ON  = default (Stage A scheduler + Stage B adaptive sizing)
+# Each pass runs:
+#   1. e2e   — a ~35K prompt. OFF is the POSITIVE CONTROL: it must come back empty
+#              (the silent no-op Stage B fixes). ON must stream real content.
+#   2. tps   — B=1..4 concurrent SHORT prompts; per-B mean tok/s must match within
+#              ±5% (isolates adaptive-sizing overhead; short prompts never resize).
+#   3. conc  — ON pass only: 3 SIMULTANEOUS large admits with `footprint` sampled
+#              throughout. 3, not 2: the round-1 reservedBytes TOCTOU guard only
+#              bites when budgetedStep peeks at >=3 free slots in one round.
+#
+# Usage: scripts/bench_lane_stage_b.sh [promptTokens]   # default 35000
+set -euo pipefail
+
+BIG="${1:-35000}"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$REPO/swift/.xcode-build-rel/Build/Products/Release/qwisp"
+MODEL="${QWISP_MODEL:-$HOME/.mtplx/models/Youssofal--Qwen3.6-35B-A3B-MTPLX-Optimized-Speed-FP16}"
+PORT="${QWISP_PORT:-8099}"
+LANES="${QWISP_LANES:-4}"
+
+[ -x "$BIN" ] || { echo "ERROR: build the qwisp scheme first"; exit 1; }
+[ -d "$MODEL" ] || { echo "ERROR: model not found at $MODEL (set QWISP_MODEL)"; exit 1; }
+if pgrep -x qwisp >/dev/null; then echo "ERROR: qwisp server already running — stop it first (GPU exclusive)"; exit 1; fi
+if ! pmset -g batt | head -1 | grep -q "AC Power"; then
+    echo "WARNING: on battery — DVFS makes reps spike; results are diagnostic only"
+fi
+
+TS=$(date +%H%M%S)
+OUT="/tmp/lane-stage-b-$TS"
+mkdir -p "$OUT"
+echo "== Stage B bench: prompt=$BIG tok, lanes=$LANES, out=$OUT =="
+
+# Peak "Footprint: N KB" reported by /usr/bin/footprint over the sampling window,
+# normalised to MB. `footprint`, never `ps rss` (rss undercounts wired GPU pages).
+sample_footprint() {
+    local pid
+    pid="$1"
+    local dst
+    dst="$2"
+    while kill -0 "$pid" 2>/dev/null; do
+        footprint "$pid" 2>/dev/null | grep -m1 "Footprint:" >> "$dst" || true
+        sleep 2
+    done
+}
+
+peak_mb() {
+    awk '{
+        for (i = 1; i <= NF; i++) if ($i == "Footprint:") { v = $(i+1); u = $(i+2); break }
+        if (u == "KB") v /= 1024; else if (u == "GB") v *= 1024;
+        if (v > m) m = v
+    } END { printf "%.0f", m }' "$1"
+}
+
+run_pass() {
+    local label
+    label="$1"
+    local extra_env
+    extra_env="$2"
+    echo ""
+    echo "== pass: $label (env: ${extra_env:-default}) =="
+    # No QWISP_LANE_CTX override here, deliberately: Stage B's whole claim is that
+    # the SHIPPED default admits a $BIG-token prompt. bench_lane_budget_ab.sh had to
+    # raise it to 32768; needing that override again would itself be the failure.
+    env $extra_env QWISP_MODEL="$MODEL" QWISP_LANES="$LANES" QWISP_PORT="$PORT" "$BIN" serve \
+        > "$OUT/$label.server.log" 2>&1 &
+    local pid
+    pid=$!
+    for _ in $(seq 1 180); do
+        curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1 && break
+        sleep 2
+    done
+
+    echo "-- e2e ($BIG tok)"
+    node "$REPO/tools/lane_stage_b_probe.mjs" e2e "127.0.0.1:$PORT" "$BIG" 32 \
+        > "$OUT/$label.e2e.json" || echo '{"error":"probe failed"}' > "$OUT/$label.e2e.json"
+    cat "$OUT/$label.e2e.json"
+
+    local b
+    for b in 1 2 3 4; do
+        echo "-- tps B=$b"
+        node "$REPO/tools/lane_stage_b_probe.mjs" tps "127.0.0.1:$PORT" "$b" 64 \
+            > "$OUT/$label.tps$b.json"
+        cat "$OUT/$label.tps$b.json"
+    done
+
+    if [ "$label" = "on" ]; then
+        echo "-- conc N=3 ($BIG tok each) + footprint"
+        sample_footprint "$pid" "$OUT/footprint.txt" &
+        local sampler
+        sampler=$!
+        node "$REPO/tools/lane_stage_b_probe.mjs" conc "127.0.0.1:$PORT" "$BIG" 3 16 \
+            > "$OUT/$label.conc.json" || echo '{"error":"probe failed"}' > "$OUT/$label.conc.json"
+        kill "$sampler" 2>/dev/null || true
+        cat "$OUT/$label.conc.json"
+        echo "peak footprint: $(peak_mb "$OUT/footprint.txt") MB"
+    fi
+
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    sleep 2   # let wired GPU pages settle before the next pass
+}
+
+run_pass off "QWISP_TOKEN_BUDGET_SCHED=0"
+run_pass on  ""
+
+echo ""
+echo "== summary =="
+python3 - "$OUT" << 'EOF'
+import json, os, sys
+out = sys.argv[1]
+def load(name):
+    p = os.path.join(out, name)
+    try: return json.load(open(p))
+    except Exception: return {}
+print("1) E2E 35K admit (OFF is the positive control — empty is EXPECTED there)")
+for lbl in ("off", "on"):
+    d = load(f"{lbl}.e2e.json")
+    print(f"  {lbl:>4}: deltas={d.get('deltas')} ttft={d.get('ttftMs')}ms total={d.get('totalMs')}ms "
+          f"status={d.get('status')} sample={d.get('sample','')!r}")
+print("\n2) No-regression A/B, short prompts (mean tok/s per stream)")
+print(f"  {'B':>2} {'OFF':>8} {'ON':>8} {'Δ%':>7}")
+worst = 0.0
+for b in (1, 2, 3, 4):
+    o, n = load(f"off.tps{b}.json").get("meanTps"), load(f"on.tps{b}.json").get("meanTps")
+    if o and n:
+        d = (n - o) / o * 100
+        worst = max(worst, abs(d))
+        print(f"  {b:>2} {o:>8.2f} {n:>8.2f} {d:>+6.1f}%")
+    else:
+        print(f"  {b:>2} {str(o):>8} {str(n):>8} {'n/a':>7}")
+print(f"  worst |Δ| = {worst:.1f}%  (bar: <=5%)")
+c = load("on.conc.json")
+print(f"\n3) 3 simultaneous {c.get('promptTokens')}-tok admits: ok={c.get('ok')}")
+for i, s in enumerate(c.get("streams", [])):
+    print(f"  stream {i}: deltas={s['deltas']} ttft={s['ttftMs']}ms total={s['totalMs']}ms status={s['status']}")
+EOF
+echo ""
+echo "artifacts: $OUT"

--- a/swift/Sources/QwispCore/ContinuousBatch.swift
+++ b/swift/Sources/QwispCore/ContinuousBatch.swift
@@ -51,6 +51,18 @@ public protocol BatchSlots: AnyObject {
     func step(last: [Int32?]) -> [Int?]
     /// Slot finished — drop its per-slot state so the next admit starts clean.
     func release(slot: Int)
+    /// Ctx-adaptive resumable prefill (WS-B Stage B, notes/22): the 3-arg `admitStep`
+    /// plus `seqBudget` = the arena size this request needs (prompt + 1 + gen budget).
+    /// `seqBudget == 0` is the LEGACY SENTINEL — size the arena at the init-time fixed
+    /// cap, exactly today's behavior. The default extension forwards to the 3-arg
+    /// (ignoring seqBudget) so ContinuousBatchEngine/BatchBackend and the MLX path stay
+    /// untouched — only LaneBatchSlots overrides to size the arena per admit.
+    func admitStep(prompt: [Int32], slot: Int, tokenBudget: Int, seqBudget: Int) -> AdmitProgress
+    /// Aggregate memory gate (WS-B Stage B, the PR #135 collapse guard): can a request
+    /// needing `seqBudget` arena tokens be admitted right now without blowing the lane KV
+    /// budget? Default `true` — non-lane engines (ContinuousBatchEngine) are unbounded as
+    /// before. LaneBatchSlots returns whether the aggregate arena fits its byte budget.
+    func canAdmit(promptLen: Int, seqBudget: Int) -> Bool
 }
 
 public extension BatchSlots {
@@ -62,6 +74,15 @@ public extension BatchSlots {
         guard let t = admit(prompt: prompt, slot: slot) else { return .failed }
         return .done(firstToken: t, consumed: prompt.count)
     }
+    /// Default for engines that don't do ctx-adaptive arena sizing (WS-B Stage B): drop
+    /// `seqBudget` and forward to the 3-arg admitStep. Keeps ContinuousBatchEngine/BatchBackend
+    /// byte-untouched — they inherit this and never override it; only LaneBatchSlots overrides.
+    func admitStep(prompt: [Int32], slot: Int, tokenBudget: Int, seqBudget: Int) -> AdmitProgress {
+        admitStep(prompt: prompt, slot: slot, tokenBudget: tokenBudget)
+    }
+    /// Default memory gate: unbounded (WS-B Stage B). MLX engines admit freely as before;
+    /// only LaneBatchSlots overrides with its aggregate KV-byte budget.
+    func canAdmit(promptLen: Int, seqBudget: Int) -> Bool { true }
 }
 
 // ── Scheduler (pure logic; GPU only through BatchSlots) ───────────────────────
@@ -189,6 +210,12 @@ public final class ContinuousScheduler {
         let B = slots.slotCount
         var owned = Set(pending.map { $0.slot })
         for b in 0 ..< B where active[b] == nil && !owned.contains(b) && !queue.isEmpty {
+            // WS-B Stage B (notes/22): the aggregate KV-budget gate (PR #135 collapse guard).
+            // Peek the queue head — if it can't fit yet, stop admitting entirely this round
+            // (head-of-line FCFS wait), never skip ahead to a smaller item behind it.
+            let head = queue.first!
+            guard slots.canAdmit(promptLen: head.prompt.count,
+                                 seqBudget: head.prompt.count + 1 + head.maxTokens) else { break }
             let req = queue.removeFirst()
             guard req.maxTokens > 0 else { req.finish(); continue }   // 0-token request: instant no-op
             pending.append(Pend(req: req, pos: 0, slot: b))
@@ -200,7 +227,8 @@ public final class ContinuousScheduler {
         var toActivate: [(slot: Int, req: Request, first: Int)] = []
         for p in pending {
             guard pool > 0 else { stillPending.append(p); continue }
-            switch slots.admitStep(prompt: p.req.prompt, slot: p.slot, tokenBudget: pool) {
+            let seqBudget = p.req.prompt.count + 1 + p.req.maxTokens
+            switch slots.admitStep(prompt: p.req.prompt, slot: p.slot, tokenBudget: pool, seqBudget: seqBudget) {
             case .failed:
                 p.req.finish(); slots.release(slot: p.slot)
             case .prefilling(let consumed):
@@ -210,7 +238,9 @@ public final class ContinuousScheduler {
                 // Debit only the real work this call did — NOT prompt.count - p.pos, which
                 // would over-charge by any prefix-cache restore credit the lane applied
                 // internally (Fable review: a 24K prompt with a 20K warm restore is ~4K of
-                // real work, not 24K).
+                // real work, not 24K). Grant site: the #121 fan-out restore ordering (a warm
+                // request completing out of prompt-length order) is an emergent property of
+                // this ceil-grant admit + the FCFS wait above, not a separate mechanism.
                 pool -= consumed
                 toActivate.append((p.slot, p.req, first))
             }
@@ -449,6 +479,116 @@ public final class ContinuousScheduler {
         }
         boundaryOK = boundaryOK && cum == plen4
         result.append(("chunk_boundary_respected", boundaryOK))
+
+        return result
+    }
+
+    // ── WS-B Stage B: aggregate memory gate (lane KV budget, notes/22) ────────────
+    /// Locked self-check (COMPTEST `lanemem_*`, no GPU, no model): the budgeted scheduler
+    /// consults `canAdmit` before admitting a queue head and threads `seqBudget` through the
+    /// 4-arg `admitStep`. Distinct from the Stage A fake: this `MemFake` models a per-slot
+    /// arena-byte budget (`bytesPerToken = 1`, `arenaBytes[slot] = seqBudget` on a completed
+    /// admit, cleared on release) and a settable `budgetBytes`, so a small budget makes the
+    /// gate fire and a huge budget leaves scheduling untouched. Its floor-grant fake semantics
+    /// intentionally differ from the real ceil-grant `LaneBatchSlots.admitStep` (notes/22 B2.3)
+    /// — do not "fix" one to match the other.
+    public static func laneMemSelfCheck() -> [(String, Bool)] {
+        // Resumable + byte-budgeted fake. `admit()` (the 3-arg atomic path, used when the
+        // scheduler does NOT thread seqBudget) prefills atomically and logs NOTHING — so a
+        // scheduler that hasn't wired the 4-arg path yet leaves the admit log empty (RED). The
+        // real 4-arg `admitStep` advances in whole 1024 chunks, records `seqBudget` per call,
+        // and commits `arenaBytes` on completion; `canAdmit` gates on the aggregate.
+        final class MemFake: BatchSlots, @unchecked Sendable {
+            enum Ev: Equatable { case step(slot: Int); case admit(slot: Int, seqBudget: Int, consumed: Int) }
+            let slotCount: Int
+            let chunk = 1024
+            var budgetBytes: Int                 // settable aggregate KV budget (bytesPerToken = 1)
+            var pos: [Int]                        // per-slot resume position
+            var arenaBytes: [Int]                 // per-slot committed arena (0 = free)
+            var log: [Ev] = []
+            init(slots: Int, budgetBytes: Int) {
+                self.slotCount = slots
+                self.budgetBytes = budgetBytes
+                self.pos = Array(repeating: 0, count: slots)
+                self.arenaBytes = Array(repeating: 0, count: slots)
+            }
+            func admit(prompt: [Int32], slot: Int) -> Int? {   // 3-arg atomic path: NO admit log
+                guard slot >= 0, slot < slotCount, !prompt.isEmpty else { return nil }
+                pos[slot] = prompt.count
+                return Int((prompt.first ?? 0) + 1)
+            }
+            func admitStep(prompt: [Int32], slot: Int, tokenBudget: Int, seqBudget: Int) -> AdmitProgress {
+                guard slot >= 0, slot < slotCount, !prompt.isEmpty else { return .failed }
+                let first = Int((prompt.first ?? 0) + 1)
+                let remaining = prompt.count - pos[slot]
+                if remaining <= 0 { arenaBytes[slot] = seqBudget; return .done(firstToken: first, consumed: 0) }
+                let affordable = Swift.max(1, tokenBudget / chunk) * chunk   // ≥1 whole chunk
+                let consumed = Swift.min(affordable, remaining)
+                pos[slot] += consumed
+                log.append(.admit(slot: slot, seqBudget: seqBudget, consumed: consumed))
+                if pos[slot] >= prompt.count { arenaBytes[slot] = seqBudget; return .done(firstToken: first, consumed: consumed) }
+                return .prefilling(consumed: consumed)
+            }
+            func canAdmit(promptLen: Int, seqBudget: Int) -> Bool {
+                arenaBytes.reduce(0, +) + seqBudget <= budgetBytes
+            }
+            func step(last: [Int32?]) -> [Int?] {
+                var out: [Int?] = Array(repeating: nil, count: slotCount)
+                for s in 0 ..< slotCount where last[s] != nil { log.append(.step(slot: s)); out[s] = Int(last[s]!) + 1 }
+                return out
+            }
+            func release(slot: Int) { if slot >= 0, slot < slotCount { pos[slot] = 0; arenaBytes[slot] = 0 } }
+        }
+        /// Ordered list of `seqBudget`s in the admit log (one per completed small-prompt admit).
+        func admitOrder(_ log: [MemFake.Ev]) -> [Int] {
+            log.compactMap { if case let .admit(_, sb, _) = $0 { return sb }; return nil }
+        }
+        var result: [(String, Bool)] = []
+
+        // 5. head_of_line_wait: job0 (small, long-running, budget-heavy) + jobX (small, short)
+        //    both admit round 1; when jobX frees its slot, the queue head job1 STILL can't fit
+        //    alongside the running job0 → the gate blocks it and job2 must NOT jump ahead
+        //    (FCFS). Only after job0 releases does job1 admit, then job2. bytesPerToken = 1 so
+        //    seqBudget == prompt+1+maxTokens is the byte cost.
+        //      job0 = 30+1+40 = 71 ; jobX = 5+1+3 = 9 ; job1(head) = 20+1+40 = 61 ; job2 = 7+1+4 = 12
+        //      budget 100: 71+9=80 ✓ (round-1 pair) ; 71+61=132 ✗ (job1 blocked) ; 61 alone ✓.
+        let f5 = MemFake(slots: 2, budgetBytes: 100)
+        _ = ContinuousScheduler(slots: f5, tokenBudget: 2048).runToCompletion([
+            SchedJob(prompt: Array(repeating: 1, count: 30), maxTokens: 40, stop: []),   // job0
+            SchedJob(prompt: Array(repeating: 2, count: 5),  maxTokens: 3,  stop: []),   // jobX
+            SchedJob(prompt: Array(repeating: 3, count: 20), maxTokens: 40, stop: []),   // job1 (head)
+            SchedJob(prompt: Array(repeating: 4, count: 7),  maxTokens: 4,  stop: []),   // job2
+        ])
+        // FCFS + head-of-line wait: admits land in the exact order [job0, jobX, job1, job2];
+        // job1 (61) admits only after job0/jobX free budget, and job2 (12) never jumps ahead.
+        result.append(("head_of_line_wait", admitOrder(f5.log) == [71, 9, 61, 12]))
+
+        // 6. seqbudget_passthrough: a single budgeted-path admit records seqBudget exactly
+        //    equal to prompt.count + 1 + maxTokens (50 + 1 + 10 = 61).
+        let f6 = MemFake(slots: 2, budgetBytes: 1_000_000)
+        _ = ContinuousScheduler(slots: f6, tokenBudget: 2048).runToCompletion([
+            SchedJob(prompt: Array(repeating: 5, count: 50), maxTokens: 10, stop: []),
+        ])
+        result.append(("seqbudget_passthrough", admitOrder(f6.log) == [61]))
+
+        // 7. unbounded_when_gate_default: with a huge budget the gate never fires, so a large
+        //    prompt still interleaves prefill chunks with a short job's decode (no starvation) —
+        //    proving default-budget behavior is unchanged. This case is RED until the scheduler
+        //    threads the 4-arg admitStep: the 3-arg atomic default prefills the whole prompt in
+        //    one call, so no decode step can land between chunks.
+        let f7 = MemFake(slots: 2, budgetBytes: 1_000_000)
+        let out7 = ContinuousScheduler(slots: f7, tokenBudget: 2048).runToCompletion([
+            SchedJob(prompt: Array(repeating: 7, count: 1024), maxTokens: 8, stop: []),   // slot 0 decode
+            SchedJob(prompt: Array(repeating: 9, count: 6144), maxTokens: 2, stop: []),   // slot 1 chunked prefill
+        ])
+        let admits1 = f7.log.enumerated().compactMap { (i, e) -> Int? in
+            if case .admit(1, _, _) = e { return i }; return nil
+        }
+        var interleaved7 = admits1.count >= 2 && out7.count == 2 && out7[0] == [8, 9, 10, 11, 12, 13, 14, 15]
+        for k in 1 ..< Swift.max(1, admits1.count) {
+            interleaved7 = interleaved7 && f7.log[(admits1[k - 1] + 1) ..< admits1[k]].contains(.step(slot: 0))
+        }
+        result.append(("unbounded_when_gate_default", interleaved7))
 
         return result
     }

--- a/swift/Sources/QwispCore/LaneServe.swift
+++ b/swift/Sources/QwispCore/LaneServe.swift
@@ -19,9 +19,10 @@ import MLX
 //     in B, so idle lanes must not ride along; rebuild cost is two tiny buffers
 //     per lane).
 //   - release = drop the lane forward (caches freed; next admit re-creates).
-//   - Greedy only, resident tier only. Sequence budget per lane =
-//     min(model context, QWISP_LANE_CTX, default 16384) — KV arena is allocated
-//     per admit at this length.
+//   - Greedy only, resident tier only. Sequence budget per lane is ctx-adaptive
+//     (WS-B Stage B, notes/22): sized per admit from the request's own prompt +
+//     gen budget (LaneBackend.sizePlan), capped by the model context /
+//     QWISP_LANE_CTX override — KV arena is allocated per admit at that length.
 public final class LaneBatchSlots: BatchSlots {
     let engine: SeedlessEngine
     let driver: SeedlessFusedVerify.SeedlessFusedForward
@@ -39,9 +40,28 @@ public final class LaneBatchSlots: BatchSlots {
         let chunkSize: Int
         let plan: LaneAdmitPlan
         var pos: Int
+        // Only ever read within the SAME admitStep call that sets it (the final chunk reaching
+        // prompt.count, right before the first-token argmax) — a paused/resumed prefill never
+        // consumes a stale value across the pause boundary.
         var lastNormed: MLXArray?
     }
     private var prefills: [Prefill?]
+    /// WS-B Stage B (notes/22): aggregate lane KV-byte budget (the PR #135 collapse guard).
+    /// `arenaBytes[slot]` is set once the slot's arena is actually allocated (makeLane
+    /// succeeds — ceil-grant, unlike the self-check fake's floor-grant, see canAdmit below)
+    /// and cleared on release.
+    let kvBudgetBytes: Int
+    private var arenaBytes: [Int]
+    /// WS-B Stage B hardening: same-round TOCTOU guard. The scheduler's admission loop can
+    /// call `canAdmit` for MULTIPLE free slots within a single `budgetedStep()` pass, before
+    /// any of those candidates' `admitStep` has actually run — so `arenaBytes` alone is stale
+    /// for the 2nd+ peek in that pass (each would see the same pre-round `committed` total,
+    /// letting several individually-fitting big admits blow the aggregate budget together —
+    /// exactly the concurrent-burst collapse this gate exists to stop). `reservedBytes` holds
+    /// the running total of `canAdmit`-approved-but-not-yet-committed candidates; `admitStep`
+    /// releases a candidate's hold (symmetric subtract, same formula) the moment it starts
+    /// first-call setup for it, whether that setup succeeds or fails.
+    private var reservedBytes: Int = 0
     private var batch: SeedlessLaneBatch? = nil
     private var batchLanes: [ObjectIdentifier] = []   // active-set key for rebuild
     // #121 prefix-cache-aware admission: cross-request decode states (persistentStateData
@@ -57,15 +77,17 @@ public final class LaneBatchSlots: BatchSlots {
     /// Gate observability (mirrors SeedlessBackend.prefixRAMHits): warm restores this process.
     public private(set) var restoreHits = 0
 
-    public init?(store: WeightStore, slots: Int, maxSeqLen: Int) {
+    public init?(store: WeightStore, slots: Int, maxSeqLen: Int, kvBudgetBytes: Int) {
         self.engine = SeedlessEngine.build(store: store)
         // Driver = weights + M=slots scratch; its own caches are never advanced.
         guard let (drv, _) = engine.makeFused(maxM: Swift.max(8, slots), maxSeqLen: 8) else { return nil }
         self.driver = drv
         self.slotCount = slots
         self.maxSeqLen = maxSeqLen
+        self.kvBudgetBytes = kvBudgetBytes
         self.lanes = Array(repeating: nil, count: slots)
         self.prefills = Array(repeating: nil, count: slots)
+        self.arenaBytes = Array(repeating: 0, count: slots)
         // One knob: QWISP_LANE_PREFIX_MB total budget (default 3072, resident tier) —
         // 1/3 recurrence tier, 2/3 conversation tier. 0 disables.
         let mb = Swift.max(0, Tell.envInt("QWISP_LANE_PREFIX_MB", 3072))
@@ -133,13 +155,40 @@ public final class LaneBatchSlots: BatchSlots {
         ]
     }
 
+    /// Pure self-check (no GPU, no model): WS-B Stage B ctx-adaptive sizing policy
+    /// (`LaneBackend.sizePlan`). `oversized` must be computed from headroom ≤ 0 BEFORE
+    /// `cachedGenBudget` (whose `max(1, …)` floor never signals "too big"); the genBudget
+    /// reuses `SeedlessBackend.cachedGenBudget` verbatim (notes/22 fact 3).
+    public static func lanesizeSelfCheck() -> [(String, Bool)] {
+        // 1. unset maxTokens (until-EOS): a 35K prompt in a 262K ctx admits with the gen cap.
+        let p1 = LaneBackend.sizePlan(promptLen: 35_000, maxTokens: -1, ctxMax: 262_144, genCap: 16_384)
+        let c1 = !p1.oversized && p1.genBudget == 16_384 && p1.seqBudget == 35_000 + 1 + 16_384
+        // 2. explicit maxTokens capped by the gen cap; expected genBudget via the real function.
+        let ceiling2 = Swift.min(100_000, 32_768 - 1_000 - 1)
+        let expect2 = SeedlessBackend.cachedGenBudget(promptLen: 1_000, ceiling: ceiling2, arenaMax: 32_768, genCap: 16_384)
+        let p2 = LaneBackend.sizePlan(promptLen: 1_000, maxTokens: 100_000, ctxMax: 32_768, genCap: 16_384)
+        let c2 = !p2.oversized && p2.genBudget == expect2
+        // 3. prompt ≥ ctx: headroom ≤ 0 → oversized (must NOT be masked by the genBudget floor).
+        let p3 = LaneBackend.sizePlan(promptLen: 40_000, maxTokens: -1, ctxMax: 32_768, genCap: 16_384)
+        let c3 = p3.oversized == true
+        // 4. legacy shape: seqBudget is exactly prompt + 1 + genBudget.
+        let p4 = LaneBackend.sizePlan(promptLen: 100, maxTokens: 50, ctxMax: 8_192, genCap: 16_384)
+        let c4 = !p4.oversized && p4.seqBudget == 100 + 1 + p4.genBudget
+        return [
+            ("unset_maxtokens", c1),
+            ("explicit_capped", c2),
+            ("prompt_too_big", c3),
+            ("legacy_shape", c4),
+        ]
+    }
+
     /// Fresh lane forward with the canonical hybrid wiring (same trios as TellRuntime's
     /// hybrid setup). maxM 1024 = the canonical steel-hybrid prefill chunk (the shipped
     /// serialize path prefills hybrid@1024; the canonical greedy stream is defined WITH
     /// it — raw chunked prefill produces the pre-hybrid stream and diverges ~100 tokens
     /// in on f16 near-ties). Costs ~200MB scratch per active lane, resident tier.
-    private func makeLane(hybrid: Bool) -> (SeedlessFusedVerify.SeedlessFusedForward, MTLBuffer)? {
-        guard let (fwd, fnBuf) = engine.makeFused(maxM: 1024, maxSeqLen: maxSeqLen) else { return nil }
+    private func makeLane(hybrid: Bool, seqLen: Int) -> (SeedlessFusedVerify.SeedlessFusedForward, MTLBuffer)? {
+        guard let (fwd, fnBuf) = engine.makeFused(maxM: 1024, maxSeqLen: seqLen) else { return nil }
         if hybrid {
             var hw: [Int: (qkv: (MLXArray, MLXArray, MLXArray), z: (MLXArray, MLXArray, MLXArray), out: (MLXArray, MLXArray, MLXArray))] = [:]
             var aw: [Int: (q: (MLXArray, MLXArray, MLXArray), k: (MLXArray, MLXArray, MLXArray), v: (MLXArray, MLXArray, MLXArray), o: (MLXArray, MLXArray, MLXArray))] = [:]
@@ -164,6 +213,28 @@ public final class LaneBatchSlots: BatchSlots {
         return (fwd, fnBuf)
     }
 
+    /// WS-B Stage B (notes/22): wired KV-cache bytes per token per active lane. attn layers
+    /// only (GDN layers carry conv/rec state, not a per-token growing cache) — numKV=2,
+    /// headDim=256 are this model's fixed attention shape (same constants used throughout
+    /// the engine, e.g. QwispModel/AttentionLayer). f16 K + f16 V = 2 * 2 bytes/element.
+    func kvBytesPerToken() -> Int {
+        let numKV = 2, headDim = 256
+        return engine.layers.reduce(0) { sum, spec in
+            spec.attn != nil ? sum + numKV * headDim * 2 * 2 : sum
+        }
+    }
+
+    /// WS-B Stage B aggregate memory gate (the PR #135 collapse guard): can a request needing
+    /// `seqBudget` arena tokens be admitted without blowing the lane KV byte budget? Ceil-grant
+    /// against the bytes ALREADY committed by other slots' allocated arenas (see `arenaBytes`).
+    public func canAdmit(promptLen: Int, seqBudget: Int) -> Bool {
+        let committed = arenaBytes.reduce(0, +) + reservedBytes
+        let candidate = Swift.min(seqBudget, maxSeqLen) * kvBytesPerToken()
+        guard committed + candidate <= kvBudgetBytes else { return false }
+        reservedBytes += candidate   // hold until this candidate's admitStep resolves it
+        return true
+    }
+
     /// Atomic prefill (thin wrapper, WS-B Stage A): drive `admitStep` to completion with
     /// an effectively-unbounded budget — one call, same result as the old atomic loop.
     public func admit(prompt: [Int32], slot: Int) -> Int? {
@@ -176,20 +247,51 @@ public final class LaneBatchSlots: BatchSlots {
         }
     }
 
-    /// Resumable prefill (WS-B Stage A, notes/21): advances `slot`'s prefill by at most
-    /// `tokenBudget` tokens, always by ≥1 legal chunk (forward-progress guarantee — see
-    /// the `!first` guard below), pausing only at the same internal chunk / `captureAt`
-    /// boundaries the old atomic loop would stop at. Setup (restore-plan lookup + lane
-    /// creation) happens once per admission, on the first call for a slot.
+    /// Legacy 3-arg entry point: size the arena at the init-time fixed cap (`seqBudget: 0` is
+    /// the LEGACY SENTINEL, not oversized/invalid — WS-B Stage B, notes/22).
     public func admitStep(prompt: [Int32], slot: Int, tokenBudget: Int) -> AdmitProgress {
-        guard slot >= 0, slot < slotCount, !prompt.isEmpty, prompt.count < maxSeqLen else { return .failed }
+        admitStep(prompt: prompt, slot: slot, tokenBudget: tokenBudget, seqBudget: 0)
+    }
+
+    /// Resumable, ctx-adaptive prefill (WS-B Stage A notes/21 + Stage B notes/22): advances
+    /// `slot`'s prefill by at most `tokenBudget` tokens, always by ≥1 legal chunk
+    /// (forward-progress guarantee — see the `!first` guard below), pausing only at the same
+    /// internal chunk / `captureAt` boundaries the old atomic loop would stop at. Setup
+    /// (arena sizing + restore-plan lookup + lane creation) happens once per admission, on the
+    /// first call for a slot; `seqBudget` (the caller's `sizePlan` result) sizes THIS lane's
+    /// arena, clamped to `maxSeqLen` (now the model-context ELIGIBILITY cap, not the allocation
+    /// size) — `0` reuses `maxSeqLen` verbatim (legacy shape, unchanged behavior).
+    public func admitStep(prompt: [Int32], slot: Int, tokenBudget: Int, seqBudget: Int) -> AdmitProgress {
+        guard slot >= 0, slot < slotCount, !prompt.isEmpty else { return .failed }
         var st: Prefill
         if let existing = prefills[slot] {
             st = existing
         } else {
+            var seqLen = seqBudget > 0 ? Swift.min(seqBudget, maxSeqLen) : maxSeqLen
+            // Release this candidate's canAdmit hold (same formula, symmetric) now that its
+            // first-call setup is actually starting — regardless of whether setup goes on to
+            // succeed or fail below, the reservation is resolved either way. seqBudget == 0
+            // (legacy sentinel / the 3-arg atomic path) never went through canAdmit, so nothing
+            // to release.
+            if seqBudget > 0 {
+                reservedBytes = Swift.max(0, reservedBytes - seqLen * kvBytesPerToken())
+            }
+            guard prompt.count < seqLen else { return .failed }
+            // Clamp-to-fit: this single request's own arena alone exceeds the aggregate KV
+            // budget — shrink it to what fits rather than refusing outright. Only fails if even
+            // the clamped arena can't hold the prompt plus ≥1 generated token.
+            let perTok = kvBytesPerToken()
+            if perTok > 0, seqLen * perTok > kvBudgetBytes {
+                seqLen = kvBudgetBytes / perTok
+                guard seqLen >= prompt.count + 2 else {
+                    FileHandle.standardError.write(Data(
+                        "[qwisp] NOTE: lane admit dropped — prompt (\(prompt.count) tokens) doesn't fit the lane KV budget (\(kvBudgetBytes) bytes) even after clamping.\n".utf8))
+                    return .failed
+                }
+            }
             let hybrid = ProcessInfo.processInfo.environment["QWISP_HYBRID_PREFILL"] != "0"
             let chunkSize = hybrid ? 1024 : 64
-            guard var (fwd, fnBuf) = makeLane(hybrid: hybrid) else { return .failed }
+            guard var (fwd, fnBuf) = makeLane(hybrid: hybrid, seqLen: seqLen) else { return .failed }
             // #121: restore the longest cached prefix, prefill only the delta.
             // Default ON; QWISP_LANE_PREFIX=0 (or _MB=0) opts out. dropLast ⇒ a hit never
             // swallows the whole prompt (the last position is always recomputed for the
@@ -212,12 +314,17 @@ public final class LaneBatchSlots: BatchSlots {
                     } else {
                         // Shape/format mismatch half-writes the arena — this lane is unusable.
                         // Cannot happen with same-engine blobs; rebuild fresh and go cold.
-                        guard let fresh = makeLane(hybrid: hybrid) else { return .failed }
+                        guard let fresh = makeLane(hybrid: hybrid, seqLen: seqLen) else { return .failed }
                         (fwd, fnBuf) = fresh
                         plan.restoreLen = 0
                     }
                 }
             }
+            // Ceil-grant (WS-B Stage B, notes/22 B2.3): commit the arena's bytes as soon as it's
+            // actually allocated, not when the admit finally completes — the self-check's
+            // MemFake deliberately uses floor-grant (commits on .done) for a simpler test model;
+            // do not "fix" one to match the other.
+            arenaBytes[slot] = seqLen * perTok
             st = Prefill(fwd: fwd, fnBuf: fnBuf, hybrid: hybrid, chunkSize: chunkSize,
                         plan: plan, pos: plan.restoreLen, lastNormed: nil)
         }
@@ -285,6 +392,7 @@ public final class LaneBatchSlots: BatchSlots {
         guard slot >= 0, slot < slotCount else { return }
         lanes[slot] = nil
         prefills[slot] = nil   // drop an aborted mid-admission's SeedlessFusedForward
+        arenaBytes[slot] = 0   // WS-B Stage B: free this slot's KV-budget reservation
         batch = nil; batchLanes = []   // active set changed
     }
 }
@@ -297,6 +405,7 @@ public final class LaneBatchSlots: BatchSlots {
 public final class LaneBackend: LLMBackend, @unchecked Sendable {
     let scheduler: ContinuousScheduler
     let laneCtx: Int
+    let genCap: Int
     public let slots: Int
 
     public convenience init(modelDir: String, tier: SeedlessTier) throws {
@@ -310,14 +419,34 @@ public final class LaneBackend: LLMBackend, @unchecked Sendable {
         }
         let store = try WeightStore(modelDir: modelDir)
         store.residentAll()
-        let ctx = Swift.min(SeedlessBackend.readContextLen(modelDir),
-                            Swift.max(2048, Tell.envInt("QWISP_LANE_CTX", 16384)))
-        guard let laneSlots = LaneBatchSlots(store: store, slots: slots, maxSeqLen: ctx) else {
+        // WS-B Stage B (notes/22): QWISP_LANE_CTX is an OVERRIDE-only knob now — unset means
+        // "use the full model context" (ctx-adaptive sizing below decides the real per-request
+        // arena), explicit means "never exceed this, even if the model context is larger".
+        // Tell.envInt's default-fallback can't distinguish unset-vs-explicit, so this one read
+        // goes straight through ProcessInfo. All three env reads for this backend live ONLY
+        // here — never inside ContinuousScheduler or LaneBatchSlots — so their self-checks stay
+        // deterministic.
+        let modelCtx = SeedlessBackend.readContextLen(modelDir)
+        let ctx: Int
+        if let raw = ProcessInfo.processInfo.environment["QWISP_LANE_CTX"], let explicit = Int(raw) {
+            ctx = Swift.min(modelCtx, Swift.max(2048, explicit))
+        } else {
+            ctx = modelCtx
+        }
+        let genCap = Swift.max(1024, Tell.envInt("QWISP_LANE_GEN_MAX", 16384))
+        // KV budget: the PR #135 collapse guard (aggregate lane arenas can otherwise blow past
+        // wired memory on large-context concurrent admits). 8GB default on ≥48GB boxes, 4GB
+        // below — plenty of headroom either way once resident expert weights are accounted for.
+        let kvBudgetBytes = Tell.envInt("QWISP_LANE_KV_MB",
+            DeviceCalibration.physicalRAMGB() >= 48 ? 8192 : 4096) * 1_048_576
+        guard let laneSlots = LaneBatchSlots(store: store, slots: slots, maxSeqLen: ctx,
+                                             kvBudgetBytes: kvBudgetBytes) else {
             throw NSError(domain: "qwisp", code: 7, userInfo: [NSLocalizedDescriptionKey:
                 "lane batching: engine build failed"])
         }
         self.slots = slots
         self.laneCtx = ctx
+        self.genCap = genCap
         // WS-B Stage A (notes/21): token-budget admission scheduler. Default ON as of the
         // GO-bar bench (notes/21 "Bench verification results", 2026-07-25): a 24K-token
         // concurrent admit's worst-case stall on another lane's decode stream drops from
@@ -330,9 +459,29 @@ public final class LaneBackend: LLMBackend, @unchecked Sendable {
         self.scheduler = ContinuousScheduler(slots: laneSlots, tokenBudget: budget)
     }
 
+    /// Ctx-adaptive sizing policy (WS-B Stage B, notes/22 Contract B1): from a request's
+    /// prompt length and requested maxTokens, decide the per-admit gen budget and the arena
+    /// size (seqBudget). `oversized` = the prompt leaves no room for even one generated token
+    /// (headroom ≤ 0); the caller must check it FIRST and never submit — the `cachedGenBudget`
+    /// floor of `max(1, …)` would otherwise silently succeed (notes/22 Subtlety 1).
+    public static func sizePlan(promptLen: Int, maxTokens: Int, ctxMax: Int, genCap: Int)
+        -> (genBudget: Int, seqBudget: Int, oversized: Bool) {
+        let headroom = ctxMax - promptLen - 1
+        guard headroom > 0 else { return (genBudget: 0, seqBudget: 0, oversized: true) }
+        let ceiling = maxTokens < 0 ? headroom : Swift.min(maxTokens, headroom)
+        let genBudget = SeedlessBackend.cachedGenBudget(promptLen: promptLen, ceiling: ceiling,
+                                                         arenaMax: ctxMax, genCap: genCap)
+        return (genBudget: genBudget, seqBudget: promptLen + 1 + genBudget, oversized: false)
+    }
+
     public func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncStream<Int> {
-        let headroom = Swift.max(0, laneCtx - prompt.count - 1)
-        let ceiling = options.maxTokens < 0 ? headroom : Swift.min(options.maxTokens, headroom)
-        return scheduler.submit(prompt: prompt, maxTokens: ceiling, stopIds: options.stopTokens)
+        let plan = LaneBackend.sizePlan(promptLen: prompt.count, maxTokens: options.maxTokens,
+                                        ctxMax: laneCtx, genCap: genCap)
+        guard !plan.oversized else {
+            FileHandle.standardError.write(Data(
+                "[qwisp] NOTE: prompt (\(prompt.count) tokens) leaves no room to generate in the \(laneCtx)-token lane context — request dropped.\n".utf8))
+            return AsyncStream { $0.finish() }
+        }
+        return scheduler.submit(prompt: prompt, maxTokens: plan.genBudget, stopIds: options.stopTokens)
     }
 }

--- a/swift/Sources/QwispCore/LaneServe.swift
+++ b/swift/Sources/QwispCore/LaneServe.swift
@@ -174,12 +174,39 @@ public final class LaneBatchSlots: BatchSlots {
         // 4. legacy shape: seqBudget is exactly prompt + 1 + genBudget.
         let p4 = LaneBackend.sizePlan(promptLen: 100, maxTokens: 50, ctxMax: 8_192, genCap: 16_384)
         let c4 = !p4.oversized && p4.seqBudget == 100 + 1 + p4.genBudget
+        // 5-7. Arena ALLOCATION size vs the eligibility cap (notes/22 addendum finding 3).
+        // maxSeqLen is the model-context eligibility cap (262144); using it as the legacy
+        // allocation size allocated 5.37GB per lane, ungated (canAdmit runs only on the
+        // budgeted path) — measured as a flag-off B≥2 throughput collapse. The legacy
+        // sentinel must keep the OLD fixed cap so QWISP_TOKEN_BUDGET_SCHED=0 stays
+        // bit-for-bit legacy, arena included.
+        let c5 = arenaSeqLen(seqBudget: 0, maxSeqLen: 262_144) == legacyArenaCap
+        // A small eligibility cap still wins over the legacy cap (never allocate past it).
+        let c6 = arenaSeqLen(seqBudget: 0, maxSeqLen: 8_192) == 8_192
+        // Budgeted path is unchanged: per-request size, clamped to the eligibility cap.
+        let c7 = arenaSeqLen(seqBudget: 51_385, maxSeqLen: 262_144) == 51_385
+            && arenaSeqLen(seqBudget: 300_000, maxSeqLen: 262_144) == 262_144
         return [
             ("unset_maxtokens", c1),
             ("explicit_capped", c2),
             ("prompt_too_big", c3),
             ("legacy_shape", c4),
+            ("legacy_arena_fixed_cap", c5),
+            ("legacy_arena_respects_ctx", c6),
+            ("budgeted_arena_per_request", c7),
         ]
+    }
+
+    /// WS-B Stage B: the arena ALLOCATION size for one admission. `seqBudget > 0` is the
+    /// budgeted path's per-request size, clamped to the eligibility cap. `seqBudget == 0`
+    /// is the LEGACY SENTINEL and keeps the OLD FIXED CAP — `maxSeqLen` became the
+    /// model-context eligibility cap (262144) in Stage B, so reusing it here allocated a
+    /// 16x arena (335MB → 5.37GB per lane) on a path `canAdmit` never gates. See notes/22
+    /// addendum finding 3 for the measurement.
+    public static let legacyArenaCap = 16_384
+    public static func arenaSeqLen(seqBudget: Int, maxSeqLen: Int) -> Int {
+        seqBudget > 0 ? Swift.min(seqBudget, maxSeqLen)
+                      : Swift.min(legacyArenaCap, maxSeqLen)
     }
 
     /// Fresh lane forward with the canonical hybrid wiring (same trios as TellRuntime's
@@ -247,8 +274,9 @@ public final class LaneBatchSlots: BatchSlots {
         }
     }
 
-    /// Legacy 3-arg entry point: size the arena at the init-time fixed cap (`seqBudget: 0` is
-    /// the LEGACY SENTINEL, not oversized/invalid — WS-B Stage B, notes/22).
+    /// Legacy 3-arg entry point: size the arena at the legacy fixed cap (`seqBudget: 0` is
+    /// the LEGACY SENTINEL, not oversized/invalid — WS-B Stage B, notes/22). See
+    /// `arenaSeqLen` for why that cap is NOT `maxSeqLen` any more.
     public func admitStep(prompt: [Int32], slot: Int, tokenBudget: Int) -> AdmitProgress {
         admitStep(prompt: prompt, slot: slot, tokenBudget: tokenBudget, seqBudget: 0)
     }
@@ -260,14 +288,14 @@ public final class LaneBatchSlots: BatchSlots {
     /// (arena sizing + restore-plan lookup + lane creation) happens once per admission, on the
     /// first call for a slot; `seqBudget` (the caller's `sizePlan` result) sizes THIS lane's
     /// arena, clamped to `maxSeqLen` (now the model-context ELIGIBILITY cap, not the allocation
-    /// size) — `0` reuses `maxSeqLen` verbatim (legacy shape, unchanged behavior).
+    /// size) — `0` falls back to `legacyArenaCap` (see `arenaSeqLen`).
     public func admitStep(prompt: [Int32], slot: Int, tokenBudget: Int, seqBudget: Int) -> AdmitProgress {
         guard slot >= 0, slot < slotCount, !prompt.isEmpty else { return .failed }
         var st: Prefill
         if let existing = prefills[slot] {
             st = existing
         } else {
-            var seqLen = seqBudget > 0 ? Swift.min(seqBudget, maxSeqLen) : maxSeqLen
+            var seqLen = LaneBatchSlots.arenaSeqLen(seqBudget: seqBudget, maxSeqLen: maxSeqLen)
             // Release this candidate's canAdmit hold (same formula, symmetric) now that its
             // first-call setup is actually starting — regardless of whether setup goes on to
             // succeed or fail below, the reservation is resolved either way. seqBudget == 0

--- a/swift/Sources/QwispCore/SeedlessVerifyTests.swift
+++ b/swift/Sources/QwispCore/SeedlessVerifyTests.swift
@@ -49,7 +49,7 @@ public enum SeedlessVerifyTests {
         MLXRandom.seed(UInt64(42))
         var lines: [String] = []
         var passed = 0
-        let total = 96
+        let total = 97
 
         // Nested runner: records result and increments counter
         func run(_ name: String, body: () -> (Bool, String)) {
@@ -5964,6 +5964,165 @@ public enum SeedlessVerifyTests {
             let frac = Double(agree) / Double(ra.count)
             if frac < 0.99 { return (false, "argmax agree \(agree)/\(ra.count) = \(frac) < 0.99") }
             return (true, "ok maxΔ=\(maxAbs) agree=\(agree)/\(ra.count)")
+        }
+
+        // ── WS-B Stage B #141: cross-arena lane restore (notes/22b) ──────────
+        // WRITE-LOCKED (guarded by total = 97). Do not weaken/skip/delete.
+        //
+        // Test 97: lane_admit_restore_cross_arena_bitexact
+        // Stage B sizes each lane's arena per request, so a persistentStateData blob
+        // captured on a lane whose arena is S1 routinely lands in a lane sized S2 ≠ S1
+        // (#121 prefix-cache fan-out). Before Stage B every lane shared one arena size,
+        // so this path was never exercised. The wire format is arena-size-independent
+        // by construction (used-slice save, DESTINATION-stride restore, len ≤ maxLen
+        // validation) — this test locks that, plus notes/22 "fact 1":
+        //   1. grow  S1 → S2: restored lane ≡ cold lane at S2 (delta out + all caches).
+        //   2. shrink S2 → S1: same. This is the direction that breaks if restore ever
+        //      wrote at the SOURCE's stride instead of the destination's.
+        //   3. A blob whose saved len exceeds the destination's maxLen is REFUSED
+        //      (returns false) — never silently truncated; caller falls back to cold.
+        //   4. Lanes with DIFFERENT maxSeqLen ride ONE SeedlessLaneBatch and agree with
+        //      each other and with a solo stepArgmax (heterogeneous arenas kernel-safe).
+        // Placed last so it does not shift the shared MLXRandom stream of tests 1-96.
+        // S3 = 20 (notes/22b sketched 4): the shared fixture seeds a 16-token KV cache,
+        // so an arena below 16 is not constructible — 20 still refuses the 21-row blob.
+        run("lane_admit_restore_cross_arena_bitexact") {
+            let H = 2048, E = 16, I = 512, vocab = 1024
+            func q4(_ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine); return (q, s, b!)
+            }
+            func q8(_ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 8, mode: .affine); return (q, s, b!)
+            }
+            func q4e(_ e: Int, _ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([e, n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine); return (q, s, b!)
+            }
+            func mkMoE() -> SeedlessVerifyForward.MoEBlockW {
+                let (gW, gS, gB) = q8(E, H); let (sgW, sgS, sgB) = q8(8, H)
+                let (a0, a1, a2) = q4e(E, I, H); let (b0, b1, b2) = q4e(E, I, H); let (c0, c1, c2) = q4e(E, H, I)
+                let (d0, d1, d2) = q4(I, H); let (e0, e1, e2) = q4(I, H); let (f0, f1, f2) = q4(H, I)
+                return SeedlessVerifyForward.MoEBlockW(gateWq: gW, gateSc: gS, gateBi: gB,
+                    swGWq: a0, swGSc: a1, swGBi: a2, swUWq: b0, swUSc: b1, swUBi: b2,
+                    swDWq: c0, swDSc: c1, swDBi: c2, shGWq: d0, shGSc: d1, shGBi: d2,
+                    shUWq: e0, shUSc: e1, shUBi: e2, shDWq: f0, shDSc: f1, shDBi: f2,
+                    sharedGateWq: sgW, sharedGateSc: sgS, sharedGateBi: sgB)
+            }
+            let Hk = 16, Dk = 128, Hv = 32, Dv = 128, cK = 4
+            let convDim = Hk * Dk * 2 + Hv * Dv
+            let (qkvW, qkvS, qkvB) = q4(convDim, H); let (zW, zS, zB) = q4(Hv * Dv, H)
+            let (bW, bS, bB) = q4(Hv, H); let (aW, aS, aB) = q4(Hv, H); let (oW, oS, oB) = q4(H, Hv * Dv)
+            let gdnW = SeedlessVerifyForward.GDNLayerW(qkvWq: qkvW, qkvSc: qkvS, qkvBi: qkvB,
+                zWq: zW, zSc: zS, zBi: zB, bWq: bW, bSc: bS, bBi: bB, aWq: aW, aSc: aS, aBi: aB,
+                outWq: oW, outSc: oS, outBi: oB,
+                conv1dW: MLXRandom.normal([convDim, cK]).asType(.float16),
+                normWeight: MLXRandom.normal([Dv]).asType(.float16),
+                aLog: MLXRandom.normal([Hv]).asType(.float32), dtBias: MLXRandom.normal([Hv]).asType(.float32))
+            let nH = 16, nKV = 2, hD = 256
+            let (aqW, aqS, aqB) = q4(nH * 2 * hD, H); let (akW, akS, akB) = q4(nKV * hD, H)
+            let (avW, avS, avB) = q4(nKV * hD, H); let (aoW, aoS, aoB) = q4(H, nH * hD)
+            let attnW = SeedlessVerifyForward.AttnLayerW(qWq: aqW, qSc: aqS, qBi: aqB, kWq: akW, kSc: akS, kBi: akB,
+                vWq: avW, vSc: avS, vBi: avB, oWq: aoW, oSc: aoS, oBi: aoB,
+                qNorm: MLXRandom.normal([hD]).asType(.float16), kNorm: MLXRandom.normal([hD]).asType(.float16))
+            let layers = [
+                SeedlessVerifyForward.LayerSpec(isLinear: true,
+                    inputLN: MLXRandom.normal([H]).asType(.float16), postLN: MLXRandom.normal([H]).asType(.float16),
+                    gdn: gdnW, attn: nil, moe: mkMoE(), moeE: E, moeI: I),
+                SeedlessVerifyForward.LayerSpec(isLinear: false,
+                    inputLN: MLXRandom.normal([H]).asType(.float16), postLN: MLXRandom.normal([H]).asType(.float16),
+                    gdn: nil, attn: attnW, moe: mkMoE(), moeE: E, moeI: I),
+            ]
+            let (eW, eS, eB) = q4(vocab, H)
+            let (lW, lS, lB) = q4(vocab, H)
+            let fnW = MLXRandom.normal([H]).asType(.float16)
+            let cs0 = MLXRandom.normal([cK - 1, convDim]).asType(.float16)
+            let rs0 = MLXRandom.normal([1, Hv, Dv, Dk]).asType(.float32)
+            let kC0 = MLXRandom.normal([nKV, 16, hD]).asType(.float16)
+            let vC0 = MLXRandom.normal([nKV, 16, hD]).asType(.float16)
+            MLX.eval([cs0, rs0, kC0, vC0, eW, eS, eB, lW, lS, lB, fnW])
+            func freshCaches() -> [SeedlessVerifyForward.LayerCaches] {
+                [SeedlessVerifyForward.LayerCaches(convState: cs0, recState: rs0),
+                 SeedlessVerifyForward.LayerCaches(kCache: kC0, vCache: vC0)]
+            }
+            // The one structural difference from test 92: arena size is a parameter.
+            func mkFwd(_ seqLen: Int) -> SeedlessFusedVerify.SeedlessFusedForward? {
+                SeedlessFusedVerify.SeedlessFusedForward(layers: layers, caches: freshCaches(),
+                                                         maxM: 4, H: H, maxSeqLen: seqLen)
+            }
+            let S1 = 32, S2 = 128, S3 = 20
+            let W3 = MLXRandom.normal([3, H]).asType(.float16)
+            let Dx = MLXRandom.normal([2, H]).asType(.float16)
+            MLX.eval([W3, Dx])
+
+            // Donor at `src` saves at the W3 boundary; a cold and a restored lane at
+            // `dst` then run the SAME delta chunk. Returns (restored, cold) at `dst`.
+            var err = ""
+            func cross(_ src: Int, _ dst: Int)
+                -> (SeedlessFusedVerify.SeedlessFusedForward, SeedlessFusedVerify.SeedlessFusedForward)? {
+                let tag = "\(src)→\(dst)"
+                guard let donor = mkFwd(src), donor.forwardRows(W3, M: 3) != nil
+                else { err = "donor init/forward nil \(tag)"; return nil }
+                let blob = donor.persistentStateData()
+                guard let cold = mkFwd(dst), cold.forwardRows(W3, M: 3) != nil
+                else { err = "cold init/forward nil \(tag)"; return nil }
+                guard let rest = mkFwd(dst) else { err = "restored init nil \(tag)"; return nil }
+                guard rest.restorePersistentState(blob) else { err = "restore false \(tag)"; return nil }
+                guard let outC = cold.forwardRows(Dx, M: 2), let outR = rest.forwardRows(Dx, M: 2)
+                else { err = "delta forward nil \(tag)"; return nil }
+                outC.eval(); outR.eval()
+                let (hOk, hDet) = bitEqual(outR, outC)
+                if !hOk { err = "delta h \(tag): \(hDet)"; return nil }
+                for (li, names) in [(0, ("convState", "recState")), (1, ("kCache", "vCache"))] {
+                    let (ra, rb) = rest.readLayerCache(li)
+                    let (ca, cb) = cold.readLayerCache(li)
+                    for (x, y, nm) in [(ra, ca, names.0), (rb, cb, names.1)] {
+                        guard let xx = x, let yy = y else { err = "\(nm) nil \(tag)"; return nil }
+                        let (ok, det) = bitEqual(xx, yy)
+                        if !ok { err = "\(nm) \(tag): \(det)"; return nil }
+                    }
+                }
+                return (rest, cold)
+            }
+            // (1) grow, (2) shrink.
+            guard let (restS2, _) = cross(S1, S2) else { return (false, err) }
+            guard let (_, coldS1) = cross(S2, S1) else { return (false, err) }
+
+            // (3) Oversized blob refused: 16 seeded rows + W3 + Dx = 21 > S3 = 20.
+            guard let big = mkFwd(S1), big.forwardRows(W3, M: 3) != nil,
+                  big.forwardRows(Dx, M: 2) != nil
+            else { return (false, "oversized donor init/forward nil") }
+            guard let small = mkFwd(S3) else { return (false, "S3 init nil") }
+            if small.restorePersistentState(big.persistentStateData()) {
+                return (false, "oversized blob accepted into maxLen=\(S3)")
+            }
+
+            // (4) Mixed-arena batch: restored@S2 and cold@S1 in ONE SeedlessLaneBatch,
+            // both tracking a solo lane token-for-token.
+            guard let solo = mkFwd(S2),
+                  solo.attachHead(embedW: eW, embedS: eS, embedB: eB, lmW: lW, lmS: lS, lmB: lB,
+                                  fnW: fnW, vocab: vocab),
+                  solo.forwardRows(W3, M: 3) != nil, solo.forwardRows(Dx, M: 2) != nil
+            else { return (false, "solo init/forward nil") }
+            guard let drv = SeedlessFusedVerify.SeedlessFusedForward(layers: layers, caches: freshCaches(),
+                                                                     maxM: 8, H: H, maxSeqLen: S2),
+                  drv.attachHead(embedW: eW, embedS: eS, embedB: eB, lmW: lW, lmS: lS, lmB: lB,
+                                 fnW: fnW, vocab: vocab),
+                  let batch = SeedlessLaneBatch(driver: drv, lanes: [restS2, coldS1])
+            else { return (false, "driver/batch init nil") }
+            var tok: Int32 = 7
+            for step in 0 ..< 3 {
+                guard let r = solo.stepArgmax([tok]), r.count == 1
+                else { return (false, "solo stepArgmax nil step=\(step)") }
+                guard let got = batch.stepArgmaxBatch([tok, tok])
+                else { return (false, "batch nil step=\(step)") }
+                if got[0] != got[1] || got[0] != r[0] {
+                    return (false, "tokens step=\(step): got \(got) want \(r[0])")
+                }
+                tok = Int32(got[0])
+            }
+            return (true, "ok")
         }
 
         // ── Summary ───────────────────────────────────────────────────────

--- a/swift/Sources/qwisp/Selftest.swift
+++ b/swift/Sources/qwisp/Selftest.swift
@@ -141,6 +141,12 @@ func runCompletionSelftest(modelDir: String) async -> String {
     // token-budget admission scheduler (WS-B Stage A; pure logic over a scripted fake).
     for (name, ok) in ContinuousScheduler.tokenBudgetSelfCheck() { check("tokenbudget_\(name)", ok) }
 
+    // ctx-adaptive lane sizing (WS-B Stage B; pure sizing policy, no GPU).
+    for (name, ok) in LaneBatchSlots.lanesizeSelfCheck() { check("lanesize_\(name)", ok) }
+
+    // aggregate lane memory gate (WS-B Stage B; pure scheduler logic over a byte-budgeted fake).
+    for (name, ok) in ContinuousScheduler.laneMemSelfCheck() { check("lanemem_\(name)", ok) }
+
     // incremental detokenizer (server O(n²) fix; pure fake byte-level tokenizer).
     for (name, ok) in StreamDetok.selfCheck() { check("detok_\(name)", ok) }
 

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -42,8 +42,11 @@ environment:
                                      bit-exact with single-stream — opt-in)
   QWISP_LANES=<B>                    serve only: lane batching with B raw-engine lanes
                                      (parallel sub-agent fan-out; resident ≥32GB, greedy-only,
-                                     BIT-EXACT with single-stream — opt-in). Per-lane context
-                                     capped by QWISP_LANE_CTX (default 16384)
+                                     BIT-EXACT with single-stream — opt-in). Per-lane arena is
+                                     ctx-adaptive (sized per request, up to the model context);
+                                     QWISP_LANE_CTX=<N> overrides the eligibility cap lower.
+                                     QWISP_LANE_GEN_MAX/QWISP_LANE_KV_MB tune the gen-length cap
+                                     and the aggregate lane KV byte budget
 
 first run: `qwisp pull` downloads ~20GB. The first chat/serve request loads the model, and
 on <32GB machines runs a one-time bolt calibration (a few minutes; progress goes to stderr).
@@ -75,7 +78,7 @@ case "serve":
     } else if let ls = Int(ProcessInfo.processInfo.environment["QWISP_LANES"] ?? ""), ls >= 2 {
         // Lane batching (parallel sub-agent fan-out, opt-in): raw-engine lanes on the
         // continuous scheduler — bit-exact with the default serialize path, resident
-        // tier only, greedy only. Per-lane context capped by QWISP_LANE_CTX (16384).
+        // tier only, greedy only. Per-lane arena is ctx-adaptive (QWISP_LANE_CTX overrides).
         print("[qwisp serve] lane batching: B=\(ls) lanes (raw engine, greedy, bit-exact; requests batch instead of queueing)")
         backend = try LaneBackend(modelDir: model, slots: ls)
         batchMode = true

--- a/tools/lane_budget_probe.mjs
+++ b/tools/lane_budget_probe.mjs
@@ -8,6 +8,7 @@
 // Usage: node tools/lane_budget_probe.mjs <host:port> [bigPromptTokens]
 // Output: one JSON line on stdout: {n, p50, p90, p99, max, gapsMs}
 import http from "node:http";
+import { pathToFileURL } from "node:url";
 
 const hostport = process.argv[2] || "127.0.0.1:8080";
 const bigTokens = parseInt(process.argv[3] || "24000", 10);
@@ -50,10 +51,15 @@ function fireStream(body, onDelta) {
 // multi-chunk prefill; exact token count doesn't matter for the ITL comparison. `reps`
 // is the SENTENCE repeat count (bugfix: the original version repeated the whole
 // multi-word sentence `words` times, inflating the prompt ~14x past the target).
-const sentence = "The quick brown fox jumps over the lazy dog near the riverbank at dusk.";
-const sentenceWords = sentence.split(" ").length;
-const reps = Math.max(1, Math.round(bigTokens / 1.3 / sentenceWords));
-const filler = Array(reps).fill(sentence).join(" ");
+// Exported so lane_stage_b_probe.mjs shares ONE copy of this formula — the
+// sentence-repeat bug above must never be re-derived in a second file.
+export function makeFiller(bigTokens) {
+  const sentence = "The quick brown fox jumps over the lazy dog near the riverbank at dusk.";
+  const sentenceWords = sentence.split(" ").length;
+  const reps = Math.max(1, Math.round(bigTokens / 1.3 / sentenceWords));
+  return Array(reps).fill(sentence).join(" ");
+}
+const filler = makeFiller(bigTokens);
 
 async function main() {
   const gaps = [];
@@ -76,4 +82,7 @@ async function main() {
     max: gaps.length ? gaps[gaps.length - 1] : null, gapsMs: gaps,
   }));
 }
-main().catch((e) => { console.error("[lane_budget_probe] error:", e); process.exit(1); });
+// Only run when invoked directly — importing makeFiller must not fire a probe.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main().catch((e) => { console.error("[lane_budget_probe] error:", e); process.exit(1); });
+}

--- a/tools/lane_stage_b_probe.mjs
+++ b/tools/lane_stage_b_probe.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// WS-B Stage B bench probe (notes/22 "Bench verification"): the three Stage B
+// measurements against a running qwisp server. Built-in http only (ponytail —
+// same shape as lane_budget_probe.mjs, whose filler generator it imports so the
+// sentence-repeat formula lives in exactly one place).
+//
+// Usage:
+//   node tools/lane_stage_b_probe.mjs e2e  <host:port> <promptTokens> [maxTokens]
+//   node tools/lane_stage_b_probe.mjs tps  <host:port> <B>            [maxTokens]
+//   node tools/lane_stage_b_probe.mjs conc <host:port> <promptTokens> <N> [maxTokens]
+// Output: one JSON line on stdout.
+import http from "node:http";
+import { makeFiller } from "./lane_budget_probe.mjs";
+
+const [mode, hostport = "127.0.0.1:8080"] = process.argv.slice(2);
+const [host, port] = hostport.split(":");
+
+// Fires one streaming completion; resolves with per-stream timing. `deltas` counts
+// SSE content deltas — a token-count PROXY (the server emits one delta per decoded
+// token today), good enough for a paired ±5% A/B, not an absolute tok/s claim.
+function fireStream(content, maxTokens) {
+  const payload = Buffer.from(JSON.stringify({
+    model: "qwisp", messages: [{ role: "user", content }],
+    max_tokens: maxTokens, stream: true, temperature: 0,
+  }));
+  const t0 = Date.now();
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      host, port, method: "POST", path: "/v1/chat/completions",
+      headers: { "content-type": "application/json", "content-length": payload.length,
+                 authorization: "Bearer sk-noauth" },
+    }, (res) => {
+      let buf = "", deltas = 0, ttft = null, text = "";
+      res.on("data", (c) => {
+        buf += c.toString("utf8");
+        let nl;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+          const line = buf.slice(0, nl).trim(); buf = buf.slice(nl + 1);
+          if (!line.startsWith("data:")) continue;
+          const d = line.slice(5).trim();
+          if (d === "[DONE]") continue;
+          try {
+            const j = JSON.parse(d);
+            const dl = j.choices?.[0]?.delta;
+            const t = dl?.reasoning_content || dl?.content;
+            if (t) { if (ttft === null) ttft = Date.now() - t0; deltas += 1; text += t; }
+          } catch {}
+        }
+      });
+      res.on("end", () => {
+        const totalMs = Date.now() - t0;
+        // Decode rate excludes prefill: (deltas-1) gaps over the post-TTFT window.
+        const decodeMs = ttft === null ? 0 : totalMs - ttft;
+        resolve({
+          status: res.statusCode, deltas, ttftMs: ttft, totalMs,
+          tps: deltas > 1 && decodeMs > 0 ? +((deltas - 1) / (decodeMs / 1000)).toFixed(2) : null,
+          sample: text.slice(0, 120),
+        });
+      });
+      res.on("error", reject);
+    });
+    req.on("error", reject);
+    req.end(payload);
+  });
+}
+
+async function main() {
+  if (mode === "e2e") {
+    // (1) The motivating E2E: a prompt far past the old 16K lane cap must ADMIT
+    // and stream real content. On main this returns an empty 200 (silent no-op).
+    const tokens = parseInt(process.argv[4] || "35000", 10);
+    const maxTokens = parseInt(process.argv[5] || "32", 10);
+    const r = await fireStream(makeFiller(tokens), maxTokens);
+    console.log(JSON.stringify({ mode, promptTokens: tokens, ...r, ok: r.deltas > 0 }));
+    return;
+  }
+  if (mode === "tps") {
+    // (2) No-regression paired A/B: B concurrent SHORT prompts (well under 16K so
+    // adaptive sizing is immaterial) — isolates the sizing overhead itself.
+    const B = parseInt(process.argv[4] || "1", 10);
+    const maxTokens = parseInt(process.argv[5] || "64", 10);
+    const rs = await Promise.all(Array.from({ length: B }, (_, i) =>
+      fireStream(`Count slowly from 1 to ${60 + i}, one number per line, nothing else.`, maxTokens)));
+    const tpsAll = rs.map((r) => r.tps).filter((x) => x != null);
+    const mean = tpsAll.length ? +(tpsAll.reduce((a, b) => a + b, 0) / tpsAll.length).toFixed(2) : null;
+    console.log(JSON.stringify({ mode, B, meanTps: mean, perStream: rs.map((r) => ({ tps: r.tps, deltas: r.deltas, ttftMs: r.ttftMs, status: r.status })) }));
+    return;
+  }
+  if (mode === "conc") {
+    // (3) Footprint gate: N SIMULTANEOUS large admits. N>=3 is the point — the
+    // round-1 reservedBytes TOCTOU guard only bites when budgetedStep peeks at
+    // >=3 free slots in ONE round (2 passes even with the bug).
+    const tokens = parseInt(process.argv[4] || "35000", 10);
+    const N = parseInt(process.argv[5] || "3", 10);
+    const maxTokens = parseInt(process.argv[6] || "16", 10);
+    const filler = makeFiller(tokens);
+    // Distinct suffixes so the prefix cache cannot collapse them into one lane.
+    const rs = await Promise.all(Array.from({ length: N }, (_, i) =>
+      fireStream(`${filler} Request id ${i}. Reply with the id.`, maxTokens)));
+    console.log(JSON.stringify({
+      mode, promptTokens: tokens, N,
+      ok: rs.every((r) => r.deltas > 0),
+      streams: rs.map((r) => ({ deltas: r.deltas, ttftMs: r.ttftMs, totalMs: r.totalMs, status: r.status })),
+    }));
+    return;
+  }
+  console.error("usage: lane_stage_b_probe.mjs e2e|tps|conc <host:port> ...");
+  process.exit(2);
+}
+main().catch((e) => { console.error("[lane_stage_b_probe] error:", e); process.exit(1); });


### PR DESCRIPTION
Closes #141.

Lifts the 16K lane cap that made ~35K-token prompts (the real OpenCode workload) silently unservable in lane mode, and adds the aggregate KV memory gate that makes per-request arena sizing safe.

## What landed

- **B1 core** (`6d36aa7`, pre-existing on branch): `LaneBackend.sizePlan`, `QWISP_LANE_CTX` as an eligibility-cap override (default = model context), new `QWISP_LANE_GEN_MAX` / `QWISP_LANE_KV_MB`, additive `admitStep(...seqBudget:)` + `canAdmit`, FCFS head-of-line wait, per-slot `arenaBytes`/`reservedBytes` TOCTOU guard.
- **Locked test 97** `lane_admit_restore_cross_arena_bitexact` (`3573afc`): locks cross-arena persist/restore (grow S1→S2, shrink S2→S1, oversized refusal) and heterogeneous-arena batch composition. RAWTESTS 96→97 by addition; tests 90-96 untouched.
- **Bench harness + results** (`f72f4d9`, `84e68ef`): `scripts/bench_lane_stage_b.sh` + `tools/lane_stage_b_probe.mjs`, results in notes/22.
- **Regression fix** (`d4f7e27`): see below.

## The bench found a blocking regression, now fixed

The flag-off escape hatch (`QWISP_TOKEN_BUDGET_SCHED=0`) was allocating lane arenas at the *eligibility cap*: raising `laneCtx` 16384 → 262144 turned a 335 MB/lane arena into **5.37 GB/lane**, on the one path `canAdmit` never gates. Measured: flag-off throughput collapsed from 83.9 tok/s at B=1 to **4.8-7.2 at B≥2** (wired-page exhaustion).

Root cause was a contradiction inside notes/22 itself — 16384 was one number doing two jobs. Fixed by splitting eligibility cap from allocation size in a single pure function `LaneBatchSlots.arenaSeqLen`, locked by 3 new COMPTEST cases, and the spec prose reconciled (`500bf97`) so it can't recur.

## Measurements

| gate | result |
|---|---|
| E2E: 30,778-token prompt | **admits and streams**, TTFT 152.7s, 29.6 tok/s |
| control (`QWISP_LANE_CTX=16384`) | refused in 816ms with a visible stderr NOTE |
| no-regression A/B (warmed, one-sided) | worst regression **−2.2%** (B=1); B=2/3/4 favour ON |
| footprint, 3 simultaneous admits | all stream, peak **37,888 MB** (`footprint`, not `ps rss`) |

## Gates

RAWTESTS **97/97** · COMPTEST **93/93** · BENCHBATCHTEST **PASS**

## Known-open (not blocking, recorded in notes/22)

- Oversized prompts fail visibly on **stderr**, but the HTTP surface is still an empty 200 rather than an error status. If spec item 6's "failed stream" meant a non-200/error SSE frame, that half is not done.
- The first bench run's tps rows were invalid (warm-vs-cold confound); the harness now warms both passes identically. Don't quote the pre-fix B≥2 deltas as a speedup — they measure the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)