### PR TITLE
fix(cli): read piped stdin to EOF instead of the first line (#166)

### DIFF
--- a/scripts/test_completion.sh
+++ b/scripts/test_completion.sh
@@ -22,4 +22,20 @@ total="$(printf '%s\n' "$line" | sed 's|COMPTEST ||' | cut -d/ -f2)"
 if printf '%s\n' "$out" | grep -q 'FAIL' || [ "$passed" != "$total" ]; then
     echo "RESULT: FAIL ($line)"; exit 1
 fi
+# ── #166: piped stdin must be read to EOF, not truncated to the first line ──────────
+# QWISP_FAKE=1 uses FakeBackend: no model weights, no GPU — only the tokenizer this gate
+# already requires. Asserts a strict increase rather than an exact count so it does not
+# encode the tokenizer's segmentation. Before the fix both arms reported 11 tok.
+tok_of() {
+    printf '%b' "$1" | QWISP_FAKE=1 QWISP_MODEL="$MODEL" "$BIN" chat --max-tokens 2 2>&1 \
+        | sed -n 's/.*prompt \([0-9]*\) tok.*/\1/p'
+}
+one="$(tok_of 'alpha\n')"
+two="$(tok_of 'alpha\nbeta gamma delta epsilon zeta eta theta iota kappa lambda\n')"
+if [ -z "$one" ] || [ -z "$two" ] || [ "$two" -le "$one" ]; then
+    echo "RESULT: FAIL (piped stdin truncated to line 1: 1-line=${one:-NA} tok, 2-line=${two:-NA} tok — #166)"
+    exit 1
+fi
+echo "[stdin] piped multi-line read to EOF: 1-line=$one tok < 2-line=$two tok  ok"
+
 echo "RESULT: PASS ($line)"

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -123,7 +123,21 @@ case "chat":
         }
     }
     let promptText = rest.joined(separator: " ")
-    let prompt = promptText.isEmpty ? (readLine(strippingNewline: true) ?? "") : promptText
+    // Piped stdin is a documented input path ("or pipe text via stdin" in the usage line), and
+    // readLine() takes only the FIRST line — `cat spec.md | qwisp chat` silently answered on
+    // line 1 and exited 0 (#166; it ingested 52 tokens of a 35K-token file while reporting a
+    // healthy run). Read to EOF when stdin is not a TTY; keep readLine() interactively, where
+    // one line IS what the user means and reading to EOF would block until ^D.
+    let prompt: String
+    if !promptText.isEmpty {
+        prompt = promptText
+    } else if isatty(FileHandle.standardInput.fileDescriptor) == 1 {
+        prompt = readLine(strippingNewline: true) ?? ""
+    } else {
+        let piped = FileHandle.standardInput.readDataToEndOfFile()
+        prompt = String(decoding: piped, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
     if prompt.isEmpty {
         print("usage: qwisp chat [--max-tokens N] [--lossless] <prompt>   (or pipe text via stdin)")
     } else {


### PR DESCRIPTION
## Summary

`cat file | qwisp chat` and `qwisp chat < file` answered using only the **first line** of the input — no error, no warning, exit 0 — while both the help text and the usage line advertise piping as an input path. `main.swift` used `readLine()` (one line) for every non-argv prompt, with no TTY check, so the interactive case (where one line is what the user means) and the piped case shared the same call. Now stdin is read to EOF when it is not a TTY; `readLine()` stays for the interactive case, where reading to EOF would block until `^D`.

Found while building #162's A/B harness: a 126KB (~35K-token) file was ingested as **52 tokens** and reported `prompt 52 tok (94 tok/s) · gen 32 tok (96.4 tok/s)` — a completely healthy-looking run that measured nothing. Same silent-failure class as #151.

## Related issue

Closes #166

## Verification

Gates run on a tree containing **only** this change (the in-progress #162 knob was stashed and both schemes rebuilt first, so the green below is evidence for this commit and not a superset):

- `scripts/test_raw.sh` → **RAWTESTS 98/98** PASS
- `scripts/test_completion.sh` → **COMPTEST 97/97** PASS + `[stdin] piped multi-line read to EOF: 1-line=11 tok < 2-line=23 tok  ok`
- `scripts/test_bench_batch.sh` → **BENCHBATCHTEST PASS**

The new regression check is GPU-free (`QWISP_FAKE=1` uses `FakeBackend`: no model weights, only the tokenizer this gate already requires). It asserts a **strict increase** in prompt tokens between one-line and two-line stdin rather than an exact count, so it does not encode the tokenizer's segmentation.

Verified RED before the fix (both arms reported 11 tok on the pre-fix binary) and GREEN after (11 < 23).

- [x] Tests pass
- [x] Zero warnings
- [x] Related docs updated (n/a — help text already documented the intended behaviour; the code now matches it)

## Notes for reviewer

- Behaviour change is confined to the piped/redirected case. Interactive `qwisp chat` with no argument still takes one line, deliberately.
- The prompt is trimmed of surrounding whitespace/newlines so a trailing newline in a piped file does not change tokenization.
