### PR TITLE
fix(seedless): flag-off lane admit refuses >16K visibly instead of an empty 200

### DIFF
--- a/scripts/bench_lane_budget_ab.sh
+++ b/scripts/bench_lane_budget_ab.sh
@@ -54,19 +54,38 @@ run_pass() {
     cat "$out"
 }
 
-run_pass off ""
-run_pass on  "QWISP_TOKEN_BUDGET_SCHED=1"
+# BUDGETS: one ON pass per value (sweep in ONE session so all arms share the OFF
+# control and the same thermal state — separate invocations would re-pay the ~95s
+# OFF pass per arm and compare across sessions, which notes/20's paired-A/B
+# discipline forbids). STEADY_TOKENS (read by the probe) sets lane 0's stream length.
+BUDGETS="${BUDGETS:-2048}"
+FILES=("/tmp/lane-budget-ab-$TS-off.json")
+# MUST pass =0 explicitly: QWISP_TOKEN_BUDGET_SCHED defaults to 1 since the 2026-07-25
+# GO (LaneServe.swift, notes/21). An empty env here silently ran the ON path as the
+# "OFF" control — both arms then measured identical (k=12, sum within 2.5%).
+run_pass off "QWISP_TOKEN_BUDGET_SCHED=0"
+for b in $BUDGETS; do
+    run_pass "on$b" "QWISP_TOKEN_BUDGET_SCHED=1 QWISP_TOKEN_BUDGET=$b"
+    FILES+=("/tmp/lane-budget-ab-$TS-on$b.json")
+done
 
 echo ""
-echo "== summary =="
-python3 - "/tmp/lane-budget-ab-$TS-off.json" "/tmp/lane-budget-ab-$TS-on.json" << 'EOF'
-import json, sys
-off = json.load(open(sys.argv[1]))
-on = json.load(open(sys.argv[2]))
-print(f"{'':>6} {'n':>4} {'p50':>8} {'p90':>8} {'p99':>8} {'max':>8}  (ms)")
-for name, d in (("OFF", off), ("ON", on)):
-    print(f"{name:>6} {d['n']:>4} {d['p50']:>8} {d['p90']:>8} {d['p99']:>8} {d['max']:>8}")
-if off['p99'] and on['p99']:
-    print(f"\np99 ratio (ON/OFF): {on['p99']/off['p99']:.2f}x")
-    print(f"max ratio (ON/OFF): {on['max']/off['max']:.2f}x")
+echo "== summary (steady stream = ${STEADY_TOKENS:-45} tokens, big prompt = $BIG) =="
+python3 - "${FILES[@]}" << 'EOF'
+import json, sys, os, re
+rows = []
+for path in sys.argv[1:]:
+    label = re.sub(r'^.*?-\d{6}-(.*)\.json$', r'\1', os.path.basename(path))
+    rows.append((label, json.load(open(path))))
+print(f"{'':>9} {'n':>4} {'p50':>8} {'p90':>8} {'p99':>8} {'max':>8}  (ms)")
+for name, d in rows:
+    print(f"{name:>9} {d['n']:>4} {d['p50']:>8} {d['p90']:>8} {d['p99']:>8} {d['max']:>8}")
+# Polluted-gap count is the model's real observable: gaps an order of magnitude above
+# p50 are the prefill-bearing rounds (k). Predicted k = ceil(promptLen / budget).
+print("")
+for name, d in rows:
+    gaps = d.get('gapsMs') or []
+    big = [g for g in gaps if d['p50'] and g > 10 * d['p50']]
+    void = "" if d.get('bTokens') else "   <-- VOID: big admit produced 0 tokens (dropped)"
+    print(f"{name:>9} polluted gaps k={len(big):>3} / n={d['n']:<4} ({100*len(big)/max(1,d['n']):.0f}%)  sum={sum(big)/1000:.1f}s{void}")
 EOF

