### PR TITLE
fix(seedless): guard the serving prefill path and the multi-CB forward

### DIFF
--- a/scripts/check_cb_guard.sh
+++ b/scripts/check_cb_guard.sh
@@ -18,7 +18,7 @@
 set -uo pipefail
 cd "$(dirname "$0")/.."
 
-BASELINE=89
+BASELINE=87
 
 count=$(grep -rn "waitUntilCompleted" --include='*.swift' swift/Sources \
         | grep -vc "commitAndWaitChecked" || true)

--- a/swift/Sources/QwispCore/QwispModel.swift
+++ b/swift/Sources/QwispCore/QwispModel.swift
@@ -417,8 +417,8 @@ public final class QwispModel {
         if hBuf == nil { hBuf = SeedlessMetalForward.makeResidentBuffer(H * 2) }
         guard let hb = hBuf, let sc = gpuScratch else { return nil }
         SeedlessMetalForward.writeBuffer(hb, e, H)
-        SeedlessMetalForward.fusedForwardGPU(hBuf: hb, layers: layers, scratch: sc, H: H, E: 256, K: 8, eps: eps,
-                                        finalNormW: ensureFinalNorm())
+        if SeedlessMetalForward.fusedForwardGPU(hBuf: hb, layers: layers, scratch: sc, H: H, E: 256, K: 8,
+                                                eps: eps, finalNormW: ensureFinalNorm()) != nil { return nil }
         let fn = SeedlessMetalForward.readBuffer(sc.normed, H)   // final norm 同梱済（CB 内）
         return headProj().apply(fn.reshaped([1, 1, H]))
     }
@@ -432,8 +432,9 @@ public final class QwispModel {
         guard let hb = hBuf, let sc = gpuScratch else { return nil }
         let e = embed(MLXArray([tokenId], [1, 1]))
         SeedlessMetalForward.writeBuffer(hb, e, H)
-        SeedlessMetalForward.fusedForwardGPU(hBuf: hb, layers: layers, scratch: sc, H: H, E: 256, K: 8, eps: eps,
-                                        decode: true, pos: pos, finalNormW: ensureFinalNorm())
+        if SeedlessMetalForward.fusedForwardGPU(hBuf: hb, layers: layers, scratch: sc, H: H, E: 256, K: 8,
+                                                eps: eps, decode: true, pos: pos,
+                                                finalNormW: ensureFinalNorm()) != nil { return nil }
         let fn = SeedlessMetalForward.readBuffer(sc.normed, H)   // final norm 同梱済（CB 内）
         return headProj().apply(fn.reshaped([1, 1, H]))
     }

--- a/swift/Sources/QwispCore/SeedlessFusedVerify.swift
+++ b/swift/Sources/QwispCore/SeedlessFusedVerify.swift
@@ -3639,6 +3639,7 @@ public enum SeedlessFusedVerify {
         /// 全層 forward。x[M,H] → h[M,H]。cache は常駐更新(次 call にチェーン)。
         /// finalNormW を渡すと最終 rmsNorm も同梱し normed [M,H] を返す。
         public func forwardRows(_ x: MLXArray, M: Int, finalNormW: MTLBuffer? = nil) -> MLXArray? {
+            guard !gpuFault.isPoisoned else { return nil }
             guard M <= maxM else { return nil }
             // hBuf upload(resident/bolt/strict 共通)
             let xf = x.asType(.float16).reshaped([-1]); xf.eval()
@@ -3653,7 +3654,13 @@ public enum SeedlessFusedVerify {
                 if let fw = finalNormW {
                     SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: fw, out: normed, rows: M, D: H, eps: eps)
                 }
-                enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+                enc.endEncoding()
+                // #169: prefill runs first and is far larger than a decode step. A failure here
+                // is not "no tokens" — it is a KV/GDN state the GPU never wrote, on top of which
+                // decode then runs happily and produces confident nonsense.
+                if let f = SeedlessFusedVerify.commitAndWaitChecked(cb, "forwardRows(.resident, M=\(M))") {
+                    gpuFault.record(f); return nil
+                }
                 SeedlessFusedForward.profLastGPUMs = (cb.gpuEndTime - cb.gpuStartTime) * 1000.0
 
             case .bolt:
@@ -3663,7 +3670,13 @@ public enum SeedlessFusedVerify {
                 if let fw = finalNormW {
                     SeedlessFusedVerify.encodeRmsNormRows(enc, x: hBuf, w: fw, out: normed, rows: M, D: H, eps: eps)
                 }
-                enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+                enc.endEncoding()
+                // #169: prefill runs first and is far larger than a decode step. A failure here
+                // is not "no tokens" — it is a KV/GDN state the GPU never wrote, on top of which
+                // decode then runs happily and produces confident nonsense.
+                if let f = SeedlessFusedVerify.commitAndWaitChecked(cb, "forwardRows(.bolt, M=\(M))") {
+                    gpuFault.record(f); return nil
+                }
                 SeedlessFusedForward.profLastGPUMs = (cb.gpuEndTime - cb.gpuStartTime) * 1000.0
 
             case .strict:
@@ -3673,6 +3686,7 @@ public enum SeedlessFusedVerify {
                                                          rows: M, D: self.H, eps: self.eps)
                     }
                 })
