### PR TITLE
fix(seedless): extend the command buffer firewall to strict, lane batch, and add a ratchet

### DIFF
--- a/scripts/check_cb_guard.sh
+++ b/scripts/check_cb_guard.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Static gate for the GPU failure firewall (#169).
+#
+# A bare `waitUntilCompleted()` means the caller does not know whether the GPU
+# actually ran. Reading an output buffer after a failed command buffer yields
+# its zero-initialised contents, which is how a GPU OOM became an unbounded run
+# of token id 0 with no error anywhere. Sites that read results MUST go through
+# SeedlessFusedVerify.commitAndWaitChecked.
+#
+# This is a ratchet, not a clean bill of health: the baseline below is the count
+# that existed when the firewall landed. It may only go DOWN. Adding a bare wait
+# fails the gate; converting one to a checked commit means lowering the number.
+#
+# ponytail: a per-file baseline, not a real dataflow analysis. It cannot tell a
+# fire-and-forget blit from a decode readback — it only stops the count growing.
+# Upgrade path if that stops being enough: mark intentional bare waits with a
+# `// cb-unchecked: <reason>` comment and gate on unmarked ones instead.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+BASELINE=89
+
+count=$(grep -rn "waitUntilCompleted" --include='*.swift' swift/Sources \
+        | grep -vc "commitAndWaitChecked" || true)
+
+echo "[cb-guard] bare waitUntilCompleted sites: $count (baseline $BASELINE)"
+
+if [ "$count" -gt "$BASELINE" ]; then
+  echo "[cb-guard] FAIL: $((count - BASELINE)) new unchecked command buffer wait(s)."
+  echo "[cb-guard] Route result-reading commits through SeedlessFusedVerify.commitAndWaitChecked."
+  echo "[cb-guard] New sites:"
+  grep -rn "waitUntilCompleted" --include='*.swift' swift/Sources | grep -v "commitAndWaitChecked"
+  exit 1
+fi
+
+if [ "$count" -lt "$BASELINE" ]; then
+  echo "[cb-guard] NOTE: down from the baseline — lower BASELINE in this script to $count to keep the ratchet tight."
+fi
+
+echo "CBGUARD PASS"

--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -3696,9 +3696,15 @@ public enum SeedlessFusedVerify {
             }
             func flushCB() {
                 curEnc!.endEncoding()
-                curCB!.commit()
-                curCB!.waitUntilCompleted()
-                gpuMs += (curCB!.gpuEndTime - curCB!.gpuStartTime) * 1000.0
+                // #169: strict splits the forward across many command buffers. Any one of them
+                // can fail, and a partial forward is worse than a whole one — the surviving
+                // layers sit on top of state the failed CB never wrote. Record and let
+                // stepArgmax refuse; do not read anything downstream.
+                if let f = SeedlessFusedVerify.commitAndWaitChecked(curCB!, "runStrictLayers(M=\(M))") {
+                    gpuFault.record(f)
+                } else {
+                    gpuMs += (curCB!.gpuEndTime - curCB!.gpuStartTime) * 1000.0
+                }
                 curEnc = nil; curCB = nil
             }
 
@@ -3883,6 +3889,7 @@ public enum SeedlessFusedVerify {
 
             case .strict:
                 runStrictLayers(M: M, firstCBExtra: encodeEmbed, finalCBExtra: encodeFinalOps)
+                if gpuFault.isPoisoned { return nil }
             }
 
             if SeedlessFusedVerify.logitDbg { dumpLogitStats(hd, M: M, tag: "step") }

--- a/swift/Sources/QwispCore/SeedlessLaneBatch.swift
+++ b/swift/Sources/QwispCore/SeedlessLaneBatch.swift
@@ -857,7 +857,10 @@ public final class SeedlessLaneBatch {
         let cb = driver.queue.makeCommandBuffer()!
         let enc = cb.makeComputeCommandEncoder()!
         encodeAllLayers(enc)
-        enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+        enc.endEncoding()
+        if let f = SeedlessFusedVerify.commitAndWaitChecked(cb, "forwardRowsBatch(B=\(B))") {
+            driver.gpuFault.record(f); return nil
+        }
         SeedlessFusedVerify.SeedlessFusedForward.profLastGPUMs = (cb.gpuEndTime - cb.gpuStartTime) * 1000.0
 
         let ptr = driver.hBuf.contents().bindMemory(to: Float16.self, capacity: driver.maxM * H)
@@ -919,7 +922,12 @@ public final class SeedlessLaneBatch {
         var vv = UInt32(hd.vocab); enc.setBytes(&vv, length: 4, index: 2)
         enc.dispatchThreadgroups(MTLSize(width: B, height: 1, depth: 1),
                                  threadsPerThreadgroup: MTLSize(width: 256, height: 1, depth: 1))
-        enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+        enc.endEncoding()
+        // #169: same firewall as the solo funnels — a failed batch CB leaves tokensOut at
+        // whatever it held, and every lane would take a token the GPU never produced.
+        if let f = SeedlessFusedVerify.commitAndWaitChecked(cb, "stepArgmaxBatch(B=\(B))") {
+            driver.gpuFault.record(f); return nil
+        }
         SeedlessFusedVerify.SeedlessFusedForward.profLastGPUMs = (cb.gpuEndTime - cb.gpuStartTime) * 1000.0
 
         let ptr = hd.tokensOut.contents().bindMemory(to: Int32.self, capacity: driver.maxM)


### PR DESCRIPTION
Refs #169. Fourth and last of the firewall series (#171 → #172 → #173 → this).

## What was still open after #171

| path | why it matters |
|---|---|
| `runStrictLayers` split CBs | strict splits the forward across many command buffers, so one failure gives a **partial forward** — surviving layers sitting on state the failed CB never wrote. Worse than an all-or-nothing failure because the output looks less obviously broken. |
| `stepArgmaxBatch` / `forwardRowsBatch` | a failed batch CB leaves `tokensOut` holding whatever it held, so **every lane** takes a token the GPU never produced. |

Strict was the urgent one: the error message added in #173 recommends `--lossless` as the workaround, so strict failing silently would make the advice we hand users actively unsafe.

## The ratchet

`scripts/check_cb_guard.sh` — bare `waitUntilCompleted` count, currently **89** (down from 94 as sites were converted). Increase fails the gate; decrease prints a reminder to lower the baseline.

Deliberately **not** a dataflow analysis, and the script says so: it cannot tell a fire-and-forget blit from a decode readback, and it only stops the count from growing. The upgrade path — mark intentional bare waits with `// cb-unchecked: <reason>` and gate on unmarked ones — is written into the script rather than left as tribal knowledge.

## Still open

- prefill command buffers (`SeedlessMetalForward`, 40 sites) — the largest remaining block
- admission control: refuse before failing, using the thresholds measured on #169
- deadlock / watchdog: give a hung `waitUntilCompleted` somewhere to go, reusing this same recovery path
- the capacity bug itself — #169 stays open

## Gates

RAWTESTS 99/99 · BENCHBATCHTEST PASS · COMPTEST 97/97 · CBGUARD PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)