--- a/swift/Sources/QwispCore/LaneServe.swift
+++ b/swift/Sources/QwispCore/LaneServe.swift
@@ -186,6 +186,29 @@ public final class LaneBatchSlots: BatchSlots {
         // Budgeted path is unchanged: per-request size, clamped to the eligibility cap.
         let c7 = arenaSeqLen(seqBudget: 51_385, maxSeqLen: 262_144) == 51_385
             && arenaSeqLen(seqBudget: 300_000, maxSeqLen: 262_144) == 262_144
+        // 8-11. #151: eligibility must not promise more than the path will allocate.
+        // Regression under test: flag-off admitted a 24K prompt (eligible against the
+        // 262K ctx), then admitStep allocated legacyArenaCap and returned .failed, which
+        // ContinuousBatch.loop() turns into an empty 200 with no NOTE. Capping eligibility
+        // to the allocation makes sizePlan refuse it VISIBLY instead.
+        let c8 = eligibilityCtx(budgetSchedOn: false, ctx: 262_144) == legacyArenaCap
+        // Flag-ON is untouched — the budgeted path sizes each arena from its own seqBudget.
+        let c9 = eligibilityCtx(budgetSchedOn: true, ctx: 262_144) == 262_144
+        // The general invariant, stated once: on the flag-off path the arena actually
+        // allocated for an eligible prompt always covers the whole eligibility window.
+        let c10 = [8_192, 16_384, 32_768, 262_144].allSatisfy { ctx in
+            let elig = eligibilityCtx(budgetSchedOn: false, ctx: ctx)
+            return arenaSeqLen(seqBudget: 0, maxSeqLen: elig) == elig
+        }
+        // The reproduction itself: 24K prompt, model-context ctx. Refused when flag-off,
+        // still served when flag-on.
+        let off11 = LaneBackend.sizePlan(promptLen: 24_000, maxTokens: 3,
+                                         ctxMax: eligibilityCtx(budgetSchedOn: false, ctx: 262_144),
+                                         genCap: 16_384)
+        let on11 = LaneBackend.sizePlan(promptLen: 24_000, maxTokens: 3,
+                                        ctxMax: eligibilityCtx(budgetSchedOn: true, ctx: 262_144),
+                                        genCap: 16_384)
+        let c11 = off11.oversized == true && on11.oversized == false
         return [
             ("unset_maxtokens", c1),
             ("explicit_capped", c2),
@@ -194,6 +217,10 @@ public final class LaneBatchSlots: BatchSlots {
             ("legacy_arena_fixed_cap", c5),
             ("legacy_arena_respects_ctx", c6),
             ("budgeted_arena_per_request", c7),
+            ("flagoff_eligibility_matches_arena", c8),
+            ("flagon_eligibility_unchanged", c9),
+            ("flagoff_arena_covers_eligibility", c10),
+            ("flagoff_24k_refused_visibly", c11),
         ]
     }
 
@@ -207,6 +234,18 @@ public final class LaneBatchSlots: BatchSlots {
     public static func arenaSeqLen(seqBudget: Int, maxSeqLen: Int) -> Int {
         seqBudget > 0 ? Swift.min(seqBudget, maxSeqLen)
                       : Swift.min(legacyArenaCap, maxSeqLen)
+    }
+
+    /// The ELIGIBILITY cap that must pair with `arenaSeqLen`'s ALLOCATION cap (#151).
+    /// Stage B split the two and only the budgeted path re-coupled them (its `seqBudget`
+    /// IS the allocation size). The flag-off path allocates at `legacyArenaCap` via the
+    /// legacy sentinel, so admitting anything longer produced a `.failed` admitStep →
+    /// `ContinuousBatch.loop()`'s `req.finish()` → an empty 200 with no NOTE, for every
+    /// prompt over 16K. Capping eligibility to match routes those prompts to `sizePlan`'s
+    /// EXISTING visible refusal instead. Keep this the only source of that pairing: the
+    /// escape hatch's arena stays bit-for-bit legacy (d4f7e27), it just stops over-promising.
+    public static func eligibilityCtx(budgetSchedOn: Bool, ctx: Int) -> Int {
+        budgetSchedOn ? ctx : Swift.min(ctx, legacyArenaCap)
     }
 
     /// Fresh lane forward with the canonical hybrid wiring (same trios as TellRuntime's
@@ -540,7 +579,12 @@ public final class LaneBackend: LLMBackend, @unchecked Sendable {
                 "lane batching: engine build failed"])
         }
         self.slots = slots
