### PR TITLE
fix(engine): stop making the unused vision encoder resident (852 MB, every tier)

### DIFF
--- a/swift/Sources/QwispCore/QwispModel.swift
+++ b/swift/Sources/QwispCore/QwispModel.swift
@@ -9,6 +9,19 @@ import MLXFast
 public final class WeightStore {
     public private(set) var arrays: [String: MLXArray] = [:]
 
+    /// The checkpoint ships a vision encoder. qwisp is a text-only engine and never reads a
+    /// single one of those tensors — but `residentNonExperts()` filtered only on `.switch_mlp.`,
+    /// so all 852 MB of `vision_tower.*` were handed to MLX.eval and made resident on every run,
+    /// on every tier. Measured: active 7,071 MB (8GB tier) = arena 4,320 + language_model
+    /// non-expert 1,325 + vision 852 + scratch 574; the 16GB tier's 11,391 MB decomposes the
+    /// same way. Dropping them is free — there is no quality knob involved.
+    ///
+    /// Filtered at load rather than at eval: keeping the MLXArray alive holds its mmap slice,
+    /// so excluding it from eval alone would not have returned the bytes.
+    public static func isUsedByEngine(_ tensorName: String) -> Bool {
+        !(tensorName.hasPrefix("vision_tower") || tensorName.contains("visual"))
+    }
+
     public init(modelDir: String) throws {
         let dir = URL(fileURLWithPath: modelDir)
         let idxURL = dir.appendingPathComponent("model.safetensors.index.json")
@@ -16,9 +29,17 @@ public final class WeightStore {
         let top = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
         let wm = (top["weight_map"] as? [String: String]) ?? [:]
         let shards = Set(wm.values)
+        var dropped = 0
         for shard in shards.sorted() {
             let m = try loadArrays(url: dir.appendingPathComponent(shard))
-            for (k, v) in m { arrays[k] = v }
+            for (k, v) in m {
+                guard WeightStore.isUsedByEngine(k) else { dropped += 1; continue }
+                arrays[k] = v
+            }
+        }
+        if dropped > 0 {
+            FileHandle.standardError.write(Data(
+                "[qwisp] skipped \(dropped) vision-encoder tensors (text-only engine)\n".utf8))
         }
     }
 

--- a/swift/Sources/QwispCore/SeedlessVerifyTests.swift
+++ b/swift/Sources/QwispCore/SeedlessVerifyTests.swift
@@ -49,7 +49,7 @@ public enum SeedlessVerifyTests {
         MLXRandom.seed(UInt64(42))
         var lines: [String] = []
         var passed = 0
-        let total = 99
+        let total = 100
 
         // Nested runner: records result and increments counter
         func run(_ name: String, body: () -> (Bool, String)) {
@@ -6278,6 +6278,34 @@ public enum SeedlessVerifyTests {
             a.record("second-fault")
             guard a.fault?.contains("test-injected") == true else {
                 return (false, "first fault was overwritten: \(a.fault ?? "nil")")
+            }
+            return (true, "ok")
+        }
+
+        // WRITE-LOCKED (guarded by total = 100). Do not weaken/skip/delete.
+        // The checkpoint ships a vision encoder qwisp never reads. residentNonExperts()
+        // filtered only on `.switch_mlp.`, so 852 MB of vision_tower.* were eval'd resident
+        // on every run of every tier — on the 8GB tier that is more than the entire deficit
+        // that made the tier not fit. This asserts the predicate keeps engine tensors and
+        // drops vision ones; a regression here silently costs 852 MB again.
+        run("100 weight-store drops the unused vision encoder") {
+            let keep = [
+                "language_model.model.embed_tokens.weight",
+                "language_model.lm_head.scales",
+                "language_model.model.layers.0.mlp.switch_mlp.up_proj.weight",
+                "language_model.model.layers.7.linear_attn.in_proj_qkv.weight",
+                "language_model.model.layers.3.mlp.gate.weight",
+            ]
+            let drop = [
+                "vision_tower.merger.linear_fc1.weight",
+                "vision_tower.blocks.0.mlp.linear_fc2.scales",
+                "model.visual.patch_embed.proj.weight",
+            ]
+            for k in keep where !WeightStore.isUsedByEngine(k) {
+                return (false, "dropped an engine tensor: \(k)")
+            }
+            for k in drop where WeightStore.isUsedByEngine(k) {
+                return (false, "kept a vision tensor: \(k)")
             }
             return (true, "ok")
         }


### PR DESCRIPTION
The checkpoint ships a vision encoder. qwisp is a **text-only engine and never reads one of those tensors** — but `WeightStore.residentNonExperts()` filtered only on `.switch_mlp.`, so all of `vision_tower.*` went to `MLX.eval()` and was made resident on every run, on every tier. **333 tensors, 852 MB.**

## Measured

Byte-exact against the prediction made before running it:

| tier | before | after |
|---|---|---|
| 8GB (budgetC=64) | 7,071 MB | **6,219 MB** |
| 16GB (budgetC=128) | 11,391 MB | **10,539 MB** |

Which confirms the decomposition those predictions came from:

```
active = arena(40 x budgetC x 1.6875 MB) + language_model non-expert 1,325 + scratch 574
```

Output unchanged (it was never read).

## Filtered at load, not at eval

Keeping the `MLXArray` alive holds its mmap slice, so removing it from the eval list alone would not have returned the bytes. `residentAll()` becomes correct for free — the tensors are simply not in the store.

## Why this matters beyond the byte count

- **8GB tier.** It needs ~761 MB to hold coverage at or above the ~103-expert per-layer footprint (the LOOPY-safety line). 852 MB is more than the entire deficit, at zero quality cost. This session had been measuring whether non-expert weights survive 2-bit in order to find those bytes. They do not — GDN loses **31 points** of teacher-forced agreement below its own same-bit round-trip floor (94.3% → 62.9%), lm_head 24.6, embed 6.3 — and quantizing *every* non-expert tensor would only have freed **589 MB** anyway. The bytes were already there, being wasted.
- **16GB tier.** The #169 OOM cliff was measured at **two experts per layer, ~150 MB** (coverage 228 passes, 230 fails). 852 MB is 5.7x that margin.

## Not claimed here

Whether this makes the 8GB tier actually fit a real 8GB Mac, and whether it moves the #169 threshold, are follow-up measurements — both need the wired-limit emulation and are not in this PR. This PR is the byte reclamation and its proof.

## Gates

RAWTESTS **100/100** · BENCHBATCHTEST PASS · COMPTEST 97/97 · CBGUARD PASS

The new locked test asserts the predicate keeps engine tensors (embed, lm_head, switch_mlp, linear_attn, mlp.gate) and drops vision ones — a regression would silently cost 852 MB again. Runs without a model or GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)