### PR TITLE
perf(seedless): cross-layer resid_add + input rmsnorm fold, flag-off (#144)

### DIFF
--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -349,6 +349,17 @@ public enum SeedlessFusedVerify {
     /// When the MOE2 fold is active, encodeMoEGatherRowsRange skips the separate combine dispatch
     /// and the count stays at 0 for that block call.
     nonisolated(unsafe) public static var _combineRowsDispatchCount: Int = 0
+    /// Testable seams for the cross-layer fold (#144, same idiom as _combineRowsDispatchCount).
+    /// The fold replaces one `resid_add` + one `rmsnorm_rows` per LAYER BOUNDARY with a single
+    /// `gdn_resid_postnorm_rows`, so what a test can assert is the SUM of these two dropping by
+    /// exactly (layers - 1). Counting the pair rather than the fold kernel is deliberate: the
+    /// fold kernel is also used mid-layer for the mixer residual, so its own count is not a
+    /// clean signal. #143's P1 (a full 694/token census) is deliberately NOT attempted — it
+    /// would need a seam in ~80 encode helpers and a single miss silently under-counts; the
+    /// delta these two give is what calibrates the inventory (see #143 comment).
+    nonisolated(unsafe) public static var _residAddDispatchCount: Int = 0
+    nonisolated(unsafe) public static var _rmsNormRowsDispatchCount: Int = 0
+    nonisolated(unsafe) public static var _gdnResidPostNormRowsDispatchCount: Int = 0
     nonisolated(unsafe) static var _finalCombineRowsPipeline: MTLComputePipelineState?
     nonisolated(unsafe) static var _writeKVRowsPipeline: MTLComputePipelineState?
     nonisolated(unsafe) static var _convHistRowsPipeline: MTLComputePipelineState?
@@ -1351,6 +1362,7 @@ public enum SeedlessFusedVerify {
     static func encodeGdnResidPostNormRows(_ enc: MTLComputeCommandEncoder,
                                            h: MTLBuffer, r: MTLBuffer, w: MTLBuffer,
                                            postNorm: MTLBuffer, M: Int, H: Int, eps: Float) {
+        _gdnResidPostNormRowsDispatchCount += 1   // testable seam (#144)
         let p = _gdnResidPostNormRowsPipeline!
         enc.setComputePipelineState(p)
         enc.setBuffer(h,        offset: 0, index: 0); enc.setBuffer(r,        offset: 0, index: 1)
@@ -1947,6 +1959,7 @@ public enum SeedlessFusedVerify {
     /// weight は非 nil buffer(no-weight は ones を渡す)。promoteF32 は _rmsPipelineF32(out f32)。
     static func encodeRmsNormRows(_ enc: MTLComputeCommandEncoder, x: MTLBuffer, w: MTLBuffer, out: MTLBuffer,
                                   rows: Int, D: Int, eps: Float, promoteF32: Bool = false) {
+        _rmsNormRowsDispatchCount += 1   // testable seam (#144)
         let p = promoteF32 ? SeedlessMetalForward._rmsPipelineF32! : SeedlessMetalForward._rmsPipeline!
         enc.setComputePipelineState(p)
         enc.setBuffer(x, offset: 0, index: 0); enc.setBuffer(w, offset: 0, index: 1); enc.setBuffer(out, offset: 0, index: 2)
@@ -3038,6 +3051,7 @@ public enum SeedlessFusedVerify {
 
     /// resid_add(既存 aux kernel, in-place h[i]+=r[i])を encode-only で提供。
     static func encodeResidAdd(_ enc: MTLComputeCommandEncoder, h: MTLBuffer, r: MTLBuffer, total: Int) {
+        _residAddDispatchCount += 1   // testable seam (#144)
         let p = SeedlessMetalForward._residAddPipeline!
         enc.setComputePipelineState(p)
         enc.setBuffer(h, offset: 0, index: 0); enc.setBuffer(r, offset: 0, index: 1)
@@ -3084,6 +3098,27 @@ public enum SeedlessFusedVerify {
         /// flag-off で encodeGdnLayerRows は既存経路のままで byte 不変(G3 gate)。
         nonisolated(unsafe) public static var fuseGDN =
             ProcessInfo.processInfo.environment["QWISP_FUSE_GDN"] != "0"
+
+        /// 層跨ぎ融合(#144): 層 i 末尾の resid_add と層 i+1 先頭の input rmsnorm を、既にこの
+        /// ファイルが持つ gdn_resid_postnorm_rows(h += r; out = rmsnorm(h, w))の 1 dispatch に
+        /// 畳む。同カーネルは同じ encodeLayer 内の mixer 側 residual で既に使われており、
+        /// 構造的に同一な 2 箇所のうち片方にだけ適用されていなかった、というのが #144。
+        /// −1 dispatch/層境界 ⇒ 40 層で −39/token。
+        /// bit-exact: 当該カーネルは residual 和を half に丸めて格納し、正規化はその格納済み
+        /// half を読み戻す(:907/:936)。分離版の resid も half 書き出し(SeedlessMetalForward:1019)
+        /// なので「レジスタ保持 vs 格納・再読込」の差が存在しない。新カーネルも演算列変更も無し。
+        /// 適用範囲は encodeLayer / encodeLayerBolt 経路のみ。chunked streaming 経路(自前で
+        /// resid→次層 encodePreMoE を並べる)は意図的に対象外＝bytes 不変。
+        /// **既定 OFF**(`QWISP_FUSE_XLAYER=1` で opt-in)。正しさは証明済みだが速度は未証明、
+        /// というのが 2026-08-01 の測定結論。実モデル 192tok × 5rep で ON median 72.04 /
+        /// OFF 70.73 tok/s だが、ON は 68.7→72.7 と単調増加・OFF は 71.3→68.9 と単調減少して
+        /// おり、アーム順序と暖機ドリフトが交絡している。アーム内変動(4.0/2.4)が主張したい差
+        /// (1.3)より大きく、別回では −0.7% と符号すら反転した。1% 級はこのハーネスの分解能外。
+        /// 測定で勝てなかったものは flag-off で出荷し再入点として残す、という WS-A の前例
+        /// (notes/20)に従う。#143 U2(serial encoder barrier に実コストがあるか)の対照ノブとして
+        /// 有用: bit 同一のまま barrier を 39 個消せる唯一の実装済みレバー。
+        nonisolated(unsafe) public static var fuseXLayer =
+            ProcessInfo.processInfo.environment["QWISP_FUSE_XLAYER"] == "1"
 
         /// attn 層融合(notes/08 §3)へ分岐。既定 ON。QWISP_FUSE_ATTN=0 で opt-out。
         /// flag-on でも各融合原子は既存 kernel 連鎖と bit-exact(G1 gate)なので OUT byte 不変(G2)。
@@ -3356,9 +3391,28 @@ public enum SeedlessFusedVerify {
 
         /// 1 層を encoder に encode(norm→mixer→resid→postNorm→MoE→resid)。resident/bolt 経路のみ。
         func encodeLayer(_ enc: MTLComputeCommandEncoder, _ L: Layer, li: Int, M: Int) {
-            encodePreMoE(enc, L, M: M)
+            let folded = foldPrevResid(enc, L, li: li, M: M)
+            encodePreMoE(enc, L, M: M, skipInputNorm: folded)
             SeedlessFusedVerify.encodeMoEBlockRows(enc, x: postNorm, out: moeOut, w: L.moe, sc: moeSc,
                                               M: M, E: L.E, I: L.I, Ktop: L.Ktop, H: H)
+            emitOrDeferResid(enc, li: li, M: M)
+        }
+
+        /// #144 前半: 前層が持ち越した MoE residual を、この層の input norm と 1 dispatch で畳む。
+        /// `moeOut` は層共有バッファだが、同一 encoder 内は serial 実行なので前層が書いた値を
+        /// この層の encodeMoEBlockRows が上書きする前に読む順序が保証される。
+        /// 戻り値 true = `normed` を書いたので呼び出し側は input rmsnorm を出さない。
+        private func foldPrevResid(_ enc: MTLComputeCommandEncoder, _ L: Layer, li: Int, M: Int) -> Bool {
+            guard SeedlessFusedForward.fuseXLayer, li > 0 else { return false }
+            SeedlessFusedVerify.encodeGdnResidPostNormRows(enc, h: hBuf, r: moeOut, w: L.inputLN,
+                                                           postNorm: normed, M: M, H: H, eps: eps)
+            return true
+        }
+
+        /// #144 後半: 融合時は resid を次層へ持ち越す(dispatch を出さない)。最終層だけは
+        /// 持ち越し先が無いので必ず出す — ここを落とすと hBuf が最後の MoE 分だけ古くなる。
+        private func emitOrDeferResid(_ enc: MTLComputeCommandEncoder, li: Int, M: Int) {
+            guard !SeedlessFusedForward.fuseXLayer || li == layers.count - 1 else { return }
             SeedlessFusedVerify.encodeResidAdd(enc, h: hBuf, r: moeOut, total: M * H)
         }
 
@@ -3375,7 +3429,8 @@ public enum SeedlessFusedVerify {
 
         /// bolt 層: resident と同一だが MoE gather 前に全 inds を GPU remap する。
         func encodeLayerBolt(_ enc: MTLComputeCommandEncoder, _ L: Layer, M: Int, li: Int) {
-            encodePreMoE(enc, L, M: M)
+            let folded = foldPrevResid(enc, L, li: li, M: M)
+            encodePreMoE(enc, L, M: M, skipInputNorm: folded)
             var diag: (indsDst: MTLBuffer, indsOff: Int, indsCount: Int,
                        glDst: MTLBuffer, glOff: Int, glCount: Int)? = nil
             if let bufs = diagRouteBufs, M <= diagObsMaxM {
@@ -3392,15 +3447,20 @@ public enum SeedlessFusedVerify {
             SeedlessFusedVerify.encodeMoEBlockRows(enc, x: postNorm, out: moeOut, w: L.moe, sc: moeSc,
                                               M: M, E: L.E, I: L.I, Ktop: L.Ktop, H: H,
                                               slotTable: slotTables[li], diag: diag, bias: biasTuple)
-            SeedlessFusedVerify.encodeResidAdd(enc, h: hBuf, r: moeOut, total: M * H)
+            emitOrDeferResid(enc, li: li, M: M)
         }
 
         /// MoE 前半 encode: norm → mixer(+cache bookkeeping) → resid → postNorm。
         // useMmaPrefill: default false everywhere; ONLY forwardRowsProfiled threads the env flag
         // through so the decay bench can A/B the MMA prefill kernel (WS-A #137). The strict
         // forwardRows/verify call sites never pass it — their bytes are unchanged.
-        func encodePreMoE(_ enc: MTLComputeCommandEncoder, _ L: Layer, M: Int, useMmaPrefill: Bool = false) {
-            SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: L.inputLN, out: normed, rows: M, D: H, eps: eps)
+        /// skipInputNorm: #144 の層跨ぎ融合が呼び出し側で既に `normed` を書いている場合のみ true。
+        /// 既定 false なので、この関数を直接呼ぶ他経路(chunked streaming の次層連結など)は不変。
+        func encodePreMoE(_ enc: MTLComputeCommandEncoder, _ L: Layer, M: Int, useMmaPrefill: Bool = false,
+                          skipInputNorm: Bool = false) {
+            if !skipInputNorm {
+                SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: L.inputLN, out: normed, rows: M, D: H, eps: eps)
+            }
             if L.isLinear, let gw = L.gdn, let gc = L.gdnCache {
                 SeedlessFusedVerify.encodeGdnLayerRows(enc, x: normed, out: mixerOut, w: gw, sc: gdnSc, cache: gc,
                                                   M: M, H: H, numKHeads: numKHeads, numVHeads: numVHeads,

--- a/swift/Sources/QwispCore/SeedlessVerifyTests.swift
+++ b/swift/Sources/QwispCore/SeedlessVerifyTests.swift
@@ -49,7 +49,7 @@ public enum SeedlessVerifyTests {
         MLXRandom.seed(UInt64(42))
         var lines: [String] = []
         var passed = 0
-        let total = 97
+        let total = 98
 
         // Nested runner: records result and increments counter
         func run(_ name: String, body: () -> (Bool, String)) {
@@ -6121,6 +6121,116 @@ public enum SeedlessVerifyTests {
                     return (false, "tokens step=\(step): got \(got) want \(r[0])")
                 }
                 tok = Int32(got[0])
+            }
+            return (true, "ok")
+        }
+
+        // WRITE-LOCKED (#144). Cross-layer fold: layer i's MoE `resid_add` and layer i+1's
+        // input `rmsnorm_rows` are replaced by one `gdn_resid_postnorm_rows`. Two properties,
+        // both of which must hold or the fold is not shippable:
+        //   (a) fold ON produces BIT-IDENTICAL output to fold OFF (it is a dispatch-count
+        //       change, never a numeric one), and
+        //   (b) the dispatch count really drops by exactly (layers - 1) — the "-39/token" claim
+        //       for the 40-layer model. Asserting (a) alone would pass even if the fold silently
+        //       did nothing, which is the failure this case exists to catch.
+        // 4 layers alternating GDN/attn ⇒ 3 boundaries, so a partial fold (e.g. only the first
+        // boundary, or only one layer type) is distinguishable from a complete one.
+        run("xlayer_fold_bitexact") {
+            let H = 2048, E = 16, I = 512
+            func q4(_ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine); return (q, s, b!)
+            }
+            func q8(_ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 8, mode: .affine); return (q, s, b!)
+            }
+            func q4e(_ e: Int, _ n: Int, _ k: Int) -> (MLXArray, MLXArray, MLXArray) {
+                let wf = MLXRandom.normal([e, n, k]).asType(.float16)
+                let (q, s, b) = MLX.quantized(wf, groupSize: 64, bits: 4, mode: .affine); return (q, s, b!)
+            }
+            func mkMoE() -> SeedlessVerifyForward.MoEBlockW {
+                let (gW, gS, gB) = q8(E, H); let (sgW, sgS, sgB) = q8(8, H)
+                let (a0, a1, a2) = q4e(E, I, H); let (b0, b1, b2) = q4e(E, I, H); let (c0, c1, c2) = q4e(E, H, I)
+                let (d0, d1, d2) = q4(I, H); let (e0, e1, e2) = q4(I, H); let (f0, f1, f2) = q4(H, I)
+                return SeedlessVerifyForward.MoEBlockW(gateWq: gW, gateSc: gS, gateBi: gB,
+                    swGWq: a0, swGSc: a1, swGBi: a2, swUWq: b0, swUSc: b1, swUBi: b2,
+                    swDWq: c0, swDSc: c1, swDBi: c2, shGWq: d0, shGSc: d1, shGBi: d2,
+                    shUWq: e0, shUSc: e1, shUBi: e2, shDWq: f0, shDSc: f1, shDBi: f2,
+                    sharedGateWq: sgW, sharedGateSc: sgS, sharedGateBi: sgB)
+            }
+            let Hk = 16, Dk = 128, Hv = 32, Dv = 128, cK = 4
+            let convDim = Hk * Dk * 2 + Hv * Dv
+            let (qkvW, qkvS, qkvB) = q4(convDim, H); let (zW, zS, zB) = q4(Hv * Dv, H)
+            let (bW, bS, bB) = q4(Hv, H); let (aW, aS, aB) = q4(Hv, H); let (oW, oS, oB) = q4(H, Hv * Dv)
+            let gdnW = SeedlessVerifyForward.GDNLayerW(qkvWq: qkvW, qkvSc: qkvS, qkvBi: qkvB,
+                zWq: zW, zSc: zS, zBi: zB, bWq: bW, bSc: bS, bBi: bB, aWq: aW, aSc: aS, aBi: aB,
+                outWq: oW, outSc: oS, outBi: oB,
+                conv1dW: MLXRandom.normal([convDim, cK]).asType(.float16),
+                normWeight: MLXRandom.normal([Dv]).asType(.float16),
+                aLog: MLXRandom.normal([Hv]).asType(.float32), dtBias: MLXRandom.normal([Hv]).asType(.float32))
+            let nH = 16, nKV = 2, hD = 256
+            let (aqW, aqS, aqB) = q4(nH * 2 * hD, H); let (akW, akS, akB) = q4(nKV * hD, H)
+            let (avW, avS, avB) = q4(nKV * hD, H); let (aoW, aoS, aoB) = q4(H, nH * hD)
+            let attnW = SeedlessVerifyForward.AttnLayerW(qWq: aqW, qSc: aqS, qBi: aqB, kWq: akW, kSc: akS, kBi: akB,
+                vWq: avW, vSc: avS, vBi: avB, oWq: aoW, oSc: aoS, oBi: aoB,
+                qNorm: MLXRandom.normal([hD]).asType(.float16), kNorm: MLXRandom.normal([hD]).asType(.float16))
+            func mkLayer(_ linear: Bool) -> SeedlessVerifyForward.LayerSpec {
+                SeedlessVerifyForward.LayerSpec(isLinear: linear,
+                    inputLN: MLXRandom.normal([H]).asType(.float16),
+                    postLN: MLXRandom.normal([H]).asType(.float16),
+                    gdn: linear ? gdnW : nil, attn: linear ? nil : attnW,
+                    moe: mkMoE(), moeE: E, moeI: I)
+            }
+            let layers = [mkLayer(true), mkLayer(false), mkLayer(true), mkLayer(false)]
+            let boundaries = layers.count - 1
+
+            let cs0 = MLXRandom.normal([cK - 1, convDim]).asType(.float16)
+            let rs0 = MLXRandom.normal([1, Hv, Dv, Dk]).asType(.float32)
+            let kC0 = MLXRandom.normal([nKV, 16, hD]).asType(.float16)
+            let vC0 = MLXRandom.normal([nKV, 16, hD]).asType(.float16)
+            MLX.eval([cs0, rs0, kC0, vC0])
+            func freshCaches() -> [SeedlessVerifyForward.LayerCaches] {
+                [SeedlessVerifyForward.LayerCaches(convState: cs0, recState: rs0),
+                 SeedlessVerifyForward.LayerCaches(kCache: kC0, vCache: vC0),
+                 SeedlessVerifyForward.LayerCaches(convState: cs0, recState: rs0),
+                 SeedlessVerifyForward.LayerCaches(kCache: kC0, vCache: vC0)]
+            }
+
+            let saved = SeedlessFusedVerify.SeedlessFusedForward.fuseXLayer
+            defer { SeedlessFusedVerify.SeedlessFusedForward.fuseXLayer = saved }
+
+            // Same input for both arms; counts are read per arm around one forwardRows.
+            func arm(_ fold: Bool, _ x: MLXArray, M: Int) -> (MLXArray, Int)? {
+                SeedlessFusedVerify.SeedlessFusedForward.fuseXLayer = fold
+                guard let f = SeedlessFusedVerify.SeedlessFusedForward(layers: layers, caches: freshCaches(),
+                                                                       maxM: 8, H: H, maxSeqLen: 64)
+                else { return nil }
+                SeedlessFusedVerify._residAddDispatchCount = 0
+                SeedlessFusedVerify._rmsNormRowsDispatchCount = 0
+                SeedlessFusedVerify._gdnResidPostNormRowsDispatchCount = 0
+                guard let out = f.forwardRows(x, M: M) else { return nil }
+                out.eval()
+                // NET dispatch count over the three kernels the fold can move between. The fold
+                // REMOVES a resid_add and an rmsnorm and ADDS a gdn_resid_postnorm, so the net
+                // is -1 per boundary — that is the "-39/token" claim for 40 layers. Summing only
+                // the removed pair would show -2 per boundary and overstate the win.
+                return (out, SeedlessFusedVerify._residAddDispatchCount
+                           + SeedlessFusedVerify._rmsNormRowsDispatchCount
+                           + SeedlessFusedVerify._gdnResidPostNormRowsDispatchCount)
+            }
+
+            for M in [1, 2, 8] {
+                let x = MLXRandom.normal([M, H]).asType(.float16); x.eval()
+                guard let (off, nOff) = arm(false, x, M: M) else { return (false, "fold-OFF nil M=\(M)") }
+                guard let (on,  nOn)  = arm(true,  x, M: M) else { return (false, "fold-ON nil M=\(M)") }
+                let (ok, d) = bitEqual(on, off)
+                if !ok { return (false, "M=\(M) fold-ON != fold-OFF: \(d)") }
+                if nOn != nOff - boundaries {
+                    return (false, "M=\(M) net dispatches (resid_add+rmsnorm+gdn_resid_postnorm): " +
+                                   "OFF=\(nOff) ON=\(nOn) want ON = OFF - \(boundaries) " +
+                                   "(fold did not fire on every boundary)")
+                }
             }
             return (true, "ok")
         }


### PR DESCRIPTION
Closes #144.

## Change

Layer i ends with `encodeResidAdd(hBuf, moeOut)`; layer i+1 begins with `encodeRmsNormRows(hBuf, inputLN → normed)`. That pair is exactly what the existing `gdn_resid_postnorm_rows` kernel computes — a kernel already used one step earlier in the same function for the mixer residual. It was applied to one of two structurally identical sites and not the other.

Folding the second: **−1 dispatch per layer boundary = −39/token** on the 40-layer model. No new kernel, no kernel edit, no arithmetic change — only which encode helper emits it. Scope is `encodeLayer`/`encodeLayerBolt`; the chunked-streaming path sequences its own resid → next-layer `encodePreMoE` and is deliberately untouched.

## Correctness — proven

- New WRITE-LOCKED RAWTESTS case `xlayer_fold_bitexact` (97 → **98**): 4 layers alternating GDN/attn (3 boundaries, so partial folding is distinguishable from complete), M ∈ {1,2,8}. Asserts fold-ON output is **bit-identical** to fold-OFF **and** that the net dispatch count drops by exactly (layers − 1).
- Real model, 192 greedy tokens: message bytes **identical** with the flag on vs off.

The net-count assertion earned its keep immediately. The first version summed only `resid_add` + `rmsnorm` and expected −1 per boundary. The fold removes **two** of those and adds one fold dispatch, so that sum drops by 2 per boundary while the **net** is −1. Locking the pair alone would have pinned a metric that overstates the win 2×.

## Speed — not proven, and not claimed

Real model, 192 tok × 5 reps in one server (warm-up discarded):

| | rep1 | rep2 | rep3 | rep4 | rep5 | median |
|---|---|---|---|---|---|---|
| ON | 68.707 | 70.623 | 72.412 | 72.041 | 72.710 | 72.041 |
| OFF | 71.319 | 70.731 | 69.717 | 68.892 | 70.907 | 70.731 |

Medians differ by +1.9%, **but that number is not usable**: ON trends 68.7 → 72.7 while OFF trends 71.3 → 68.9, so arm order is confounded with warm-up/thermal drift, and within-arm spread (4.0 / 2.4) exceeds the difference (1.3). An earlier single-rep pair gave **−0.7%** — the sign is not stable. A ~1% effect is below this harness's resolution, and the flag is read at startup so the arms cannot be interleaved in-process.

## Therefore: default OFF

`QWISP_FUSE_XLAYER=1` opts in. Follows WS-A's precedent (notes/20): what the measurement does not support ships flag-off as a re-entry point. It is also the natural control for **#143's U2** — the only implemented lever that removes 39 serial-encoder barriers while leaving the stream bit-identical.

## On #143's P1

Three dispatch-counting seams are added (same idiom as the shipped `_combineRowsDispatchCount`). They deliberately do **not** attempt P1's full 694/token census: that needs a seam in ~80 encode helpers where a single miss silently under-counts, and the delta measured here is what P1 actually wanted — see the issue comment.

## Gates

RAWTESTS **98/98**, COMPTEST **97/97**, BENCHBATCHTEST **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)