### PR TITLE
feat(server): return GPU failures as HTTP errors, stop swallowing them at the CLI

### DIFF
--- a/swift/Sources/qwisp/ChatCompletion.swift
+++ b/swift/Sources/qwisp/ChatCompletion.swift
@@ -151,7 +151,8 @@ func runChat(prompt: String, tokenizer: QwispTokenizer, backend: any LLMBackend,
     // only the answer while the thinking still streams to the terminal.
     var full = "", sentR = "", sentC = ""
     var tFirst: Date? = nil
-    let r = await runGeneration(promptIds: promptIds, maxTokens: maxTokens, stopIds: tokenizer.stopTokenIds,
+    let r: CompletionResult
+    do { r = try await runGeneration(promptIds: promptIds, maxTokens: maxTokens, stopIds: tokenizer.stopTokenIds,
                             decode: { tokenizer.decode($0) }, backend: backend,
                             temperature: temperature, topP: topP, seed: seed,
                             frequencyPenalty: frequencyPenalty, presencePenalty: presencePenalty,
@@ -165,6 +166,11 @@ func runChat(prompt: String, tokenizer: QwispTokenizer, backend: any LLMBackend,
         if c.count > sentC.count, c.hasPrefix(sentC) {
             fputs(String(c.dropFirst(sentC.count)), stdout); fflush(stdout); sentC = c
         }
+    } } catch {
+        // #169 (CLI): a GPU failure is not a short answer. Report it and stop rather than
+        // letting a truncated stream look like a completed one.
+        fputs("\nchat: generation failed: \(error)\n", stderr)
+        return
     }
     fputs("\n", stdout)
     // Exit-teardown fix (#47 handoff): join the decode thread before main returns —
@@ -194,7 +200,7 @@ func runGeneration(promptIds: [Int], maxTokens: Int, stopIds: [Int],
                    temperature: Double = 0, topP: Double = 1.0, seed: UInt64 = 0,
                    frequencyPenalty: Double = 0, presencePenalty: Double = 0,
                    logitBias: [Int: Double] = [:], promptContentLen: Int? = nil,
-                   onDelta: (String) -> Void) async -> CompletionResult {
+                   onDelta: (String) -> Void) async throws -> CompletionResult {
     let opts = GenerateOptions(maxTokens: maxTokens, stopTokens: stopIds,
                                temperature: temperature, topP: topP, seed: seed,
                                frequencyPenalty: frequencyPenalty, presencePenalty: presencePenalty,
@@ -221,9 +227,11 @@ func runGeneration(promptIds: [Int], maxTokens: Int, stopIds: [Int],
         if maxTokens >= 0 && outIds.count >= maxTokens { finish = "length"; break }  // <0 = until EOS/context
     }
     } catch {
-        // #169: surface the GPU failure instead of returning a truncated answer.
+        // #169: rethrow. Swallowing this here would hand the caller a short answer plus
+        // finish="error", which the HTTP layer cannot turn into a status code — the failure
+        // has to stay an error all the way out.
         FileHandle.standardError.write(Data("[qwisp] generation failed: \(error)\n".utf8))
-        finish = "error"
+        throw error
     }
     // Flush anything still held in the pending window (finalized ⊆ text always).
     let final = detok.text

--- a/swift/Sources/qwisp/Selftest.swift
+++ b/swift/Sources/qwisp/Selftest.swift
@@ -22,7 +22,7 @@ final class FakeBackend: LLMBackend {
 }
 
 /// Completion-core self-test (GPU-free): real tokenizer for decode + FakeBackend.
-func runCompletionSelftest(modelDir: String) async -> String {
+func runCompletionSelftest(modelDir: String) async throws -> String {
     var passed = 0, total = 0
     var lines: [String] = []
     func check(_ name: String, _ ok: Bool) {
@@ -37,14 +37,14 @@ func runCompletionSelftest(modelDir: String) async -> String {
 
     // 1. basic: script decodes back to its text; finish=stop; token count matches.
     let helloIds = tok.encode("hello world")
-    let r1 = await runGeneration(promptIds: [], maxTokens: 128, stopIds: [],
+    let r1 = try await runGeneration(promptIds: [], maxTokens: 128, stopIds: [],
                                  decode: decode, backend: FakeBackend(script: helloIds)) { _ in }
     check("roundtrip_text", r1.text.contains("hello world") && r1.finishReason == "stop"
                             && r1.completionTokens == helloIds.count)
 
     // 2. maxTokens → finish=length, exactly maxTokens emitted.
     let longIds = tok.encode("one two three four five six seven eight")
-    let r2 = await runGeneration(promptIds: [], maxTokens: 3, stopIds: [],
+    let r2 = try await runGeneration(promptIds: [], maxTokens: 3, stopIds: [],
                                  decode: decode, backend: FakeBackend(script: longIds)) { _ in }
     check("maxtokens_length", r2.completionTokens == 3 && r2.finishReason == "length")
 
@@ -52,14 +52,14 @@ func runCompletionSelftest(modelDir: String) async -> String {
     let stopId = 999_999   // synthetic id not in "hi"
     let hiIds = tok.encode("hi")
     let script3 = hiIds + [stopId] + tok.encode("SHOULDNOTAPPEAR")
-    let r3 = await runGeneration(promptIds: [], maxTokens: 128, stopIds: [stopId],
+    let r3 = try await runGeneration(promptIds: [], maxTokens: 128, stopIds: [stopId],
                                  decode: decode, backend: FakeBackend(script: script3)) { _ in }
     check("eos_stop", r3.finishReason == "stop" && !r3.text.contains("SHOULDNOTAPPEAR")
                       && r3.completionTokens == hiIds.count)
 
     // 4. streaming deltas concatenate to the full text.
     var streamed = ""
-    let r4 = await runGeneration(promptIds: [], maxTokens: 128, stopIds: [],
+    let r4 = try await runGeneration(promptIds: [], maxTokens: 128, stopIds: [],
                                  decode: decode, backend: FakeBackend(script: helloIds)) { streamed += $0 }
     check("delta_concat", streamed == r4.text && !streamed.isEmpty)
 
@@ -69,7 +69,7 @@ func runCompletionSelftest(modelDir: String) async -> String {
     // (streamSSE) or duplicate (this path). Deltas must concat to the exact text.
     let frags: [[UInt8]] = [Array("a".utf8) + [0xF0, 0x9F], [0x9A, 0x80] + Array("x".utf8)]
     var mbStreamed = ""
-    let r4b = await runGeneration(promptIds: [], maxTokens: 8, stopIds: [],
+    let r4b = try await runGeneration(promptIds: [], maxTokens: 8, stopIds: [],
                                   decode: { ids in String(decoding: ids.flatMap { frags[$0] }, as: UTF8.self) },
                                   backend: FakeBackend(script: [0, 1])) { mbStreamed += $0 }
     check("delta_multibyte_split", mbStreamed == "a🚀x" && r4b.text == "a🚀x")

--- a/swift/Sources/qwisp/Server.swift
+++ b/swift/Sources/qwisp/Server.swift
@@ -142,7 +142,7 @@ final class QwispEngine: @unchecked Sendable {
         let s = sampling(req)
         if serialize { await lock.acquire() }
         let t0 = Date(); var tFirst: Date? = nil
-        let r = await runGeneration(promptIds: p.ids, maxTokens: p.maxTokens, stopIds: p.stop,
+        let r = try await runGeneration(promptIds: p.ids, maxTokens: p.maxTokens, stopIds: p.stop,
                                     decode: { self.tokenizer.decode($0) }, backend: backend,
                                     temperature: s.temperature, topP: s.topP, seed: s.seed,
                                     frequencyPenalty: s.frequencyPenalty, presencePenalty: s.presencePenalty,
@@ -165,6 +165,25 @@ final class QwispEngine: @unchecked Sendable {
 
     /// Streaming completion: writes OpenAI SSE chunks to the response writer.
     /// Mirrors runGeneration's loop (async writes preclude reusing its sync onDelta).
+    /// OpenAI-compatible error envelope. #169: a GPU failure must reach the client as an
+    /// error, not as a short completion — a truncated answer that looks successful is exactly
+    /// the failure mode the command-buffer firewall exists to remove.
+    struct APIError: Encodable {
+        struct Body: Encodable { let message: String; let type: String; let code: String? }
+        let error: Body
+        init(_ message: String, type: String = "server_error", code: String? = nil) {
+            self.error = Body(message: message, type: type, code: code)
+        }
+    }
+
+    static func errorPayload(_ error: Error) -> (APIError, HTTPResponse.Status) {
+        if let gpu = error as? GPUGenerationFailure {
+            return (APIError(gpu.description, type: "insufficient_gpu_memory", code: "gpu_command_buffer_failed"),
+                    .serviceUnavailable)
+        }
+        return (APIError("\(error)"), .internalServerError)
+    }
+
     func streamSSE(_ req: ChatCompletionRequest, writer: inout some ResponseBodyWriter) async throws {
         let p = try prompt(req)
         let id = "chatcmpl-\(UUID().uuidString.prefix(24))"
@@ -259,15 +278,33 @@ func makeRouter(engine: QwispEngine, modelID: String) -> Router<BasicRequestCont
             headers[.contentType] = "text/event-stream"
             headers[.cacheControl] = "no-cache"
             let body = ResponseBody { writer in
-                try await engine.streamSSE(req, writer: &writer)
+                // #169: the 200 + SSE headers are already on the wire by the time generation
+                // runs, so a mid-stream GPU failure cannot change the status code. Emit it as
+                // an error event (the OpenAI streaming convention) so the client sees a failure
+                // rather than a stream that simply stops looking like a finished answer.
+                do {
+                    try await engine.streamSSE(req, writer: &writer)
+                } catch {
+                    let (payload, _) = QwispEngine.errorPayload(error)
+                    let json = String(data: (try? JSONEncoder().encode(payload)) ?? Data(), encoding: .utf8) ?? "{}"
+                    try? await writer.write(ByteBuffer(string: "data: \(json)\n\n"))
+                    try? await writer.write(ByteBuffer(string: "data: [DONE]\n\n"))
+                }
                 try await writer.finish(nil)   // terminate the chunked body (not auto-called)
             }
             return Response(status: .ok, headers: headers, body: body)
         } else {
-            let resp = try await engine.complete(req)
             headers[.contentType] = "application/json"
-            let data = try JSONEncoder().encode(resp)
-            return Response(status: .ok, headers: headers, body: ResponseBody(byteBuffer: ByteBuffer(bytes: data)))
+            do {
+                let resp = try await engine.complete(req)
+                let data = try JSONEncoder().encode(resp)
+                return Response(status: .ok, headers: headers, body: ResponseBody(byteBuffer: ByteBuffer(bytes: data)))
+            } catch {
+                // #169: no bytes written yet, so this one can carry a real status code.
+                let (payload, status) = QwispEngine.errorPayload(error)
+                let data = (try? JSONEncoder().encode(payload)) ?? Data()
+                return Response(status: status, headers: headers, body: ResponseBody(byteBuffer: ByteBuffer(bytes: data)))
+            }
         }
     }
 

--- a/swift/Sources/qwisp/main.swift
+++ b/swift/Sources/qwisp/main.swift
@@ -193,7 +193,7 @@ case "version", "--version", "-v":
 case "selftest":
     print(await runTokenizerSelftest(modelDir: model))
 case "comptest":
-    print(await runCompletionSelftest(modelDir: model))
+    print(try await runCompletionSelftest(modelDir: model))
 case "sampletest":
     let (passed, total, log) = Sampler.selfCheck()   // GPU-free sampling-math check
     print(log.joined(separator: "\n") + "\nSAMPLETEST \(passed)/\(total)")


### PR DESCRIPTION
Refs #169. Third of three: #171 stopped the garbage, #172 made the failure throwable, this makes it visible to a client.

## Two paths, two mechanisms — for a physical reason

| path | why | behaviour |
|---|---|---|
| non-streaming | nothing on the wire yet | **503** + OpenAI-shaped error body (`type: insufficient_gpu_memory`, `code: gpu_command_buffer_failed`); other errors 500 |
| streaming SSE | 200 + event-stream headers already sent, status cannot change | error event on the stream, then `[DONE]` — the OpenAI streaming convention |

The message carries the cause **and the workarounds** (shorter prompt, `--lossless`, smaller resident budget). This failure is entirely actionable, so "internal error" would be a wasted signal.

## Fixes a defect introduced by #172

`runGeneration` caught the error and set `finish = "error"`, so `complete` never threw — meaning **the non-streaming 503 branch was dead code for the exact case it was written for.** Found by checking whether the new branch could actually fire rather than assuming it did.

It now rethrows, and each caller decides explicitly:

- `Server.complete` → 503 + error body
- `runChat` (CLI) → report on stderr and stop, rather than printing a truncated answer as if it had finished
- `runCompletionSelftest` → throwing; decision pushed to `main`

## Still open

- strict's split command buffers, `stepArgmaxBatch`, prefill CBs, static gate against bare `waitUntilCompleted`
- admission control (refuse before failing — today's measured thresholds make this tractable) and deadlock/watchdog
- the capacity bug itself — #169 stays open

## Gates

RAWTESTS 99/99 · BENCHBATCHTEST PASS · COMPTEST 97/97

🤖 Generated with [Claude Code](https://claude.com/claude-code)