### PR TITLE
fix(engine): mtlBuf's documented copy fallback was an infinite recursion

### DIFF
--- a/swift/Sources/QwispCore/SeedlessMetalForward.swift
+++ b/swift/Sources/QwispCore/SeedlessMetalForward.swift
@@ -39,7 +39,11 @@ public enum SeedlessMetalForward {
     /// 実モデル重みの per-call copy(254MB 級)を排除する perf 用。数値へは無影響(同一バイト)。
     static func mtlBuf(_ a: MLXArray, _ device: MTLDevice) -> MTLBuffer? {
         if let b = a.asMTLBuffer(device: device, noCopy: true) { return b }
-        return mtlBuf(a, device)
+        // #177: this fallback used to call mtlBuf(a, device) — the same arguments — so the
+        // documented copy path was an infinite recursion. Latent only because mlx-swift
+        // currently copies internally rather than returning nil; a version that returns nil
+        // would have turned every one of the 267 call sites into a stack overflow.
+        return a.asMTLBuffer(device: device, noCopy: false)
     }
 
     static func mlxMatchCompileOpts() -> MTLCompileOptions {


### PR DESCRIPTION
Closes #177.

```swift
if let b = a.asMTLBuffer(device: device, noCopy: true) { return b }
return mtlBuf(a, device)          // same arguments -> infinite recursion
```

The docstring promises a copy fallback ("不可なら copy"). There was none: the fallback called itself with identical arguments, so a nil from the no-copy wrap would recurse until the stack overflowed. It now passes `noCopy: false` — what the comment already described.

## Latent, not live

mlx-swift currently copies internally rather than returning nil, so today the branch is unreachable. It is latent across **267 call sites**, and whether it stays unreachable is a property of mlx-swift's implementation, not of qwisp. A version that returns nil instead of copying would turn every weight-buffer wrap into a crash rather than a slow path.

## No test, deliberately

The branch cannot be reached without forcing `asMTLBuffer` to return nil, and there is no hook for that. A test that only exercises the happy path would raise the locked-test count without guarding anything — the opposite of what that counter is for.

## Found while

Attributing the 8GB tier's memory. `nonMLXmetal` is `metal - active - cache` with `metal = MTLDevice.currentAllocatedSize`, and `mtlBuf` wrappers alias existing pages: they inflate that counter without costing resident memory. **This repo had already documented exactly that in #150** (`TellRuntime.swift:640-644`) — reading `mtlBuf` to confirm it was a view and not a copy is what surfaced the recursion.

## Gates

RAWTESTS 100/100 · BENCHBATCHTEST PASS · COMPTEST 97/97 · CBGUARD PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)