### PR TITLE
feat(server): surface GPU failures as a thrown error instead of ending the stream

### DIFF
--- a/swift/Sources/QwispCore/ContinuousBatch.swift
+++ b/swift/Sources/QwispCore/ContinuousBatch.swift
@@ -116,8 +116,8 @@ public final class ContinuousScheduler {
         self.tokenBudget = tokenBudget
     }
 
-    public func submit(prompt: [Int], maxTokens: Int, stopIds: [Int]) -> AsyncStream<Int> {
-        AsyncStream { cont in
+    public func submit(prompt: [Int], maxTokens: Int, stopIds: [Int]) -> AsyncThrowingStream<Int, Error> {
+        AsyncThrowingStream { cont in
             let req = Request(prompt: prompt.map { Int32($0) }, maxTokens: Swift.max(0, maxTokens),
                               stop: Set(stopIds), yield: { cont.yield($0) }, finish: { cont.finish() })
             self.cond.lock()
@@ -293,11 +293,11 @@ public final class ContinuousScheduler {
         let box = Box()
         for i in 0 ..< 5 {
             let s = sched.submit(prompt: [100 * i], maxTokens: 4, stopIds: [])
-            Task.detached { for await t in s { box.streams[i].append(t) }; sem.signal() }
+            Task.detached { do { for try await t in s { box.streams[i].append(t) } } catch {}; sem.signal() }
         }
         // request 5: stop token cuts the stream after 2 tokens (503 is not emitted).
         let s5 = sched.submit(prompt: [500], maxTokens: 100, stopIds: [503])
-        Task.detached { for await t in s5 { box.streams[5].append(t) }; sem.signal() }
+        Task.detached { do { for try await t in s5 { box.streams[5].append(t) } } catch {}; sem.signal() }
         for _ in 0 ..< 6 { sem.wait() }
         var allLen = true
         for i in 0 ..< 5 {
@@ -704,7 +704,7 @@ public final class BatchBackend: LLMBackend, @unchecked Sendable {
     private var sharedPrefixSeen = 0
     private var warnedSharedPrefix = false
 
-    public func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncStream<Int> {
+    public func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncThrowingStream<Int, Error> {
         if !warnedSharedPrefix {
             let head = Array(prompt.prefix(4096))
             var lcp = 0

--- a/swift/Sources/QwispCore/LLMBackend.swift
+++ b/swift/Sources/QwispCore/LLMBackend.swift
@@ -57,9 +57,23 @@ public struct GenerateOptions {
 
 /// Coarse backend protocol: load + generate + tier. Both a future MLXBackend and
 /// SeedlessBackend conform, so the server picks a backend in one line.
+/// A generation that stopped because the GPU stopped answering, not because the model
+/// finished (#169). Carried as a thrown error so callers cannot silently treat a failed
+/// run as a short answer — the whole point of the firewall is that this is unignorable.
+public struct GPUGenerationFailure: Error, CustomStringConvertible {
+    /// Raw fault: which command buffer, its MTLCommandBufferStatus, and the Metal error.
+    public let fault: String
+    public init(fault: String) { self.fault = fault }
+    public var description: String {
+        "GPU command buffer failed — \(fault). "
+        + "The most common cause is running out of GPU memory at this context length; "
+        + "a shorter prompt, --lossless, or a smaller resident budget will get past it."
+    }
+}
+
 public protocol LLMBackend {
     init(modelDir: String, tier: SeedlessTier) throws
-    func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncStream<Int>
+    func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncThrowingStream<Int, Error>
 }
 
 // ponytail: SeedlessBackend is a thin LLMBackend conformer that holds the built
@@ -209,9 +223,22 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
         }
         self.store = store
         self.engine = SeedlessEngine.build(store: store)
+        // #162 measurement knob. The lane path bounds MLX's free-buffer pool in
+        // LaneBackend.init (QWISP_LANE_MLX_CACHE_MB, default 2048, −22.5GB peak there); the
+        // serialize path never did, and #150 measured the pool growing +7.7GB (cache 4,845 →
+        // 12,523MB) across a 35,178-token prefill. DEFAULT 0 = unbounded = today's behaviour:
+        // whether bounding helps HERE is unmeasured — serialize holds one request's working
+        // set, not B lanes', so the same bound may cost time rather than save it. #162's
+        // pre-registered kill criteria decide it (>2% decode tok/s at resident tier ⇒ close).
+        // Setting the limit does not purge what is already pooled, hence the clearCache().
+        let mlxCacheMB = Swift.max(0, Tell.envInt("QWISP_PREFILL_MLX_CACHE_MB", 0))
+        if mlxCacheMB > 0 {
+            Memory.cacheLimit = mlxCacheMB * 1_048_576
+            Memory.clearCache()
+        }
     }
 
-    public func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncStream<Int> {
+    public func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncThrowingStream<Int, Error> {
         // c / maxK / maxM / isStreaming are prompt-length independent; only maxSeqLen (per
         // segment, below) tracks the growing sequence. Resolve those once.
         let cfg = SeedlessBackend.config(tier: tier, promptLen: 0, maxTokens: 0)
@@ -242,7 +269,7 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
         // First KV arena budget; grows geometrically to `ceiling` only if generation needs it.
         let baseline = Swift.max(1, Tell.envInt("QWISP_CTX_BASELINE", 8192))
         let cancel = CancelFlag()
-        return AsyncStream { continuation in
+        return AsyncThrowingStream { continuation in
             // Consumer dropped the stream (EOS at the consumer / client disconnect) → cancel the
             // detached decode so it stops at the next spec-step boundary instead of running to the
             // ceiling on the (exclusive) GPU and overlapping the next request's decode.
@@ -258,6 +285,9 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
             // changes (frozen forward path). The spec backend is also rebuilt per segment — fine for
             // a single-user server; a persistent per-instance backend is the throughput lever.
             // QWISP_FORCE_SAMPLE=1 forces the sampling loop even at temperature 0 (T=0-equivalence gate).
+            // #169: the SpecBackend is scoped to the segment loop; keep its fault accessor
+            // so the stream can tell EOS apart from "the GPU stopped answering".
+            var lastFault: (() -> String?)? = nil
             let forceSample = Tell.envFlag("QWISP_FORCE_SAMPLE")
             let wantSample = options.sampling || forceSample
             // Productization tier→mode: streaming tiers (<32GB) decode with bolt (near-lossless
@@ -385,6 +415,7 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                             maxM: ProcessInfo.processInfo.environment["QWISP_HYBRID_PREFILL"] != "0" ? Swift.max(cfg.maxM, 1032) : cfg.maxM,
                             maxSeqLen: maxSeqLen)
                     guard let backend = sb else { break }
+                    lastFault = backend.gpuFault
                     // Each segment dispatches to greedy or sampling. Sampling keeps its own state
                     // per segment (RNG restarts, so vary the seed by `produced` to avoid reusing the
                     // same stream across segment boundaries). ponytail: penalty counts reset per
@@ -441,7 +472,10 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                     budget = Swift.min(budget * 2, 65536)
                 }
                 if let g = lguard { for t in g.flush() { continuation.yield(t) } }
-                continuation.finish()
+                // #169: a poisoned backend returns nil from every step, which the decode loop
+                // sees as "no more tokens" — indistinguishable from EOS without this check.
+                if let f = lastFault?() { continuation.finish(throwing: GPUGenerationFailure(fault: f)) }
+                else { continuation.finish() }
             }
         }
     }
@@ -450,9 +484,9 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
     // to fit each request, plus stride-aligned restore points along the current path. Restores the
     // longest cached prefix of the new content and re-prefills only the delta. Greedy only; provably
     // lossless — SuffixSpec verifies every drafted token (see prefix-cache-poc).
-    private func generateCached(prompt: [Int], contentLen: Int, ceiling: Int, cfg: Config) -> AsyncStream<Int> {
+    private func generateCached(prompt: [Int], contentLen: Int, ceiling: Int, cfg: Config) -> AsyncThrowingStream<Int, Error> {
         let cancel = CancelFlag()
-        return AsyncStream { continuation in
+        return AsyncThrowingStream { continuation in
             continuation.onTermination = { _ in cancel.cancel() }
             Thread.detachNewThread {
                 self.segGate.wait()           // same gate as generate() — one decode thread at a time
@@ -621,7 +655,8 @@ public final class SeedlessBackend: LLMBackend, @unchecked Sendable {
                                      N: genBudget, maxK: maxK, prefillTokens: genSuffix,
                                      isCancelled: { cancel.isCancelled },
                                      onToken: { continuation.yield($0) })
-                continuation.finish()
+                if let f = backend.gpuFault?() { continuation.finish(throwing: GPUGenerationFailure(fault: f)) }
+                else { continuation.finish() }
             }
         }
     }

--- a/swift/Sources/QwispCore/LaneServe.swift
+++ b/swift/Sources/QwispCore/LaneServe.swift
@@ -646,13 +646,13 @@ public final class LaneBackend: LLMBackend, @unchecked Sendable {
         return (genBudget: genBudget, seqBudget: promptLen + 1 + genBudget, oversized: false)
     }
 
-    public func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncStream<Int> {
+    public func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncThrowingStream<Int, Error> {
         let plan = LaneBackend.sizePlan(promptLen: prompt.count, maxTokens: options.maxTokens,
                                         ctxMax: laneCtx, genCap: genCap)
         guard !plan.oversized else {
             FileHandle.standardError.write(Data(
                 "[qwisp] NOTE: prompt (\(prompt.count) tokens) leaves no room to generate in the \(laneCtx)-token lane context — request dropped.\n".utf8))
-            return AsyncStream { $0.finish() }
+            return AsyncThrowingStream { $0.finish() }
         }
         return scheduler.submit(prompt: prompt, maxTokens: plan.genBudget, stopIds: options.stopTokens)
     }

--- a/swift/Sources/QwispCore/PrefixCachePoC.swift
+++ b/swift/Sources/QwispCore/PrefixCachePoC.swift
@@ -673,7 +673,7 @@ extension Tell {
             let box = Box()
             let sem = DispatchSemaphore(value: 0)
             let stream = backend.generate(p, options: GenerateOptions(maxTokens: maxTok, promptContentLen: cl))
-            Task { for await t in stream { box.v.append(t) }; sem.signal() }
+            Task { do { for try await t in stream { box.v.append(t) } } catch { box.v = [] }; sem.signal() }
             sem.wait()
             return box.v
         }
@@ -727,7 +727,7 @@ extension Tell {
             let box = Box()
             let sem = DispatchSemaphore(value: 0)
             let stream = backend.generate(p, options: GenerateOptions(maxTokens: maxTok, promptContentLen: cl))
-            Task { for await t in stream { box.v.append(t) }; sem.signal() }
+            Task { do { for try await t in stream { box.v.append(t) } } catch { box.v = [] }; sem.signal() }
             sem.wait()
             return box.v
         }
@@ -790,7 +790,7 @@ extension Tell {
             let box = Box()
             let sem = DispatchSemaphore(value: 0)
             let stream = backend.generate(p, options: GenerateOptions(maxTokens: maxTok, promptContentLen: cl))
-            Task { for await t in stream { box.v.append(t) }; sem.signal() }
+            Task { do { for try await t in stream { box.v.append(t) } } catch { box.v = [] }; sem.signal() }
             sem.wait()
             return box.v
         }
@@ -856,7 +856,7 @@ extension Tell {
             let box = Box()
             let sem = DispatchSemaphore(value: 0)
             let stream = backend.generate(p, options: GenerateOptions(maxTokens: maxTok, promptContentLen: cl))
-            Task { for await t in stream { box.v.append(t) }; sem.signal() }
+            Task { do { for try await t in stream { box.v.append(t) } } catch { box.v = [] }; sem.signal() }
             sem.wait()
             return box.v
         }
@@ -904,7 +904,7 @@ extension Tell {
             setenv("QWISP_BOLT_PREFIX", prefix ? "1" : "0", 1)
             let box = Box(); let sem = DispatchSemaphore(value: 0)
             let s = b.generate(p, options: GenerateOptions(maxTokens: 24, promptContentLen: p.count - 8))
-            Task.detached { for await t in s { box.v.append(t) }; sem.signal() }
+            Task.detached { do { for try await t in s { box.v.append(t) } } catch { box.v = [] }; sem.signal() }
             sem.wait()
             return box.v
         }
@@ -942,7 +942,7 @@ extension Tell {
         func ttft(_ p: [Int], _ cl: Int) -> Double {
             let box = Box(); let sem = DispatchSemaphore(value: 0); let t0 = Date()
             let stream = backend.generate(p, options: GenerateOptions(maxTokens: 4, promptContentLen: cl))
-            Task { for await t in stream { if box.v.isEmpty { box.ttft = Date().timeIntervalSince(t0) }; box.v.append(t) }; sem.signal() }
+            Task { do { for try await t in stream { if box.v.isEmpty { box.ttft = Date().timeIntervalSince(t0) }; box.v.append(t) } } catch { box.v = [] }; sem.signal() }
             sem.wait(); return box.ttft
         }
 

--- a/swift/Sources/QwispCore/TellRuntime.swift
+++ b/swift/Sources/QwispCore/TellRuntime.swift
@@ -104,6 +104,10 @@ extension Tell {
         // Option B GPU sampler: (tokens, draftPerRow, invT, seed, basePos) → per-row
         // (full sample, residual sample, accept). Returns the decision on-GPU, tiny readback.
         var stepSampleRows: (([Int32], [Int], Float, UInt64, Int, [Float]?, Float) -> (full: [Int], resid: [Int], accept: [Bool])?)? = nil
+        /// GPU failure firewall (#169): non-nil result = this backend is poisoned and every
+        /// step from here returns nil. The decode loop cannot distinguish "EOS" from "the GPU
+        /// stopped answering" without it, which is how a failed command buffer became `!`x N.
+        var gpuFault: (() -> String?)? = nil
     }
 
     /// forward + lm_head logits, read back to CPU per row (for speculative sampling).
@@ -186,6 +190,7 @@ extension Tell {
         // here is what makes an instrumentation attempt land on the path that actually executes.
         FileHandle.standardError.write(Data(
             "[qwisp] decode path: \(fwd.head != nil ? "raw-fused-step" : "mlx-composed") (streamingBackend)\n".utf8))
+        let faultAccessor: () -> String? = { fwd.gpuFault.fault }
         var backend = SpecBackend(
             forward: forward,
             stepArgmax: step,
@@ -243,6 +248,7 @@ extension Tell {
                 fwd.stepSampleRows(toks, drafts: drafts, invT: invT, seed: seed, basePos: base, logitAdj: adj, topP: topP)
             }
         }
+        backend.gpuFault = faultAccessor
         return (backend, fwd)
     }
 
@@ -289,6 +295,7 @@ extension Tell {
         // here is what makes an instrumentation attempt land on the path that actually executes.
         FileHandle.standardError.write(Data(
             "[qwisp] decode path: \(fwd.head != nil ? "raw-fused-step" : "mlx-composed") (streamingBackend)\n".utf8))
+        let faultAccessor: () -> String? = { fwd.gpuFault.fault }
         var backend = SpecBackend(
             forward: forward,
             stepArgmax: step,
@@ -453,6 +460,7 @@ extension Tell {
             backend.stepArgmax = traced
             backend.chainedStepArgmax = nil
         }
+        backend.gpuFault = faultAccessor
         return backend
     }
 

--- a/swift/Sources/qwisp/Benchtest.swift
+++ b/swift/Sources/qwisp/Benchtest.swift
@@ -166,7 +166,8 @@ private func benchRun(name: String, mode: String, prompt: String, maxTokens: Int
     var outIds: [Int] = []
     let t0 = Date()
     var tFirst: Date? = nil
-    for await id in backend.generate(promptIds, options: opts) {
+    do {
+    for try await id in backend.generate(promptIds, options: opts) {
         if tFirst == nil { tFirst = Date() }
         // Mirror runGeneration's defensive stop/max guards: the spec loop streams tokens
         // in accepted-draft/chain granularity, so the raw stream can overshoot EOS and
@@ -174,6 +175,11 @@ private func benchRun(name: String, mode: String, prompt: String, maxTokens: Int
         if tokenizer.stopTokenIds.contains(id) { break }
         outIds.append(id)
         if outIds.count >= maxTokens { break }
+    }
+    } catch {
+        // #169: a GPU failure is not a short answer. A censored run is not a result.
+        note("[bench] \(name)/\(mode): generation FAILED — \(error)")
+        return nil
     }
     let tEnd = Date()
     guard let tf = tFirst, outIds.count > 1 else { return nil }

--- a/swift/Sources/qwisp/ChatCompletion.swift
+++ b/swift/Sources/qwisp/ChatCompletion.swift
@@ -205,7 +205,8 @@ func runGeneration(promptIds: [Int], maxTokens: Int, stopIds: [Int],
     // Incremental detokenize (StreamDetok, O(n²) fix): push() returns the same text as
     // decode(outIds) at every step (TOKTEST-locked contract), multi-token characters included.
     var detok = StreamDetok(decode: decode)
-    for await id in backend.generate(promptIds, options: opts) {
+    do {
+    for try await id in backend.generate(promptIds, options: opts) {
         // Defensive: the backend must already honor stopTokens/maxTokens, but guard here too.
         if stopIds.contains(id) { finish = "stop"; break }
         outIds.append(id)
@@ -218,6 +219,11 @@ func runGeneration(promptIds: [Int], maxTokens: Int, stopIds: [Int],
         emitted = full
         if !delta.isEmpty { onDelta(delta) }
         if maxTokens >= 0 && outIds.count >= maxTokens { finish = "length"; break }  // <0 = until EOS/context
+    }
+    } catch {
+        // #169: surface the GPU failure instead of returning a truncated answer.
+        FileHandle.standardError.write(Data("[qwisp] generation failed: \(error)\n".utf8))
+        finish = "error"
     }
     // Flush anything still held in the pending window (finalized ⊆ text always).
     let final = detok.text

--- a/swift/Sources/qwisp/Selftest.swift
+++ b/swift/Sources/qwisp/Selftest.swift
@@ -7,9 +7,9 @@ final class FakeBackend: LLMBackend {
     let script: [Int]
     init(modelDir: String, tier: SeedlessTier) throws { self.script = [] }   // unused in tests
     init(script: [Int]) { self.script = script }
-    func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncStream<Int> {
+    func generate(_ prompt: [Int], options: GenerateOptions) -> AsyncThrowingStream<Int, Error> {
         let script = self.script
-        return AsyncStream { cont in
+        return AsyncThrowingStream { cont in
             var n = 0
             for id in script {
                 if options.stopTokens.contains(id) { break }

--- a/swift/Sources/qwisp/Server.swift
+++ b/swift/Sources/qwisp/Server.swift
@@ -191,7 +191,9 @@ final class QwispEngine: @unchecked Sendable {
         // Incremental detokenize (StreamDetok): full re-decode per token was O(n²) in the
         // generation length — the dominant share of the measured 14-25% per-token server tax.
         var detok = StreamDetok(decode: { self.tokenizer.decode($0) })
-        for await tok in backend.generate(p.ids, options: opts) {
+        // #169: streamSSE is `async throws` — a GPU failure propagates to the HTTP layer
+        // rather than ending the stream as if the model had finished.
+        for try await tok in backend.generate(p.ids, options: opts) {
             if p.stop.contains(tok) { finish = "stop"; break }
             outIds.append(tok)
             if tFirst == nil { tFirst = Date() }


### PR DESCRIPTION
Refs #169. Follow-up to #171 — the firewall stops the garbage, this makes the failure reach the caller.

## Why

#171 stops a poisoned backend from emitting tokens, but the failure could not get out: `generate` returned `AsyncStream<Int>`, which cannot express "this stopped because the GPU stopped answering". A consumer saw a short answer and could not tell it from EOS — the same silent-failure shape the firewall was added to kill, one layer up.

## What

- `LLMBackend.generate` → `AsyncThrowingStream<Int, Error>`. A `lastError` property on the backend would have been a far smaller diff, but it is **ignorable**, and being ignorable is the defect. The type system now forces every consumer to decide.
- `GPUGenerationFailure` carries the raw fault (command buffer label, `MTLCommandBufferStatus`, Metal error) and renders the cause plus workarounds: shorter prompt, `--lossless`, smaller resident budget.
- `Tell.SpecBackend` gains `gpuFault: (() -> String?)?`, wired **unconditionally** in both glue sites. (First attempt wired it inside the `chainedStepArgmax` conditional, which would have left it nil whenever the chain was off — caught before commit.)

## Consumers — each decides explicitly

| site | behaviour on failure |
|---|---|
| `Server.streamSSE` | already `async throws` → propagates to the HTTP layer |
| `Benchtest` | returns `nil`. A censored run is not a result; a half-length row would have been recorded as one |
| `ChatCompletion` | stderr + `finish = "error"` |
| PrefixCachePoC, ContinuousBatch self-tests, `FakeBackend`, `LaneBackend`, `BatchBackend` | conformances updated |

## Not in this PR

- Turning the propagated error into a **proper HTTP error response** — today `streamSSE` stops the stream loudly rather than returning a structured error. That is the next step.
- strict's split command buffers, `stepArgmaxBatch`, prefill CBs, the static gate against bare `waitUntilCompleted`.
- The capacity bug itself — stays open in #169.

## Note on scope

`LLMBackend.swift` in this branch also carries an unrelated in-progress knob from #162 (`QWISP_PREFILL_MLX_CACHE_MB`, default 0 = today's behaviour). It was swept into this commit rather than split out. Flagging it so review is not surprised; happy to extract it if preferred.

## Gates

RAWTESTS 99/99 · BENCHBATCHTEST PASS · COMPTEST 97/97

🤖 Generated with [Claude Code](https://claude.com/claude-code)