### PR TITLE
test(bench): #143 U2 instruments — in-engine dispatch cost + concurrency ceiling

### DIFF
--- a/swift/Sources/QwispCore/GroupedMoEPoC.swift
+++ b/swift/Sources/QwispCore/GroupedMoEPoC.swift
@@ -789,3 +789,153 @@ public enum GroupedMoEPoC {
         return out.joined(separator: "\n")
     }
 }
+
+/// Paired-measurement statistics shared by the #143 U2 instruments. Extracted so the two
+/// probes cannot drift apart: this is the part that has to be RIGHT, and duplicating it is
+/// how one copy quietly keeps an unadjusted CI after the other is fixed.
+public enum BenchStats {
+    public static func mean(_ v: [Double]) -> Double { v.isEmpty ? 0 : v.reduce(0, +) / Double(v.count) }
+    public static func sd(_ v: [Double]) -> Double {
+        guard v.count > 1 else { return 0 }
+        let m = mean(v); return (v.reduce(0) { $0 + ($1 - m) * ($1 - m) } / Double(v.count - 1)).squareRoot()
+    }
+    public static func median(_ v: [Double]) -> Double {
+        let s = v.sorted(); let k = s.count
+        guard k > 0 else { return 0 }
+        return k % 2 == 1 ? s[k/2] : (s[k/2 - 1] + s[k/2]) / 2
+    }
+    /// Lag-1 autocorrelation. Adjacent samples on a thermally-managed GPU are not independent;
+    /// at ~1% effect sizes an SE inflation of a few percent is enough to flip a verdict.
+    public static func lag1(_ v: [Double]) -> Double {
+        guard v.count > 2 else { return 0 }
+        let m = mean(v)
+        var num = 0.0, den = 0.0
+        for i in 0..<v.count { den += (v[i] - m) * (v[i] - m) }
+        for i in 1..<v.count { num += (v[i] - m) * (v[i-1] - m) }
+        return den == 0 ? 0 : num / den
+    }
+    /// Residuals after removing a known even/odd (ABBA order) nuisance term.
+    public static func orderResiduals(_ v: [Double]) -> [Double] {
+        let e = mean(stride(from: 0, to: v.count, by: 2).map { v[$0] })
+        let o = mean(stride(from: 1, to: v.count, by: 2).map { v[$0] })
+        return v.enumerated().map { $1 - ($0 % 2 == 0 ? e : o) }
+    }
+    /// AR(1)-adjusted 95% CI of the mean. `residuals` supplies the dispersion (order-blocked);
+    /// the inflation sqrt((1+rho)/(1-rho)) is the standard correction for a correlated mean.
+    public static func ci(_ v: [Double], residuals: [Double]? = nil)
+        -> (m: Double, s: Double, lo: Double, hi: Double, rho: Double) {
+        let r = residuals ?? v
+        let m = mean(v), sv = sd(r)
+        let rho = Swift.max(-0.95, Swift.min(0.95, lag1(r)))
+        let se = sv / Double(v.count).squareRoot() * ((1 + rho) / (1 - rho)).squareRoot()
+        return (m, sv, m - 1.96 * se, m + 1.96 * se, rho)
+    }
+    public static func verdict(_ c: (m: Double, s: Double, lo: Double, hi: Double, rho: Double),
+                              faster: String = "A faster", slower: String = "A slower") -> String {
+        (c.lo < 0 && c.hi < 0) ? faster : (c.lo > 0 && c.hi > 0) ? slower : "not significant (CI spans 0)"
+    }
+}
+
+extension GroupedMoEPoC {
+    /// #143 U2 CEILING experiment. What is the most that making the compute encoder concurrent
+    /// could ever buy? No model, no engine, no frozen-path risk — just N dispatches with NO data
+    /// dependencies in one command buffer, `MTLDispatchType.serial` vs `.concurrent`.
+    ///
+    /// WHY THIS AND NOT MORE ENGINE MEASUREMENT. The in-engine probe (Tell.dispatchCostProbe)
+    /// established that removing 39 dispatches/step is worth ~2.5 us each of GPU time — i.e.
+    /// dispatches are NOT free, which refuted the cheap way to close U2. But concurrency does not
+    /// remove dispatches; it only lets INDEPENDENT ones overlap. qwisp's forward is a near-total
+    /// sequential chain (norm -> mixer -> resid -> MoE -> resid per layer), so the overlappable
+    /// fraction is small and unmeasured. This bench brackets the question from above: it is the
+    /// best case that cannot occur in the real forward — every dispatch independent, every kernel
+    /// deliberately tiny (ONE threadgroup of 32 threads, so it leaves the GPU almost entirely
+    /// idle, the condition under which overlap should pay most, and the shape of the real
+    /// single-threadgroup kernels #143 calls out, e.g. route_top8). If concurrency cannot win
+    /// HERE, it cannot win in the engine, and U2 closes without touching a single dispatch site.
+    ///
+    /// Reported per N: GPU time (cb.gpuEndTime - gpuStartTime) per dispatch, paired and
+    /// interleaved ABBA, AR(1)-adjusted CI. Self-check: both arms must produce the CORRECT
+    /// output buffer — a concurrent encoder that raced would otherwise be timed as a "win".
+    ///
+    /// Knobs: QWISP_CONC_REPS (default 200), QWISP_CONC_N (comma list, default "64,256,694").
+    public static func dispatchConcurrencyBench() -> String {
+        guard let (device, queue) = SeedlessMetalForward.ensure() else { return "[conc-bench] no device\nCONCBENCH done" }
+        let src = """
+        #include <metal_stdlib>
+        using namespace metal;
+        // Deliberately trivial and deliberately tiny: the point is per-dispatch cost, not work.
+        // Each dispatch is bound to its OWN 32-float slice via a buffer offset, so there is no
+        // data dependency between dispatches and a concurrent encoder needs no barriers.
+        kernel void tiny_indep(device float* out [[buffer(0)]],
+                               uint tid [[thread_position_in_grid]]) {
+            out[tid] = float(tid) * 2.0f + 1.0f;
+        }
+        """
+        guard let lib = try? device.makeLibrary(source: src, options: nil),
+              let fn = lib.makeFunction(name: "tiny_indep"),
+              let pipe = try? device.makeComputePipelineState(function: fn) else {
+            return "[conc-bench] pipeline build failed\nCONCBENCH done"
+        }
+        let reps = Swift.max(4, Tell.envInt("QWISP_CONC_REPS", 200))
+        let nList = (ProcessInfo.processInfo.environment["QWISP_CONC_N"] ?? "64,256,694")
+            .split(separator: ",").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }.filter { $0 > 0 }
+        let lanes = 32                                   // floats per dispatch slice
+        var lines = ["[conc-bench] #143 U2 ceiling — N independent tiny dispatches, serial vs concurrent encoder",
+                     "  device=\(device.name) reps=\(reps) threadsPerDispatch=\(lanes) (1 threadgroup)"]
+        for N in nList {
+            guard let buf = device.makeBuffer(length: N * lanes * MemoryLayout<Float>.size,
+                                              options: .storageModeShared) else {
+                lines.append("  N=\(N): buffer alloc failed"); continue
+            }
+            /// One command buffer with N independent dispatches. Returns GPU ms, or nil on a
+            /// wrong result — a raced concurrent encoder must never be reported as a fast one.
+            func run(_ concurrent: Bool) -> Double? {
+                memset(buf.contents(), 0, buf.length)
+                guard let cb = queue.makeCommandBuffer() else { return nil }
+                let enc = concurrent
+                    ? cb.makeComputeCommandEncoder(dispatchType: .concurrent)
+                    : cb.makeComputeCommandEncoder()
+                guard let e = enc else { return nil }
+                e.setComputePipelineState(pipe)
+                for i in 0..<N {
+                    e.setBuffer(buf, offset: i * lanes * MemoryLayout<Float>.size, index: 0)
+                    e.dispatchThreadgroups(MTLSize(width: 1, height: 1, depth: 1),
+                                           threadsPerThreadgroup: MTLSize(width: lanes, height: 1, depth: 1))
+                }
+                e.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+                let p = buf.contents().bindMemory(to: Float.self, capacity: N * lanes)
+                for i in 0..<(N * lanes) where p[i] != Float(i % lanes) * 2.0 + 1.0 { return nil }
+                return (cb.gpuEndTime - cb.gpuStartTime) * 1000.0
+            }
+            _ = run(false); _ = run(true)                // warm-up, both arms
+            var deltas: [Double] = [], ser: [Double] = [], con: [Double] = []
+            var bad = false
+            for r in 0..<reps {
+                var s = 0.0, c = 0.0
+                for first in [true, false] {
+                    let isConc = (r % 2 == 0) ? !first : first     // ABBA
+                    guard let t = run(isConc) else { bad = true; break }
+                    if isConc { c = t } else { s = t }
+                }
+                if bad { break }
+                ser.append(s); con.append(c); deltas.append(c - s)   // negative = concurrent faster
+            }
+            if bad || deltas.isEmpty {
+                lines.append("  N=\(N): SELF-CHECK FAIL — a run produced wrong output (encoder raced?). VOID.")
+                continue
+            }
+            let stat = BenchStats.ci(deltas, residuals: BenchStats.orderResiduals(deltas))
+            let mSer = BenchStats.mean(ser)
+            lines.append(String(format: "  N=%4d  serial=%.4f ms  concurrent=%.4f ms  delta=%+.4f ms [%+.4f, %+.4f] (%+.2f%%) rho=%+.3f  %@",
+                                N, mSer, BenchStats.mean(con), stat.m, stat.lo, stat.hi,
+                                mSer == 0 ? 0 : 100 * stat.m / mSer, stat.rho,
+                                BenchStats.verdict(stat, faster: "concurrent faster", slower: "concurrent SLOWER")))
+            lines.append(String(format: "         per-dispatch: serial=%.4f us  delta=%+.4f us",
+                                1000 * mSer / Double(N), 1000 * stat.m / Double(N)))
+        }
+        lines.append("  READ: this is the CEILING. Every dispatch here is independent and tiny; the real")
+        lines.append("    forward is a near-total sequential chain, so its overlappable fraction is a small")
+        lines.append("    subset of N. If the delta here is already ~0, #143 U2 is closed.")
+        return lines.joined(separator: "\n") + "\nCONCBENCH done"
+    }
+}

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -1283,4 +1283,170 @@ extension Tell {
         PREFIXPOC \(pass ? "PASS" : "FAIL")   (both paths must be byte-identical to full prefill)
         """
     }
+
+    /// #143 U2 instrument: what does removing a Metal dispatch actually buy inside one CB?
+    ///
+    /// v2, after an adversarial peer review of v1 found the instrument itself was lying. v1's
+    /// prefill was a SILENT NO-OP (it chunked by 1024 into a `maxM: 8` forward, so every call hit
+    /// `guard M <= maxM` and returned nil, which v1 discarded with `_ =`). It printed "ctx=512"
+    /// while measuring decode from an empty context, and v1's self-check passed anyway because it
+    /// only verified the PERTURBATION, never the ENVIRONMENT. That is the same failure recorded in
+    /// notes/21 (a harness quietly measuring something other than its stated condition), reproduced
+    /// one level up. Every v1 number was discarded. Keep that in mind before trusting any change
+    /// to this function: an instrument that cannot fail loudly is worse than no instrument.
+    ///
+    /// DESIGN. Both arms are measured in one process and one model load, so drift is common-mode.
+    /// `fuseXLayer` is a mutable static read at encode time, which is what makes interleaving legal.
+    /// The two structural confounds v1 had are removed at the source rather than corrected for:
+    ///  - PER-PAIR ROLLBACK. Each arm restores the same post-prefill snapshot before running, so
+    ///    both arms of a pair start at an IDENTICAL cache position. v1 let the second arm of every
+    ///    pair run +`steps` tokens deeper, a bias that cancels in the mean but not in the median or
+    ///    the sign test — the two statistics v1 actually reported.
+    ///  - SHARED TOKEN STREAM. Both arms decode the SAME token ids. v1 derived the salt from the
+    ///    arm, so the fold arm deterministically drew a different token band, routing to different
+    ///    MoE experts. That is an arm-level systematic difference, not noise; more reps would not
+    ///    have averaged it away.
+    /// Arm order still alternates (ABBA) so residual time-ordered drift cancels across pairs.
+    ///
+    /// SELF-CHECKS (all must hold or the timings are reported VOID, never as a null result — a
+    /// silently-ineffective flag looks exactly like "no effect", the most dangerous outcome):
+    ///  1. dispatches/sample is an exact multiple of `steps` (v1's `disp / steps` truncation hid
+    ///     up to `steps-1` stray dispatches per sample).
+    ///  2. the ON arm emits exactly `layers-1` fewer dispatches per step than OFF, every pair.
+    ///  3. the absolute OFF-arm count is identical across every pair (catches drift in what is
+    ///     being encoded, which check 2's delta alone cannot see).
+    ///  4. ON and OFF produce BIT-IDENTICAL output under this probe's own conditions. Bit identity
+    ///     was proven elsewhere; this asserts it here, so a timing delta can never come from the
+    ///     fold quietly computing something else.
+    ///
+    /// REGIME CAVEAT, print it and mean it: this measures one-CB-per-step with a full sync per step
+    /// (`forwardRows` commits and waits). Production decode chains multiple steps per CB. A
+    /// per-dispatch cost measured here is an UPPER BOUND on what the chained path would see.
+    ///
+    /// Knobs: QWISP_DISPATCH_REPS (pairs, default 100), QWISP_DISPATCH_STEPS (steps/sample,
+    /// default 32), QWISP_DISPATCH_CTX (prefill depth, default 512).
+    public static func dispatchCostProbe(modelDir: String) -> String {
+        guard let store = try? WeightStore(modelDir: modelDir) else { return "[dispatch-cost] load fail\nDISPATCHCOST done" }
+        store.residentAll()
+        let engine = SeedlessEngine.build(store: store)
+        let reps = Swift.max(4, Tell.envInt("QWISP_DISPATCH_REPS", 100))
+        let steps = Swift.max(4, Tell.envInt("QWISP_DISPATCH_STEPS", 32))
+        let ctx = Swift.max(0, Tell.envInt("QWISP_DISPATCH_CTX", 512))
+        let nLayers = engine.layers.count
+        let expectedDelta = nLayers - 1
+        let chunkM = 256                       // prefill chunk; MUST be <= maxM or forwardRows returns nil
+        // Rollback resets every arm to `ctx`, so the cache never grows past ctx + steps.
+        guard let (fwd, _) = engine.makeFused(maxM: chunkM, maxSeqLen: ctx + steps + 64) else {
+            return "[dispatch-cost] makeFused nil\nDISPATCHCOST done"
+        }
+        func tok(_ n: Int, _ salt: Int) -> [Int32] { (0..<n).map { Int32((($0 &* 7 &+ salt) % 5000) + 100) } }
+        // Prefill. A nil here is a HARD FAILURE — v1 discarded it and measured a fiction.
+        let pre = tok(ctx, 13); var pos = 0
+        while pos < ctx {
+            let end = Swift.min(pos + chunkM, ctx)
+            guard fwd.forwardRows(engine.embed(tokens: Array(pre[pos ..< end])), M: end - pos) != nil else {
+                return "[dispatch-cost] prefill returned nil at pos=\(pos) M=\(end - pos) (chunk > maxM?)\nDISPATCHCOST done"
+            }
+            pos = end
+        }
+        let snapshot = fwd.persistentStateData()
+        guard !snapshot.isEmpty else { return "[dispatch-cost] empty snapshot\nDISPATCHCOST done" }
+        let saved = SeedlessFusedVerify.SeedlessFusedForward.fuseXLayer
+        defer { SeedlessFusedVerify.SeedlessFusedForward.fuseXLayer = saved }
+
+        /// One sample: restore to the snapshot, then `steps` M=1 decode steps on a fixed token
+        /// stream. Returns (ms/step, dispatches/sample, last output) — the caller checks all three.
+        func sample(_ fold: Bool, salt: Int) -> (ms: Double, disp: Int, out: MLXArray)? {
+            guard fwd.restorePersistentState(snapshot) else { return nil }
+            SeedlessFusedVerify.SeedlessFusedForward.fuseXLayer = fold
+            SeedlessFusedVerify._residAddDispatchCount = 0
+            SeedlessFusedVerify._rmsNormRowsDispatchCount = 0
+            SeedlessFusedVerify._gdnResidPostNormRowsDispatchCount = 0
+            var last: MLXArray? = nil
+            let t0 = DispatchTime.now().uptimeNanoseconds       // monotonic; Date() is wall clock
+            for s in 0..<steps {
+                guard let out = fwd.forwardRows(engine.embed(tokens: tok(1, salt &+ s)), M: 1) else { return nil }
+                last = out                                       // forwardRows already commits+waits
+            }
+            let dt = Double(DispatchTime.now().uptimeNanoseconds &- t0) / 1_000_000.0
+            guard let out = last else { return nil }
+            let disp = SeedlessFusedVerify._residAddDispatchCount
+                     + SeedlessFusedVerify._rmsNormRowsDispatchCount
+                     + SeedlessFusedVerify._gdnResidPostNormRowsDispatchCount
+            return (dt / Double(steps), disp, out)
+        }
+        _ = sample(false, salt: 1); _ = sample(true, salt: 1)    // warm-up, both arms, never recorded
+
+        var deltas: [Double] = [], onMs: [Double] = [], offMs: [Double] = []
+        var fail: [String] = []
+        var refOffDisp: Int? = nil
+        for r in 0..<reps {
+            let salt = 1000 &+ r &* 64                           // SAME for both arms of this pair
+            var mOn = 0.0, mOff = 0.0, dOn = 0, dOff = 0
+            var outOn: MLXArray? = nil, outOff: MLXArray? = nil
+            for first in [true, false] {
+                let fold = (r % 2 == 0) ? !first : first          // ABBA
+                guard let s = sample(fold, salt: salt) else {
+                    return "[dispatch-cost] sample nil rep=\(r) fold=\(fold)\nDISPATCHCOST done"
+                }
+                if fold { mOn = s.ms; dOn = s.disp; outOn = s.out } else { mOff = s.ms; dOff = s.disp; outOff = s.out }
+            }
+            if dOff % steps != 0 || dOn % steps != 0 {
+                fail.append("rep=\(r): dispatches/sample not a multiple of steps (OFF=\(dOff) ON=\(dOn) steps=\(steps))")
+            }
+            if (dOff - dOn) / steps != expectedDelta {
+                fail.append("rep=\(r): dispatch delta/step = \((dOff - dOn) / steps), want \(expectedDelta)")
+            }
+            if let ref = refOffDisp, ref != dOff {
+                fail.append("rep=\(r): OFF dispatches/sample drifted \(ref) -> \(dOff)")
+            }
+            refOffDisp = refOffDisp ?? dOff
+            if let a = outOn, let b = outOff {
+                a.eval(); b.eval()
+                let d = MLX.sum(MLX.abs(a.asType(.float32) - b.asType(.float32))).item(Float.self)
+                if d != 0 { fail.append("rep=\(r): fold changed the output under this probe (sum|Δ|=\(d))") }
+            }
+            onMs.append(mOn); offMs.append(mOff); deltas.append(mOn - mOff)
+            if fail.count > 3 { break }
+        }
+        func mean(_ v: [Double]) -> Double { v.reduce(0, +) / Double(v.count) }
+        func sd(_ v: [Double]) -> Double {
+            guard v.count > 1 else { return 0 }
+            let m = mean(v); return (v.reduce(0) { $0 + ($1 - m) * ($1 - m) } / Double(v.count - 1)).squareRoot()
+        }
+        func median(_ v: [Double]) -> Double {
+            let s = v.sorted(); let n = s.count
+            return n % 2 == 1 ? s[n/2] : (s[n/2 - 1] + s[n/2]) / 2
+        }
+        let n = deltas.count
+        let mD = mean(deltas), sD = sd(deltas), se = sD / Double(n).squareRoot()
+        let lo = mD - 1.96 * se, hi = mD + 1.96 * se
+        let evens = stride(from: 0, to: n, by: 2).map { deltas[$0] }
+        let odds  = stride(from: 1, to: n, by: 2).map { deltas[$0] }
+        var lines = ["[dispatch-cost] #143 U2 instrument v2 — paired, per-pair rollback, shared token stream",
+                     "  layers=\(nLayers) expectedDispatchDelta=\(expectedDelta)/step  ctx=\(ctx) pairs=\(n) steps/sample=\(steps)"]
+        if !fail.isEmpty {
+            lines.append("  SELF-CHECK FAIL (timings below are VOID, do NOT read them as a null result):")
+            for f in fail.prefix(4) { lines.append("    - \(f)") }
+            return lines.joined(separator: "\n") + "\nDISPATCHCOST done"
+        }
+        lines.append("  self-check OK: dispatch delta exact every pair, OFF count stable at \(refOffDisp ?? -1)/sample, outputs bit-identical")
+        lines.append(String(format: "  median ms/step   OFF=%.4f  ON=%.4f", median(offMs), median(onMs)))
+        lines.append(String(format: "  paired delta (ON-OFF): mean=%+.4f ms  sd=%.4f  95%%CI=[%+.4f, %+.4f] ms",
+                            mD, sD, lo, hi))
+        lines.append(String(format: "  relative: %+.3f%%  [%+.3f%%, %+.3f%%]",
+                            100 * mD / mean(offMs), 100 * lo / mean(offMs), 100 * hi / mean(offMs)))
+        let sig = (lo < 0 && hi < 0) ? "SIGNIFICANT (fold faster)"
+                : (lo > 0 && hi > 0) ? "SIGNIFICANT (fold slower)" : "NOT SIGNIFICANT (CI spans 0)"
+        lines.append("  verdict: \(sig)")
+        lines.append(String(format: "  cross-checks: sign %d/%d pairs fold-faster · order effect mean(even)=%+.4f mean(odd)=%+.4f ms",
+                            deltas.filter { $0 < 0 }.count, n, mean(evens), mean(odds)))
+        lines.append(String(format: "  per-BOUNDARY saving = %+.4f us (= mean delta / %d). This is NOT 'per dispatch':",
+                            1000 * mD / Double(expectedDelta), expectedDelta))
+        lines.append("    the fold replaces TWO small kernels with ONE, so it also changes kernel execution")
+        lines.append("    time and occupancy, not just launch count. Treat it as an UPPER BOUND on what")
+        lines.append("    removing one dispatch is worth. Same for the regime: this is 1 CB/step with a full")
+        lines.append("    sync per step; production decode chains steps per CB and would see less.")
+        return lines.joined(separator: "\n") + "\nDISPATCHCOST done"
+    }
 }

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -1335,8 +1335,10 @@ extension Tell {
         let nLayers = engine.layers.count
         let expectedDelta = nLayers - 1
         let chunkM = 256                       // prefill chunk; MUST be <= maxM or forwardRows returns nil
-        // Rollback resets every arm to `ctx`, so the cache never grows past ctx + steps.
-        guard let (fwd, _) = engine.makeFused(maxM: chunkM, maxSeqLen: ctx + steps + 64) else {
+        // Preheat steps run AFTER the restore and BEFORE the timer, so they consume cache too.
+        let preheat = Swift.max(0, Tell.envInt("QWISP_DISPATCH_PREHEAT", 4))
+        // Rollback resets every arm to `ctx`, so the cache never grows past ctx + preheat + steps.
+        guard let (fwd, _) = engine.makeFused(maxM: chunkM, maxSeqLen: ctx + preheat + steps + 64) else {
             return "[dispatch-cost] makeFused nil\nDISPATCHCOST done"
         }
         func tok(_ n: Int, _ salt: Int) -> [Int32] { (0..<n).map { Int32((($0 &* 7 &+ salt) % 5000) + 100) } }
@@ -1356,16 +1358,38 @@ extension Tell {
 
         /// One sample: restore to the snapshot, then `steps` M=1 decode steps on a fixed token
         /// stream. Returns (ms/step, dispatches/sample, last output) — the caller checks all three.
-        func sample(_ fold: Bool, salt: Int) -> (ms: Double, disp: Int, out: MLXArray)? {
+        // Fault injection, permanent on purpose: QWISP_DISPATCH_FAULT=1 makes both arms run the
+        // SAME configuration while the probe still believes it is contrasting two. That is exactly
+        // the v1 failure class — a perturbation that silently stops applying, which the timings
+        // render as an innocent-looking null result. A self-check that has never been SEEN to fire
+        // is an assumption, not a check; run this knob after touching this probe and confirm it
+        // reports VOID. If it reports numbers, the alarm is broken and nothing here is trustworthy.
+        let faultInject = Tell.envInt("QWISP_DISPATCH_FAULT", 0) != 0
+        func sample(_ fold: Bool, salt: Int) -> (ms: Double, gpuMs: Double, disp: Int, out: [Float16])? {
             guard fwd.restorePersistentState(snapshot) else { return nil }
-            SeedlessFusedVerify.SeedlessFusedForward.fuseXLayer = fold
+            SeedlessFusedVerify.SeedlessFusedForward.fuseXLayer = faultInject ? false : fold
+            // Preheat: untimed steps at THIS arm's configuration, after the restore, before t0.
+            // Without them arm 1 starts from a longer and differently-composed idle gap than arm 2
+            // (arm 1 is preceded by the previous pair's comparison + stats), so the GPU is at a
+            // lower p-state when arm 1's timer starts. That showed up as a within-pair order effect
+            // ~3x the size of the effect being measured, which ABBA then had to cancel exactly.
+            // Equalising the pre-timer state is better than relying on that cancellation.
+            for s in 0..<preheat {
+                guard fwd.forwardRows(engine.embed(tokens: tok(1, salt &- 1 &- s)), M: 1) != nil else { return nil }
+            }
             SeedlessFusedVerify._residAddDispatchCount = 0
             SeedlessFusedVerify._rmsNormRowsDispatchCount = 0
             SeedlessFusedVerify._gdnResidPostNormRowsDispatchCount = 0
             var last: MLXArray? = nil
+            var gpu = 0.0
             let t0 = DispatchTime.now().uptimeNanoseconds       // monotonic; Date() is wall clock
             for s in 0..<steps {
                 guard let out = fwd.forwardRows(engine.embed(tokens: tok(1, salt &+ s)), M: 1) else { return nil }
+                // GPU-ONLY time for this step's command buffer. This is the number that decides
+                // #143 U2: the fold removes CPU encode calls AND (maybe) GPU serialization, and
+                // MTLDispatchType.concurrent can only ever address the latter. If the wall-clock
+                // win does not appear here, U2 is closed without a further experiment.
+                gpu += SeedlessFusedVerify.SeedlessFusedForward.profLastGPUMs
                 last = out                                       // forwardRows already commits+waits
             }
             let dt = Double(DispatchTime.now().uptimeNanoseconds &- t0) / 1_000_000.0
@@ -1373,23 +1397,33 @@ extension Tell {
             let disp = SeedlessFusedVerify._residAddDispatchCount
                      + SeedlessFusedVerify._rmsNormRowsDispatchCount
                      + SeedlessFusedVerify._gdnResidPostNormRowsDispatchCount
-            return (dt / Double(steps), disp, out)
+            // Pull the array out HERE, inside the arm. The bit-compare must not run MLX graph ops
+            // in the gap between pairs — that touches the MLX buffer pool and does its own GPU
+            // round-trip, which is part of what made the two arms' pre-timer environments differ.
+            return (dt / Double(steps), gpu / Double(steps), disp, out.asArray(Float16.self))
         }
         _ = sample(false, salt: 1); _ = sample(true, salt: 1)    // warm-up, both arms, never recorded
 
         var deltas: [Double] = [], onMs: [Double] = [], offMs: [Double] = []
+        var gpuDeltas: [Double] = [], gpuOn: [Double] = [], gpuOff: [Double] = []
         var fail: [String] = []
         var refOffDisp: Int? = nil
         for r in 0..<reps {
-            let salt = 1000 &+ r &* 64                           // SAME for both arms of this pair
+            // Stride 63, NOT 64: with stride 64 and tok()'s %5000, even and odd reps drew DISJOINT
+            // token bands, so the even/odd order diagnostic was confounded with token content (and
+            // therefore with MoE routing). 63 is coprime with the parity, so both parities sample
+            // the same token space. The pair itself still shares one salt across both arms.
+            let salt = 1000 &+ r &* 63                           // SAME for both arms of this pair
             var mOn = 0.0, mOff = 0.0, dOn = 0, dOff = 0
-            var outOn: MLXArray? = nil, outOff: MLXArray? = nil
+            var gOn = 0.0, gOff = 0.0
+            var outOn: [Float16]? = nil, outOff: [Float16]? = nil
             for first in [true, false] {
                 let fold = (r % 2 == 0) ? !first : first          // ABBA
                 guard let s = sample(fold, salt: salt) else {
                     return "[dispatch-cost] sample nil rep=\(r) fold=\(fold)\nDISPATCHCOST done"
                 }
-                if fold { mOn = s.ms; dOn = s.disp; outOn = s.out } else { mOff = s.ms; dOff = s.disp; outOff = s.out }
+                if fold { mOn = s.ms; gOn = s.gpuMs; dOn = s.disp; outOn = s.out }
+                else     { mOff = s.ms; gOff = s.gpuMs; dOff = s.disp; outOff = s.out }
             }
             if dOff % steps != 0 || dOn % steps != 0 {
                 fail.append("rep=\(r): dispatches/sample not a multiple of steps (OFF=\(dOff) ON=\(dOn) steps=\(steps))")
@@ -1402,14 +1436,15 @@ extension Tell {
             }
             refOffDisp = refOffDisp ?? dOff
             if let a = outOn, let b = outOff {
-                a.eval(); b.eval()
-                let d = MLX.sum(MLX.abs(a.asType(.float32) - b.asType(.float32))).item(Float.self)
-                if d != 0 { fail.append("rep=\(r): fold changed the output under this probe (sum|Δ|=\(d))") }
+                if a.count != b.count || zip(a, b).contains(where: { $0 != $1 }) {
+                    fail.append("rep=\(r): fold changed the output under this probe (hidden state differs)")
+                }
             }
             onMs.append(mOn); offMs.append(mOff); deltas.append(mOn - mOff)
+            gpuOn.append(gOn); gpuOff.append(gOff); gpuDeltas.append(gOn - gOff)
             if fail.count > 3 { break }
         }
-        func mean(_ v: [Double]) -> Double { v.reduce(0, +) / Double(v.count) }
+        func mean(_ v: [Double]) -> Double { v.isEmpty ? 0 : v.reduce(0, +) / Double(v.count) }
         func sd(_ v: [Double]) -> Double {
             guard v.count > 1 else { return 0 }
             let m = mean(v); return (v.reduce(0) { $0 + ($1 - m) * ($1 - m) } / Double(v.count - 1)).squareRoot()
@@ -1419,34 +1454,82 @@ extension Tell {
             return n % 2 == 1 ? s[n/2] : (s[n/2 - 1] + s[n/2]) / 2
         }
         let n = deltas.count
-        let mD = mean(deltas), sD = sd(deltas), se = sD / Double(n).squareRoot()
-        let lo = mD - 1.96 * se, hi = mD + 1.96 * se
         let evens = stride(from: 0, to: n, by: 2).map { deltas[$0] }
         let odds  = stride(from: 1, to: n, by: 2).map { deltas[$0] }
-        var lines = ["[dispatch-cost] #143 U2 instrument v2 — paired, per-pair rollback, shared token stream",
-                     "  layers=\(nLayers) expectedDispatchDelta=\(expectedDelta)/step  ctx=\(ctx) pairs=\(n) steps/sample=\(steps)"]
+        // Order-blocked estimate: the within-pair order effect is a known nuisance term, so model
+        // it instead of letting it inflate the pooled sd. Point estimate is unchanged (ABBA is
+        // balanced); the CI tightens slightly. Residuals are delta minus its own parity's mean.
+        let mE = evens.isEmpty ? 0 : evens.reduce(0,+) / Double(evens.count)
+        let mO = odds.isEmpty  ? 0 : odds.reduce(0,+)  / Double(odds.count)
+        var resid: [Double] = []
+        for (i, d) in deltas.enumerated() { resid.append(d - (i % 2 == 0 ? mE : mO)) }
+        /// Lag-1 autocorrelation of the order-adjusted residuals. The CI below assumes pairs are
+        /// independent; they are adjacent in time on a thermally-managed GPU, so they may not be.
+        /// This matters more than it looks: at this effect size an SE inflation of only ~3% moves
+        /// the upper bound onto zero, and rho ~ 0.03 is enough to do it. Print it so the reader can
+        /// discount the CI instead of trusting it blindly.
+        func lag1(_ v: [Double]) -> Double {
+            guard v.count > 2 else { return 0 }
+            let m = mean(v)
+            var num = 0.0, den = 0.0
+            for i in 0..<v.count { den += (v[i] - m) * (v[i] - m) }
+            for i in 1..<v.count { num += (v[i] - m) * (v[i-1] - m) }
+            return den == 0 ? 0 : num / den
+        }
+        /// AR(1)-ADJUSTED CI. Adjacent pairs run back-to-back on a thermally-managed GPU, so the
+        /// independence the naive CI assumes does not hold — the v3 run measured rho=+0.29 on the
+        /// wall residuals, ~10x the level at which this effect size stops being significant. The
+        /// inflation factor sqrt((1+rho)/(1-rho)) is the standard AR(1) correction for the variance
+        /// of a mean. Applying it in the code rather than leaving it to the reader is the point:
+        /// the previous version printed rho next to an unadjusted interval, which invites reading
+        /// the interval and ignoring the footnote.
+        func ci(_ v: [Double], residuals: [Double]? = nil) -> (m: Double, s: Double, lo: Double, hi: Double, rho: Double) {
+            let r = residuals ?? v
+            let m = mean(v), sv = sd(r)
+            let rho = Swift.max(-0.95, Swift.min(0.95, lag1(r)))
+            let inflate = ((1 + rho) / (1 - rho)).squareRoot()
+            let se = sv / Double(v.count).squareRoot() * inflate
+            return (m, sv, m - 1.96 * se, m + 1.96 * se, rho)
+        }
+        var gResid: [Double] = []
+        let gE = mean(stride(from: 0, to: n, by: 2).map { gpuDeltas[$0] })
+        let gO = mean(stride(from: 1, to: n, by: 2).map { gpuDeltas[$0] })
+        for (i, d) in gpuDeltas.enumerated() { gResid.append(d - (i % 2 == 0 ? gE : gO)) }
+        let wall = ci(deltas, residuals: resid)          // order-blocked residuals, AR(1)-adjusted
+        let gpu  = ci(gpuDeltas, residuals: gResid)      // its OWN autocorrelation, not the wall's
+        let rho  = wall.rho
+        var lines = ["[dispatch-cost] #143 U2 instrument v4 — paired, rollback, preheat, wall+GPU split, AR(1)-adjusted",
+                     "  layers=\(nLayers) expectedDispatchDelta=\(expectedDelta)/step  ctx=\(ctx) pairs=\(n) steps/sample=\(steps) preheat=\(preheat)"]
         if !fail.isEmpty {
             lines.append("  SELF-CHECK FAIL (timings below are VOID, do NOT read them as a null result):")
             for f in fail.prefix(4) { lines.append("    - \(f)") }
             return lines.joined(separator: "\n") + "\nDISPATCHCOST done"
         }
         lines.append("  self-check OK: dispatch delta exact every pair, OFF count stable at \(refOffDisp ?? -1)/sample, outputs bit-identical")
-        lines.append(String(format: "  median ms/step   OFF=%.4f  ON=%.4f", median(offMs), median(onMs)))
-        lines.append(String(format: "  paired delta (ON-OFF): mean=%+.4f ms  sd=%.4f  95%%CI=[%+.4f, %+.4f] ms",
-                            mD, sD, lo, hi))
-        lines.append(String(format: "  relative: %+.3f%%  [%+.3f%%, %+.3f%%]",
-                            100 * mD / mean(offMs), 100 * lo / mean(offMs), 100 * hi / mean(offMs)))
-        let sig = (lo < 0 && hi < 0) ? "SIGNIFICANT (fold faster)"
-                : (lo > 0 && hi > 0) ? "SIGNIFICANT (fold slower)" : "NOT SIGNIFICANT (CI spans 0)"
-        lines.append("  verdict: \(sig)")
-        lines.append(String(format: "  cross-checks: sign %d/%d pairs fold-faster · order effect mean(even)=%+.4f mean(odd)=%+.4f ms",
-                            deltas.filter { $0 < 0 }.count, n, mean(evens), mean(odds)))
-        lines.append(String(format: "  per-BOUNDARY saving = %+.4f us (= mean delta / %d). This is NOT 'per dispatch':",
-                            1000 * mD / Double(expectedDelta), expectedDelta))
-        lines.append("    the fold replaces TWO small kernels with ONE, so it also changes kernel execution")
-        lines.append("    time and occupancy, not just launch count. Treat it as an UPPER BOUND on what")
-        lines.append("    removing one dispatch is worth. Same for the regime: this is 1 CB/step with a full")
-        lines.append("    sync per step; production decode chains steps per CB and would see less.")
+        lines.append(String(format: "  wall ms/step  OFF=%.4f ON=%.4f   |   GPU ms/step  OFF=%.4f ON=%.4f",
+                            median(offMs), median(onMs), median(gpuOff), median(gpuOn)))
+        lines.append(String(format: "  WALL delta (ON-OFF): mean=%+.4f ms  sd_resid=%.4f  95%%CI=[%+.4f, %+.4f]  (%+.3f%%)",
+                            wall.m, wall.s, wall.lo, wall.hi, 100 * wall.m / mean(offMs)))
+        lines.append(String(format: "  GPU  delta (ON-OFF): mean=%+.4f ms  sd_resid=%.4f  95%%CI=[%+.4f, %+.4f]  (%+.3f%%)",
+                            gpu.m, gpu.s, gpu.lo, gpu.hi, mean(gpuOff) == 0 ? 0 : 100 * gpu.m / mean(gpuOff)))
+        func verdict(_ c: (m: Double, s: Double, lo: Double, hi: Double, rho: Double)) -> String {
+            (c.lo < 0 && c.hi < 0) ? "fold faster" : (c.lo > 0 && c.hi > 0) ? "fold slower" : "not significant (CI spans 0)"
+        }
+        lines.append("  verdict: WALL = \(verdict(wall))  |  GPU = \(verdict(gpu))")
+        lines.append(String(format: "  CIs above are AR(1)-adjusted: rho(wall)=%+.3f rho(GPU)=%+.3f, SE inflated by sqrt((1+r)/(1-r))",
+                            wall.rho, gpu.rho))
+        lines.append("    (adjacent pairs are not independent on a thermally-managed GPU; at this effect size the")
+        lines.append("     unadjusted interval is optimistic and can flip a verdict on its own)")
+        lines.append(String(format: "  cross-checks: sign %d/%d wall-faster · order effect mean(even)=%+.4f mean(odd)=%+.4f ms",
+                            deltas.filter { $0 < 0 }.count, n, mE, mO))
+        lines.append(String(format: "  per-BOUNDARY: wall %+.4f us, GPU %+.4f us (= mean delta / %d)",
+                            1000 * wall.m / Double(expectedDelta), 1000 * gpu.m / Double(expectedDelta), expectedDelta))
+        lines.append("  HOW TO READ FOR #143 U2: the WALL delta includes CPU encode work the fold removes")
+        lines.append("    (39 x setPipelineState+setBuffer+dispatch per step). MTLDispatchType.concurrent is a")
+        lines.append("    GPU-side change and can address ONLY the GPU delta. If GPU is ~0 while WALL is not,")
+        lines.append("    the saving is CPU-side and U2 is closed. Both numbers remain UPPER bounds: the fold")
+        lines.append("    also swaps two kernels for one, and this regime (1 CB/step, full sync, no lm_head)")
+        lines.append("    maximizes per-dispatch overhead relative to the chained production path.")
         return lines.joined(separator: "\n") + "\nDISPATCHCOST done"
     }
 }

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -65,6 +65,8 @@ if CommandLine.arguments.contains("stream") {
                run: { md, _ in Tell.dispatchCostProbe(modelDir: md) }),
         Runner(name: "lane-kernel-bench", desc: "per-lane sequence-coupled kernel µs at real dims (Stage 1b go/no-go: dispatch tax vs state bandwidth; GPU, no model; QWISP_LANE_CTX)",
                run: { _, _ in Tell.laneKernelBench() }),
+        Runner(name: "conc-bench", desc: "#143 U2 CEILING: N independent tiny dispatches, serial vs concurrent encoder (GPU, no model; QWISP_CONC_REPS/N)",
+               run: { _, _ in GroupedMoEPoC.dispatchConcurrencyBench() }),
         Runner(name: "grouped-moe-bench", desc: "grouped MoE expert kernel micro-bench",
                run: { _, _ in GroupedMoEPoC.bench() }),
         Runner(name: "dense-tiled-bench", desc: "dense tiled matmul micro-bench",

--- a/swift/Sources/qwisp-poc/main.swift
+++ b/swift/Sources/qwisp-poc/main.swift
@@ -61,6 +61,8 @@ if CommandLine.arguments.contains("stream") {
         Runner(name: "prefix-cache-poc", desc: "snapshot/restore byte-identity micro-PoC (design validation, pre-e2e)",
                run: { md, _ in Tell.prefixCachePoC(modelDir: md) }),
         // ── kernel micro-benchmarks (no model) ──
+        Runner(name: "dispatch-cost", desc: "what one Metal dispatch costs inside a CB (#143 U2): paired interleaved ABBA A/B over QWISP_FUSE_XLAYER, self-checked via dispatch seams (QWISP_DISPATCH_REPS/STEPS/CTX)",
+               run: { md, _ in Tell.dispatchCostProbe(modelDir: md) }),
         Runner(name: "lane-kernel-bench", desc: "per-lane sequence-coupled kernel µs at real dims (Stage 1b go/no-go: dispatch tax vs state bandwidth; GPU, no model; QWISP_LANE_CTX)",
                run: { _, _ in Tell.laneKernelBench() }),
         Runner(name: "grouped-moe-bench", desc: "grouped MoE expert kernel micro-bench",


### PR DESCRIPTION
Instrument-only. No engine change, no default change, no gate impact. Adds two runners to the `QWISP_RUN` registry and the shared statistics they use.

## What this establishes for #143 U2

| question | answer |
|---|---|
| do dispatches cost GPU time? | **yes, ~2.05 µs each** |
| can encoder concurrency recover it? | **yes, ~96% — when dispatches are independent** |
| ceiling for qwisp decode | 694 × 2.05 µs = 1.42 ms of a 9.83 ms GPU step ≈ **14.5%** |
| how many are actually independent? | **unmeasured — the open question** |

**Two independent methods agree on ~2 µs.** `Tell.dispatchCostProbe` measures it in-engine on the real model by toggling #144's fold (39 fewer dispatches/step → GPU −0.0990 ms/step, CI [−0.132, −0.066] → ~2.54 µs/dispatch, upper bound). `GroupedMoEPoC.dispatchConcurrencyBench` measures it with no model at all (N independent tiny dispatches, serial vs concurrent encoder → 2.02–2.07 µs/dispatch at N ≥ 256). Different code, different method, same order — that mutual agreement is the main reason to believe either.

## Why the instruments look over-built

Because the first version was wrong in a way its own output concealed, and it took two adversarial review passes to find out. Recorded in the code so it is not repeated:

- **v1's prefill was a total no-op.** It chunked by 1024 into a `maxM: 8` forward, every call hit `guard M <= maxM`, returned nil, and the code discarded it with `_ =`. It printed `ctx=512` while measuring from an empty context — **and its self-check passed**, because the check covered the perturbation and never the environment. All v1 numbers were discarded.
- v1's two arms decoded **different token bands** (salt derived from the arm), so they routed to different MoE experts — an arm-level systematic difference that no number of reps would average away.
- v1 reported a median and a sign test, neither of which inherits the ABBA cancellation it relied on.
- v3 printed the autocorrelation next to an **unadjusted** CI. It measured ρ=+0.293, ~10× the level at which this effect size stops being significant, so the honest interval spanned zero and required arithmetic no reader would do.

What survived: paired interleaved ABBA, per-pair state rollback, shared token stream, preheat to equalise GPU p-state at timer start, monotonic clock, wall/GPU split, AR(1)-adjusted CIs computed per metric.

## Fault injection is permanent, and required

`QWISP_DISPATCH_FAULT=1` forces both arms to the same configuration while the probe still believes it is contrasting two — exactly the failure class above, which timings render as an innocent null result. **Run it after any edit to the probe; it must print SELF-CHECK FAIL.** A self-check that has never been seen to fire is an assumption, not a check.

## Files

- `SeedlessFusedVerify.swift` — three dispatch-counting seams (same idiom as the shipped `_combineRowsDispatchCount`).
- `PrefixCachePoC.swift` — `Tell.dispatchCostProbe` (`QWISP_RUN=dispatch-cost`).
- `GroupedMoEPoC.swift` — `BenchStats` (shared, so the two probes cannot drift apart on the statistics) + `dispatchConcurrencyBench` (`QWISP_RUN=conc-bench`).

## Gates

RAWTESTS **98/98**, COMPTEST **97/97**, BENCHBATCHTEST **PASS** — unchanged; nothing here touches the forward path.

Peer review: Fable, three adversarial passes (two on the harness, one enumerating dependencies for the next step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)