+                if gpuFault.isPoisoned { return nil }
             }
 
             let src = finalNormW != nil ? normed : hBuf

--- a/swift/Sources/QwispCore/SeedlessMetalForward.swift
+++ b/swift/Sources/QwispCore/SeedlessMetalForward.swift
@@ -2359,10 +2359,12 @@ public enum SeedlessMetalForward {
     ///   各層 MoE residual は次層 mixer 先頭で hBuf に畳む（pendingResid=scratch.combined）。最終層は末尾 flush。
     nonisolated(unsafe) static var fusedNumCB = 1   // 層を G 個の CB に分割。実測 G>1 は inter-CB gap で逆効果＝1 が最速
 
+    /// Returns nil on success, or a fault description (#169). Callers must not read the
+    /// output buffers when it is non-nil.
     static func fusedForwardGPU(hBuf: MTLBuffer, layers: [GPULayer], scratch: GPUScratch,
                                 H: Int, E: Int, K: Int, eps: Float, decode: Bool = false, pos: Int = 0,
-                                finalNormW: MTLBuffer? = nil) {
-        guard let (_, queue) = ensure() else { return }
+                                finalNormW: MTLBuffer? = nil) -> String? {
+        guard let (_, queue) = ensure() else { return "fusedForwardGPU: no Metal device" }
         // ★ 多 command buffer: 各 CB を commit(待たず)→GPU が CB_g を実行中に CPU が CB_{g+1} を encode＝
         //   CPU-encode bubble を GPU-exec の裏に隠す。同一 queue の CB は commit 順に serial 実行＋メモリ整合。
         let G = max(1, min(fusedNumCB, layers.count))
@@ -2388,7 +2390,14 @@ public enum SeedlessMetalForward {
             cbs.append(cb)
         }
         cbs.last?.waitUntilCompleted()        // 最後だけ wait
+        // #169: the queue is in-order, so waiting on the last CB means every earlier one has a
+        // final status — but NOT that they succeeded. An earlier CB can fail while the last one
+        // completes, which is exactly the partial-forward case. Check all of them, not `.last`.
+        for cb in cbs where cb.status != .completed || cb.error != nil {
+            return "fusedForwardGPU: status=\(cb.status.rawValue) error=\(String(describing: cb.error))"
+        }
         if let f = cbs.first, let l = cbs.last { lastGPUExecMs = (l.gpuEndTime - f.gpuStartTime) * 1000.0 }
+        return nil
     }
 
     /// ★ issue#7 style A milestone A3b: streaming 版 1-CB forward（per-layer arena gather + GPU slot-remap +


### PR DESCRIPTION
Refs #169. Follows #174.

## The inventory corrected an assumption

The 40 unchecked `waitUntilCompleted` sites in `SeedlessMetalForward` are mostly **per-op test wrappers, not the serving prefill.** The real prefill is `Tell.prefill → backend.forward → SeedlessFusedForward.forwardRows`, which had:

- two unguarded commits (`.resident`, `.bolt`)
- a `.strict` case where `runStrictLayers` recorded the fault (added in #174) but `forwardRows` never looked at it

All three plus an entry guard now refuse.

**Prefill failing matters more than decode failing.** It is not "no tokens" — it is a KV/GDN state the GPU never wrote, on top of which decode then runs happily and produces confident nonsense.

## The site a mechanical fix would have got wrong

`fusedForwardGPU` commits several command buffers without waiting, then waits only on the last:

```swift
enc.endEncoding(); cb.commit()    // don't wait — overlap next encode with GPU exec
cbs.append(cb)
…
cbs.last?.waitUntilCompleted()    // wait on the last only
```

The queue is in-order, so that wait does mean every earlier CB has a **final status** — but not that it **succeeded**. An earlier CB can fail while the last one completes: precisely the partial-forward case. It now checks all of them and returns `String?` (nil = ok); both `QwispModel` callers already return `MLXArray?`, so the failure propagates as nil.

A sed over `cb.commit(); cb.waitUntilCompleted()` would have replaced `.last` and left this wrong in exactly the way the firewall exists to prevent. That is why #174's ratchet is documented as a count, not an analysis.

## Ratchet

89 → 87. The script printed its own reminder to lower the baseline; done in this PR.

## Still open

- 87 bare waits remain, mostly per-op test wrappers in `SeedlessMetalForward`
- admission control, deadlock/watchdog
- the capacity bug itself — #169

## Gates

RAWTESTS 99/99 · BENCHBATCHTEST PASS · COMPTEST 97/97 · CBGUARD PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)