-        self.laneCtx = ctx
+        // #151: eligibility must match the arena the SELECTED path will actually allocate,
+        // so the flag decision has to be read before laneCtx is fixed. `laneSlots` above
+        // keeps the full `ctx` as its maxSeqLen — that is the allocation CLAMP, and the
+        // legacy sentinel narrows it to legacyArenaCap on its own.
+        let budgetSchedOn = Tell.envInt("QWISP_TOKEN_BUDGET_SCHED", 1) != 0
+        self.laneCtx = LaneBatchSlots.eligibilityCtx(budgetSchedOn: budgetSchedOn, ctx: ctx)
         self.genCap = genCap
         // WS-B Stage A (notes/21): token-budget admission scheduler. Default ON as of the
         // GO-bar bench (notes/21 "Bench verification results", 2026-07-25): a 24K-token
@@ -549,7 +593,6 @@ public final class LaneBackend: LLMBackend, @unchecked Sendable {
         // back out to the old atomic drain-then-step. Gate/size env reads live here only,
         // never inside the scheduler or LaneBatchSlots, so their self-checks stay
         // deterministic.
-        let budgetSchedOn = Tell.envInt("QWISP_TOKEN_BUDGET_SCHED", 1) != 0
         let budget = budgetSchedOn ? Swift.max(1, Tell.envInt("QWISP_TOKEN_BUDGET", 2048)) : 0
         self.scheduler = ContinuousScheduler(slots: laneSlots, tokenBudget: budget)
         // Bound MLX's free-buffer pool. This is NOT the #148 leak fix (that is the per-chunk

--- a/tools/lane_budget_probe.mjs
+++ b/tools/lane_budget_probe.mjs
@@ -12,6 +12,12 @@ import { pathToFileURL } from "node:url";
 
 const hostport = process.argv[2] || "127.0.0.1:8080";
 const bigTokens = parseInt(process.argv[3] || "24000", 10);
+// Steady stream A's length. The ITL percentiles are computed over exactly these gaps,
+// so this IS the percentile denominator: prefill pollutes ~k gaps (k = rounds the admit
+// spans, set by promptLen/budget and independent of this) out of `steadyTokens - 1`.
+// Short streams therefore report a worse p90 for identical engine behaviour — the 45
+// default is the pathological end of that, not a neutral choice (notes/21 p90 = 9,983ms).
+const steadyTokens = parseInt(process.env.STEADY_TOKENS || "45", 10);
 const [host, port] = hostport.split(":");
 
 function fireStream(body, onDelta) {
@@ -65,21 +71,29 @@ async function main() {
   const gaps = [];
   let last = null;
   const aDone = fireStream(
-    { model: "qwisp", messages: [{ role: "user", content: "Count slowly from 1 to 45, one number per line, nothing else." }], max_tokens: 45 },
+    { model: "qwisp", messages: [{ role: "user", content: `Count slowly from 1 to ${steadyTokens}, one number per line, nothing else.` }], max_tokens: steadyTokens },
     (t) => { if (last !== null) gaps.push(t - last); last = t; }
   );
   // Let A's stream start before B's admit lands — mirrors "lane 0 already decoding".
   await new Promise((r) => setTimeout(r, 600));
+  // Count B's tokens: a dropped admit still returns a normal empty 200, so discarding
+  // this stream makes the whole probe silently measure "no concurrent load at all"
+  // (#151 — that is exactly how the flag-off arm read as a 13s pass with no stall).
+  let bTokens = 0;
   const bDone = fireStream(
     { model: "qwisp", messages: [{ role: "user", content: filler }], max_tokens: 3 },
-    () => {}
+    () => { bTokens += 1; }
   );
   await Promise.all([aDone, bDone]);
+  if (bTokens === 0) {
+    console.error("[lane_budget_probe] FATAL: the big-prompt stream produced 0 tokens — " +
+                  "the admit was dropped, so stream A measured an idle server. Results are void.");
+  }
   gaps.sort((x, y) => x - y);
   const pct = (p) => gaps.length ? gaps[Math.min(gaps.length - 1, Math.floor(p * gaps.length))] : null;
   console.log(JSON.stringify({
     n: gaps.length, p50: pct(0.5), p90: pct(0.9), p99: pct(0.99),
-    max: gaps.length ? gaps[gaps.length - 1] : null, gapsMs: gaps,
+    max: gaps.length ? gaps[gaps.length - 1] : null, bTokens, gapsMs: gaps,
   }));
 }
 // Only run when invoked directly — importing makeFiller must not fire a probe.


### PR DESCRIPTION
Closes #151.

## What

`QWISP_TOKEN_BUDGET_SCHED=0` (the Stage A escape hatch) returned an **empty 200, no error, no NOTE** for any prompt over 16,384 tokens. Shipped in v0.3.10. The default (`=1`) path was never affected.

## Root cause

Stage B split the **eligibility** cap from the **allocation** cap, and only the budgeted path re-coupled them (its `seqBudget` *is* the allocation size). Flag-off stayed decoupled:

1. `generate()` checks eligibility against `laneCtx` — raised to model context (262,144) by Stage B — so a 24K prompt is eligible, no NOTE.
2. Flag-off takes `loop()` → `slots.admit` → the legacy sentinel `seqBudget: 0`.
3. `arenaSeqLen` returns `legacyArenaCap` = 16,384.
4. The prompt doesn't fit → `.failed` → `ContinuousBatch.swift:150-153` `req.finish()`. Silently.

`canAdmit` doesn't help — it is only ever called from `budgetedStep`.

## Fix

Pair the two caps at their only source: `eligibilityCtx()` clamps the flag-off eligibility window to `legacyArenaCap`, so oversized prompts reach `sizePlan`'s **existing** visible refusal. One line at the call site, plus a pure helper placed next to `arenaSeqLen` so the two caps are visibly a pair.

Neither the byte-frozen `tokenBudget == 0` scheduler body nor `d4f7e27`'s flag-off arena guarantee is touched.

## Why refuse rather than serve

Refusing at 16K **is** the legacy behaviour the hatch exists to reproduce — before Stage B, `QWISP_LANE_CTX` defaulted to 16,384 and >16K prompts were refused at exactly this boundary. Serving them needs per-request arena sizing, i.e. the budgeted path's mechanism, which is the very property that makes flag-off no longer bit-for-bit legacy — and would re-open the 335MB → 5.37GB/lane regression `d4f7e27` fixed, on the one path `canAdmit` never gates. No capability is lost: those prompts already returned nothing, just silently.

## Relation to #141

Same symptom, same magic number, **different layer** — worth stating so this isn't mistaken for a revert.

| | #141 (fixed by Stage B) | this |
|---|---|---|
| layer | eligibility (`generate()` headroom) | allocation (`admitStep` arena) |
| paths | both | flag-off only |
| visibility | stderr NOTE | **nothing** |

`d4f7e27` already stated the contract ("must fail VISIBLY, never a silent empty 200") and added a `cap16k` control — but that control sets `QWISP_LANE_CTX=16384`, exercising the *eligibility* mechanism, so it never reached the flag-off + default-ctx combination where eligibility passes and allocation fails.

## Verification

Gates: **RAWTESTS 97/97**, **COMPTEST 97/97** (93 → 97), **BENCHBATCHTEST PASS**.

Unit green != wired, so the wiring was checked on the real model (21,114-token prompt, `QWISP_LANE_CTX=32768`):

| | content | usage | elapsed |
|---|---|---|---|
| flag-off | none + `NOTE: ... 16384-token lane context — request dropped` | — | immediate |
| flag-on | served (`reasoning_content`) | `completion_tokens 3, prompt_tokens 21114` | 94s |

## Second commit: the harness that hid this

Three defects, each of which made a pass look valid while measuring something else:

- `run_pass off ""` set no env, so since the GO flipped the default the OFF arm had been running the **ON** path — both arms measured k=12 and sums within 2.5%.
- The probe discarded the big-prompt stream, so a dropped admit was invisible and stream A measured an idle server. That is exactly how the flag-off arm read as a clean 13s pass. It now counts B's tokens and marks the row **VOID** at zero.
- `max_tokens: 45` was hardcoded. Percentiles are computed over exactly those gaps, so stream length is the percentile denominator — now `STEADY_TOKENS` (default 45, existing invocations unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)